### PR TITLE
feat: Add working days calculator to freelance rate calculator page

### DIFF
--- a/app/Http/Controllers/CurrencyController.php
+++ b/app/Http/Controllers/CurrencyController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Services\CurrencyService;
+use App\Services\WorkingDaysService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Log;
@@ -12,7 +13,8 @@ use Illuminate\View\View;
 class CurrencyController extends Controller
 {
     public function __construct(
-        private CurrencyService $currencyService
+        private CurrencyService $currencyService,
+        private WorkingDaysService $workingDaysService
     ) {}
 
     /**
@@ -20,7 +22,9 @@ class CurrencyController extends Controller
      */
     public function freelanceRateCalculator(): View
     {
-        return view('currency.freelance-rate-calculator');
+        $workingDaysInfo = $this->workingDaysService->getCurrentMonthWorkingDaysInfo();
+
+        return view('currency.freelance-rate-calculator', $workingDaysInfo);
     }
 
     /**

--- a/app/Models/Holiday.php
+++ b/app/Models/Holiday.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Holiday extends Model
+{
+    protected $fillable = [
+        'date',
+        'name',
+        'description',
+    ];
+
+    protected $casts = [
+        'date' => 'date',
+    ];
+}

--- a/app/Services/WorkingDaysService.php
+++ b/app/Services/WorkingDaysService.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Holiday;
+use Carbon\Carbon;
+use Carbon\CarbonPeriod;
+
+class WorkingDaysService
+{
+    /**
+     * Calculate the number of working days in the current month.
+     * Working days are Monday through Friday, excluding holidays.
+     */
+    public function getWorkingDaysInCurrentMonth(): int
+    {
+        $now = Carbon::now();
+        $startOfMonth = $now->copy()->startOfMonth();
+        $endOfMonth = $now->copy()->endOfMonth();
+
+        return $this->getWorkingDaysBetween($startOfMonth, $endOfMonth);
+    }
+
+    /**
+     * Calculate the number of working days between two dates.
+     * Working days are Monday through Friday, excluding holidays.
+     */
+    public function getWorkingDaysBetween(Carbon $startDate, Carbon $endDate): int
+    {
+        $workingDays = 0;
+        $holidays = $this->getHolidaysBetween($startDate, $endDate);
+
+        $period = CarbonPeriod::create($startDate, $endDate);
+
+        foreach ($period as $date) {
+            // Check if it's a weekday (Monday-Friday)
+            if ($date->isWeekday()) {
+                // Check if it's not a holiday
+                if (!$holidays->contains($date->format('Y-m-d'))) {
+                    $workingDays++;
+                }
+            }
+        }
+
+        return $workingDays;
+    }
+
+    /**
+     * Get all holidays between two dates.
+     */
+    protected function getHolidaysBetween(Carbon $startDate, Carbon $endDate)
+    {
+        return Holiday::whereBetween('date', [$startDate->format('Y-m-d'), $endDate->format('Y-m-d')])
+            ->pluck('date')
+            ->map(fn($date) => Carbon::parse($date)->format('Y-m-d'));
+    }
+
+    /**
+     * Get the current month name.
+     */
+    public function getCurrentMonthName(): string
+    {
+        return Carbon::now()->format('F Y');
+    }
+
+    /**
+     * Get working days information for the current month.
+     */
+    public function getCurrentMonthWorkingDaysInfo(): array
+    {
+        $workingDays = $this->getWorkingDaysInCurrentMonth();
+        $monthName = $this->getCurrentMonthName();
+
+        return [
+            'working_days' => $workingDays,
+            'month_name' => $monthName,
+        ];
+    }
+}

--- a/database/migrations/2026_01_12_091100_create_holidays_table.php
+++ b/database/migrations/2026_01_12_091100_create_holidays_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('holidays', function (Blueprint $table) {
+            $table->id();
+            $table->date('date');
+            $table->string('name');
+            $table->text('description')->nullable();
+            $table->timestamps();
+
+            $table->index('date');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('holidays');
+    }
+};

--- a/resources/views/currency/freelance-rate-calculator.blade.php
+++ b/resources/views/currency/freelance-rate-calculator.blade.php
@@ -171,6 +171,20 @@
                 </div>
             </div>
 
+            <!-- Working Days Card -->
+            <div class="bg-[color:var(--color-success-50)] dark:bg-[color:var(--color-success-900)] border border-[color:var(--color-success-200)] dark:border-[color:var(--color-success-800)] shadow-sm rounded-lg p-6">
+                <div class="flex items-center justify-between">
+                    <div>
+                        <h3 class="text-sm font-medium text-[color:var(--color-success-700)] dark:text-[color:var(--color-success-300)] mb-1">Working Days in {{ $month_name }}</h3>
+                        <div class="text-3xl font-bold text-[color:var(--color-success-800)] dark:text-[color:var(--color-success-200)]">{{ $working_days }}</div>
+                        <p class="text-xs text-[color:var(--color-success-600)] dark:text-[color:var(--color-success-400)] mt-1">Weekdays excluding holidays</p>
+                    </div>
+                    <svg class="w-12 h-12 text-[color:var(--color-success-500)] opacity-20 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
+                        <path fill-rule="evenodd" d="M6 2a1 1 0 00-1 1v1H4a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V6a2 2 0 00-2-2h-1V3a1 1 0 10-2 0v1H7V3a1 1 0 00-1-1zm0 5a1 1 0 000 2h8a1 1 0 100-2H6z" clip-rule="evenodd"/>
+                    </svg>
+                </div>
+            </div>
+
             <!-- MKD Conversion Card -->
             <div id="mkd-conversion-card" class="bg-[color:var(--color-primary-50)] dark:bg-[color:var(--color-dark-100)] border border-[color:var(--color-success-200)] dark:border-[color:var(--color-success-500)] shadow-sm rounded-lg p-6" style="display: none;">
                 <div class="flex items-center justify-between">


### PR DESCRIPTION
Added functionality to display the number of working days (weekdays excluding holidays)
in the current month on the freelance rate calculator page. This helps freelancers better
understand their available working days for planning and rate calculations.

Changes:
- Created Holiday model and migration to store holiday dates
- Created WorkingDaysService to calculate weekdays excluding holidays
- Updated CurrencyController to inject WorkingDaysService and pass working days data to view
- Added working days card to freelance calculator page showing current month's working days

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added holiday management system to track business days
  * Introduced working days calculation that automatically excludes weekends and holidays
  * Freelance rate calculator now displays current month's working days count for more accurate income projections

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->