### PR TITLE
Add Macedonian holidays listing page

### DIFF
--- a/app/Http/Controllers/HolidayController.php
+++ b/app/Http/Controllers/HolidayController.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class HolidayController extends Controller
+{
+    /**
+     * Display a listing of Macedonian holidays.
+     */
+    public function index()
+    {
+        // National Macedonian Holidays
+        $nationalHolidays = [
+            [
+                'name' => 'New Year\'s Day',
+                'name_mk' => 'Нова Година',
+                'date' => 'January 1',
+                'type' => 'national',
+                'description' => 'Celebration of the new year'
+            ],
+            [
+                'name' => 'New Year\'s Day',
+                'name_mk' => 'Нова Година',
+                'date' => 'January 2',
+                'type' => 'national',
+                'description' => 'Second day of New Year celebration'
+            ],
+            [
+                'name' => 'Christmas Eve',
+                'name_mk' => 'Бадник (Православен)',
+                'date' => 'January 6',
+                'type' => 'orthodox',
+                'description' => 'Orthodox Christmas Eve'
+            ],
+            [
+                'name' => 'Christmas Day',
+                'name_mk' => 'Божиќ (Православен)',
+                'date' => 'January 7',
+                'type' => 'orthodox',
+                'description' => 'Orthodox Christmas Day'
+            ],
+            [
+                'name' => 'Easter',
+                'name_mk' => 'Велигден (Православен)',
+                'date' => 'Variable (April/May)',
+                'type' => 'orthodox',
+                'description' => 'Orthodox Easter - celebrated on different dates each year'
+            ],
+            [
+                'name' => 'Labour Day',
+                'name_mk' => 'Ден на трудот',
+                'date' => 'May 1',
+                'type' => 'national',
+                'description' => 'International Workers\' Day'
+            ],
+            [
+                'name' => 'Saints Cyril and Methodius Day',
+                'name_mk' => 'Св. Кирил и Методиј',
+                'date' => 'May 24',
+                'type' => 'national',
+                'description' => 'Day of the Slavonic Educators and Culture'
+            ],
+            [
+                'name' => 'Ilinden (St. Elijah\'s Day)',
+                'name_mk' => 'Илинден',
+                'date' => 'August 2',
+                'type' => 'national',
+                'description' => 'Uprising Day - National holiday commemorating the Ilinden Uprising of 1903'
+            ],
+            [
+                'name' => 'Republic Day',
+                'name_mk' => 'Ден на Републиката',
+                'date' => 'August 2',
+                'type' => 'national',
+                'description' => 'Day of the Republic of North Macedonia'
+            ],
+            [
+                'name' => 'Independence Day',
+                'name_mk' => 'Ден на независноста',
+                'date' => 'September 8',
+                'type' => 'national',
+                'description' => 'Independence from Yugoslavia (1991)'
+            ],
+            [
+                'name' => 'Day of the Macedonian Revolutionary Struggle',
+                'name_mk' => 'Ден на македонската револуционерна борба',
+                'date' => 'October 23',
+                'type' => 'national',
+                'description' => 'Commemorates the founding of VMRO in 1893'
+            ],
+            [
+                'name' => 'Saint Clement of Ohrid Day',
+                'name_mk' => 'Св. Климент Охридски',
+                'date' => 'December 8',
+                'type' => 'national',
+                'description' => 'Day of Saint Clement of Ohrid - patron saint of North Macedonia'
+            ],
+        ];
+
+        return view('holidays.index', compact('nationalHolidays'));
+    }
+}

--- a/resources/views/holidays/index.blade.php
+++ b/resources/views/holidays/index.blade.php
@@ -1,0 +1,61 @@
+@extends('layouts.app')
+
+@section('title', 'Macedonian Holidays - LifeOS')
+
+@section('header')
+    <div class="flex items-center justify-between">
+        <div>
+            <h1 class="text-3xl font-bold text-[color:var(--color-primary-700)] dark:text-[color:var(--color-dark-600)]">Macedonian Holidays</h1>
+            <p class="mt-2 text-[color:var(--color-primary-600)] dark:text-[color:var(--color-dark-500)]">National and Orthodox holidays celebrated in North Macedonia</p>
+        </div>
+    </div>
+@endsection
+
+@section('content')
+    <div class="bg-[color:var(--color-primary-100)] dark:bg-[color:var(--color-dark-200)] shadow sm:rounded-lg">
+        <div class="px-4 py-5 sm:px-6">
+            <div class="overflow-x-auto">
+                <table class="min-w-full divide-y divide-[color:var(--color-primary-300)] dark:divide-[color:var(--color-dark-300)]">
+                    <thead>
+                        <tr class="text-left text-xs uppercase tracking-wider text-[color:var(--color-primary-600)] dark:text-[color:var(--color-dark-500)]">
+                            <th class="px-4 py-3">Holiday Name</th>
+                            <th class="px-4 py-3">Name in Macedonian</th>
+                            <th class="px-4 py-3">Date</th>
+                            <th class="px-4 py-3">Type</th>
+                            <th class="px-4 py-3">Description</th>
+                        </tr>
+                    </thead>
+                    <tbody class="divide-y divide-[color:var(--color-primary-300)] dark:divide-[color:var(--color-dark-300)]">
+                        @foreach ($nationalHolidays as $holiday)
+                            <tr class="text-[color:var(--color-primary-700)] dark:text-[color:var(--color-dark-600)]">
+                                <td class="px-4 py-3 font-medium">{{ $holiday['name'] }}</td>
+                                <td class="px-4 py-3">{{ $holiday['name_mk'] }}</td>
+                                <td class="px-4 py-3 whitespace-nowrap">{{ $holiday['date'] }}</td>
+                                <td class="px-4 py-3">
+                                    @if ($holiday['type'] === 'orthodox')
+                                        <span class="inline-flex items-center rounded-full bg-[color:var(--color-info-100)] text-[color:var(--color-info-700)] px-2 py-1 text-xs">Orthodox</span>
+                                    @else
+                                        <span class="inline-flex items-center rounded-full bg-[color:var(--color-accent-100)] text-[color:var(--color-accent-700)] px-2 py-1 text-xs">National</span>
+                                    @endif
+                                </td>
+                                <td class="px-4 py-3">{{ $holiday['description'] }}</td>
+                            </tr>
+                        @endforeach
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+
+    <div class="mt-6 bg-[color:var(--color-primary-100)] dark:bg-[color:var(--color-dark-200)] shadow sm:rounded-lg">
+        <div class="px-4 py-5 sm:px-6">
+            <h2 class="text-lg font-semibold text-[color:var(--color-primary-700)] dark:text-[color:var(--color-dark-600)] mb-3">About Macedonian Holidays</h2>
+            <div class="text-[color:var(--color-primary-600)] dark:text-[color:var(--color-dark-500)] space-y-2">
+                <p>North Macedonia celebrates a rich mix of national and religious holidays that reflect its diverse cultural heritage.</p>
+                <p><strong>National Holidays</strong> commemorate important historical events such as independence, the Ilinden Uprising, and significant cultural figures.</p>
+                <p><strong>Orthodox Holidays</strong> follow the Julian calendar and include major Christian celebrations observed by the Macedonian Orthodox Church.</p>
+                <p class="text-sm italic">Note: Orthodox Easter is a movable feast and its date varies each year based on the lunar calendar.</p>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -108,6 +108,11 @@
                             <a href="{{ route('cycle-menus.index') }}" class="inline-flex items-center px-1 pt-1 border-b-2 {{ request()->routeIs('cycle-menus.*') ? 'border-[color:var(--color-accent-500)] text-[color:var(--color-primary-700)] dark:text-[color:var(--color-dark-600)]' : 'border-transparent text-[color:var(--color-primary-500)] dark:text-[color:var(--color-dark-500)] hover:text-[color:var(--color-primary-600)] dark:hover:text-[color:var(--color-dark-400)] hover:border-[color:var(--color-primary-400)]' }} text-sm font-medium transition-colors duration-200">
                                 Cycle Menu
                             </a>
+
+                            <!-- Holidays -->
+                            <a href="{{ route('holidays.index') }}" class="inline-flex items-center px-1 pt-1 border-b-2 {{ request()->routeIs('holidays.*') ? 'border-[color:var(--color-accent-500)] text-[color:var(--color-primary-700)] dark:text-[color:var(--color-dark-600)]' : 'border-transparent text-[color:var(--color-primary-500)] dark:text-[color:var(--color-dark-500)] hover:text-[color:var(--color-primary-600)] dark:hover:text-[color:var(--color-dark-400)] hover:border-[color:var(--color-primary-400)]' }} text-sm font-medium transition-colors duration-200">
+                                Holidays
+                            </a>
                         </div>
                         @endauth
                     </div>
@@ -225,6 +230,8 @@
                     <a href="{{ route('job-applications.index') }}" class="block pl-3 pr-4 py-2 border-l-4 {{ request()->routeIs('job-applications.*') ? 'border-[color:var(--color-accent-500)] text-[color:var(--color-accent-600)] bg-[color:var(--color-accent-50)]' : 'border-transparent text-[color:var(--color-primary-600)] hover:text-[color:var(--color-primary-700)] hover:bg-[color:var(--color-primary-200)] hover:border-[color:var(--color-primary-400)]' }} text-base font-medium transition-colors duration-200">Job Applications</a>
 
                     <a href="{{ route('cycle-menus.index') }}" class="block pl-3 pr-4 py-2 border-l-4 {{ request()->routeIs('cycle-menus.*') ? 'border-[color:var(--color-accent-500)] text-[color:var(--color-accent-600)] bg-[color:var(--color-accent-50)]' : 'border-transparent text-[color:var(--color-primary-600)] hover:text-[color:var(--color-primary-700)] hover:bg-[color:var(--color-primary-200)] hover:border-[color:var(--color-primary-400)]' }} text-base font-medium transition-colors duration-200">Cycle Menu</a>
+
+                    <a href="{{ route('holidays.index') }}" class="block pl-3 pr-4 py-2 border-l-4 {{ request()->routeIs('holidays.*') ? 'border-[color:var(--color-accent-500)] text-[color:var(--color-accent-600)] bg-[color:var(--color-accent-50)]' : 'border-transparent text-[color:var(--color-primary-600)] hover:text-[color:var(--color-primary-700)] hover:bg-[color:var(--color-primary-200)] hover:border-[color:var(--color-primary-400)]' }} text-base font-medium transition-colors duration-200">Holidays</a>
                 </div>
             </div>
             @endauth

--- a/routes/web.php
+++ b/routes/web.php
@@ -8,6 +8,7 @@ use App\Http\Controllers\DashboardController;
 use App\Http\Controllers\ExpenseController;
 use App\Http\Controllers\FileUploadController;
 use App\Http\Controllers\GmailReceiptController;
+use App\Http\Controllers\HolidayController;
 use App\Http\Controllers\InvestmentController;
 use App\Http\Controllers\ProjectInvestmentController;
 use App\Http\Controllers\IouController;
@@ -201,4 +202,7 @@ Route::middleware('auth')->group(function () {
         Route::delete('{cycle_menu_item}', [CycleMenuItemController::class, 'destroy'])->name('destroy');
         Route::post('reorder', [CycleMenuItemController::class, 'reorder'])->name('reorder');
     });
+
+    // Holidays Routes
+    Route::get('/holidays', [HolidayController::class, 'index'])->name('holidays.index');
 });


### PR DESCRIPTION
This commit introduces a new page displaying all National Macedonian Holidays including Orthodox holidays celebrated in North Macedonia.

Changes:
- Added HolidayController with index method containing 12 holidays
- Created holidays index view with table layout matching app design
- Added route for /holidays endpoint
- Added navigation links in both desktop and mobile menus
- Included informational section about Macedonian holidays

The page displays holidays with:
- English and Macedonian names
- Dates
- Type badges (National/Orthodox)
- Descriptions of each holiday