### PR TITLE
fix: Make project_investment_transactions migration idempotent

### DIFF
--- a/database/migrations/2026_01_19_150000_create_project_investment_transactions_table.php
+++ b/database/migrations/2026_01_19_150000_create_project_investment_transactions_table.php
@@ -11,19 +11,21 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::create('project_investment_transactions', function (Blueprint $table) {
-            $table->id();
-            $table->foreignId('project_investment_id')->constrained()->onDelete('cascade');
-            $table->foreignId('user_id')->constrained()->onDelete('cascade');
-            $table->decimal('amount', 15, 2);
-            $table->string('currency', 3)->default('USD');
-            $table->date('transaction_date');
-            $table->text('notes')->nullable();
-            $table->timestamps();
+        if (!Schema::hasTable('project_investment_transactions')) {
+            Schema::create('project_investment_transactions', function (Blueprint $table) {
+                $table->id();
+                $table->foreignId('project_investment_id')->constrained()->onDelete('cascade');
+                $table->foreignId('user_id')->constrained()->onDelete('cascade');
+                $table->decimal('amount', 15, 2);
+                $table->string('currency', 3)->default('USD');
+                $table->date('transaction_date');
+                $table->text('notes')->nullable();
+                $table->timestamps();
 
-            $table->index(['project_investment_id', 'transaction_date'], 'pit_project_id_date_idx');
-            $table->index('user_id', 'pit_user_id_idx');
-        });
+                $table->index(['project_investment_id', 'transaction_date'], 'pit_project_id_date_idx');
+                $table->index('user_id', 'pit_user_id_idx');
+            });
+        }
     }
 
     /**


### PR DESCRIPTION
Add table existence check before creating project_investment_transactions
table to prevent SQLSTATE[42S01] error when table already exists in database.

This allows the migration to run safely even if the table was previously
created, resolving the deployment failure on Laravel Cloud.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced database migration handling with improved error prevention during system deployment.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->