### PR TITLE
fix: Replace deprecated getDoctrineSchemaManager with raw query

### DIFF
--- a/database/migrations/2026_01_20_000000_add_indices_to_project_investment_transactions_table.php
+++ b/database/migrations/2026_01_20_000000_add_indices_to_project_investment_transactions_table.php
@@ -40,9 +40,17 @@ return new class extends Migration
     private function indexExists(string $table, string $index): bool
     {
         $connection = Schema::getConnection();
-        $doctrineSchemaManager = $connection->getDoctrineSchemaManager();
-        $doctrineTable = $doctrineSchemaManager->introspectTable($table);
+        $databaseName = $connection->getDatabaseName();
 
-        return $doctrineTable->hasIndex($index);
+        $indexExists = $connection->select(
+            "SELECT COUNT(*) as count
+             FROM information_schema.statistics
+             WHERE table_schema = ?
+             AND table_name = ?
+             AND index_name = ?",
+            [$databaseName, $table, $index]
+        );
+
+        return $indexExists[0]->count > 0;
     }
 };


### PR DESCRIPTION
Replaced the deprecated Doctrine DBAL getDoctrineSchemaManager() method
with a raw database query to check for index existence in MySQL's
information_schema. This fixes the error where the method doesn't exist
in newer Laravel versions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized database index verification process for improved reliability

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->