### PR TITLE
fix: Handle investment_transactions table correctly in tenant assignment

### DIFF
--- a/database/migrations/2026_01_19_211041_assign_existing_data_to_default_tenants.php
+++ b/database/migrations/2026_01_19_211041_assign_existing_data_to_default_tenants.php
@@ -59,7 +59,6 @@ return new class extends Migration
             'warranties',
             'investments',
             'investment_goals',
-            'investment_transactions',
             'expenses',
             'utility_bills',
             'ious',
@@ -95,6 +94,16 @@ return new class extends Migration
                 ->whereNull('tenant_id')
                 ->update(['tenant_id' => $tenantId]);
         }
+
+        // Handle investment_transactions separately - it's related through investment_id
+        DB::table('investment_transactions')
+            ->whereNull('tenant_id')
+            ->whereIn('investment_id', function ($query) use ($userId) {
+                $query->select('id')
+                    ->from('investments')
+                    ->where('user_id', $userId);
+            })
+            ->update(['tenant_id' => $tenantId]);
 
         // Handle investment_dividends separately - it's related through investment_id
         DB::table('investment_dividends')


### PR DESCRIPTION
The investment_transactions table doesn't have a user_id column - it's
related to users through the investment_id foreign key. This commit moves
investment_transactions out of the direct user_id tables list and handles
it separately using a subquery through the investments table.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal data migration process for tenant assignment handling with no user-visible changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->