### PR TITLE
fix: Handle refunds table correctly in tenant assignment

### DIFF
--- a/database/migrations/2026_01_19_211041_assign_existing_data_to_default_tenants.php
+++ b/database/migrations/2026_01_19_211041_assign_existing_data_to_default_tenants.php
@@ -77,7 +77,6 @@ return new class extends Migration
             'discounts',
             'payments',
             'credit_notes',
-            'refunds',
             'sequences',
             'recurring_invoices',
             'recurring_invoice_items',
@@ -151,6 +150,16 @@ return new class extends Migration
             ->whereIn('credit_note_id', function ($query) use ($userId) {
                 $query->select('id')
                     ->from('credit_notes')
+                    ->where('user_id', $userId);
+            })
+            ->update(['tenant_id' => $tenantId]);
+
+        // Handle refunds - related through payment_id
+        DB::table('refunds')
+            ->whereNull('tenant_id')
+            ->whereIn('payment_id', function ($query) use ($userId) {
+                $query->select('id')
+                    ->from('payments')
                     ->where('user_id', $userId);
             })
             ->update(['tenant_id' => $tenantId]);


### PR DESCRIPTION
The refunds table doesn't have a user_id column - it's related to users
through payment_id -> payments -> user_id. This commit:

- Removes refunds from the $tablesWithUserId array
- Adds a separate handler for refunds that relates through payment_id

This fixes the "Column not found: 1054 Unknown column 'user_id'" error
when running the migration.