### PR TITLE
fix: Add job dispatch pattern to cycle menu notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,10 +125,11 @@ Getting started:
 4. Open a menu to add items to each day, set types/times/quantities, and reorder by position.
 
 Notifications:
-- Scheduler entry `cycle-menu-daily-notify` runs the command `cycle-menus:notify-today` daily at 09:00.
+- Scheduler entry `cycle-menu-daily-notify` runs the command `cycle-menus:notify-today --dispatch-job` daily at 09:00.
 - Manually trigger:
   - Dry run (no notifications sent): `php artisan cycle-menus:notify-today --dry-run`
-  - Real send: `php artisan cycle-menus:notify-today`
+  - Dispatch to queue: `php artisan cycle-menus:notify-today --dispatch-job`
+  - Run immediately: `php artisan cycle-menus:notify-today`
 - In‑app notifications include a link back to the menu.
 
 Notes:

--- a/routes/console.php
+++ b/routes/console.php
@@ -21,7 +21,7 @@ Schedule::command('subscriptions:check-renewals --dispatch-job')
     ->description('Check and send subscription renewal notifications');
 
 // Schedule Cycle Menu daily notification at 9:00 AM
-Schedule::command('cycle-menus:notify-today')
+Schedule::command('cycle-menus:notify-today --dispatch-job')
     ->dailyAt('09:00')
     ->name('cycle-menu-daily-notify')
     ->description("Send today's Cycle Menu notification");

--- a/tests/Feature/CycleMenuNotifyCommandTest.php
+++ b/tests/Feature/CycleMenuNotifyCommandTest.php
@@ -1,12 +1,14 @@
 <?php
 
 use App\Enums\MealType;
+use App\Jobs\SendCycleMenuDailyNotifications;
 use App\Models\CycleMenu;
 use App\Models\CycleMenuDay;
 use App\Models\CycleMenuItem;
 use App\Models\User;
 use App\Notifications\DailyMenuNotification;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\Str;
 
@@ -75,8 +77,47 @@ it('cycle-menus:notify-today sends DailyMenuNotification to all users when not d
 
     // When
     $this->artisan('cycle-menus:notify-today')
-        ->expectsOutputToContain("Notified users for menu '")
+        ->expectsOutputToContain('✅ Cycle menu daily notifications processed')
         ->assertExitCode(0);
+
+    // Then
+    Notification::assertSentTo([$u1, $u2], DailyMenuNotification::class, function (DailyMenuNotification $notification, array $channels) use ($menu, $u1) {
+        $data = $notification->toArray($u1);
+        return ($channels === ['database'])
+            && ($data['type'] ?? null) === 'cycle_menu_daily'
+            && ($data['menu_id'] ?? null) === $menu->id
+            && is_array($data['items'] ?? null)
+            && Str::contains($data['message'] ?? '', 'Today\'s menu');
+    });
+});
+
+it('cycle-menus:notify-today --dispatch-job dispatches job to queue', function () {
+    // Given
+    User::factory()->create();
+    seedActiveMenuForToday();
+
+    Bus::fake();
+
+    // When
+    $this->artisan('cycle-menus:notify-today --dispatch-job')
+        ->expectsOutputToContain('📤 Cycle menu daily notification job dispatched to queue')
+        ->assertExitCode(0);
+
+    // Then
+    Bus::assertDispatched(SendCycleMenuDailyNotifications::class);
+});
+
+it('SendCycleMenuDailyNotifications job sends notifications to all users', function () {
+    // Given two users and an active menu
+    $u1 = User::factory()->create();
+    $u2 = User::factory()->create();
+    $menu = seedActiveMenuForToday();
+
+    Notification::fake();
+
+    // When
+    $job = new SendCycleMenuDailyNotifications();
+    $job->handle();
 
     // Then
     Notification::assertSentTo([$u1, $u2], DailyMenuNotification::class, function (DailyMenuNotification $notification, array $channels) use ($menu, $u1) {


### PR DESCRIPTION
Cycle menu notifications were running synchronously instead of being
queued, which was inconsistent with other notification commands in the
system (subscriptions, warranties, contracts, utility bills).

Changes:
- Created SendCycleMenuDailyNotifications job class for background processing
- Updated CycleMenuDailyNotify command to support --dispatch-job flag
- Modified scheduler to use --dispatch-job for daily notifications at 09:00
- Added comprehensive tests for job dispatch functionality
- Updated README documentation with new command options

This brings cycle menu notifications in line with the existing
architecture and improves system performance by using the job queue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--dispatch-job` option to cycle menu daily notifications for flexible execution—dispatch to queue for async processing or run immediately
  * Improved notification delivery with support for background job queue processing

* **Documentation**
  * Updated command examples and documentation to reflect new dispatch options

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->