### PR TITLE
feat: Move project investment transaction indices to separate migration

### DIFF
--- a/database/migrations/2026_01_19_150000_create_project_investment_transactions_table.php
+++ b/database/migrations/2026_01_19_150000_create_project_investment_transactions_table.php
@@ -21,9 +21,6 @@ return new class extends Migration
                 $table->date('transaction_date');
                 $table->text('notes')->nullable();
                 $table->timestamps();
-
-                $table->index(['project_investment_id', 'transaction_date'], 'pit_project_id_date_idx');
-                $table->index('user_id', 'pit_user_id_idx');
             });
         }
     }

--- a/database/migrations/2026_01_20_000000_add_indices_to_project_investment_transactions_table.php
+++ b/database/migrations/2026_01_20_000000_add_indices_to_project_investment_transactions_table.php
@@ -1,0 +1,48 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('project_investment_transactions', function (Blueprint $table) {
+            // Check if indices don't already exist before adding them
+            if (!$this->indexExists('project_investment_transactions', 'pit_project_id_date_idx')) {
+                $table->index(['project_investment_id', 'transaction_date'], 'pit_project_id_date_idx');
+            }
+
+            if (!$this->indexExists('project_investment_transactions', 'pit_user_id_idx')) {
+                $table->index('user_id', 'pit_user_id_idx');
+            }
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('project_investment_transactions', function (Blueprint $table) {
+            $table->dropIndex('pit_project_id_date_idx');
+            $table->dropIndex('pit_user_id_idx');
+        });
+    }
+
+    /**
+     * Check if an index exists on a table.
+     */
+    private function indexExists(string $table, string $index): bool
+    {
+        $connection = Schema::getConnection();
+        $doctrineSchemaManager = $connection->getDoctrineSchemaManager();
+        $doctrineTable = $doctrineSchemaManager->introspectTable($table);
+
+        return $doctrineTable->hasIndex($index);
+    }
+};


### PR DESCRIPTION
- Created new migration to add pit_project_id_date_idx and pit_user_id_idx
- Removed indices from original table creation migration
- Added index existence checks to prevent conflicts
- Made migration idempotent with proper rollback support

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized database indexing strategy for project investment transaction queries through conditional index creation.
  * Improved data assignment workflow for tenant management, refining how related records are associated across the system.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->