### PR TITLE
fix: Enforce strict tenant isolation and add production diagnostic tools

### DIFF
--- a/TENANCY_PRODUCTION_FIX.md
+++ b/TENANCY_PRODUCTION_FIX.md
@@ -1,0 +1,169 @@
+# Tenancy Production Fix
+
+## Problem Summary
+
+The previous TenantScope implementation included all records with `NULL tenant_id`, which caused:
+1. **Security risk**: Users could see other users' data if records had NULL tenant_id
+2. **Data visibility issues**: Inconsistent data showing based on database state
+
+## Changes Made
+
+### 1. Fixed TenantScope (app/Scopes/TenantScope.php)
+- **Removed** the insecure `orWhereNull()` clause
+- **Enforced** strict tenant isolation - users now only see data for their current tenant
+- Maintains fail-closed security when no tenant is set
+
+### 2. Added CheckTenancyStatus Command
+```bash
+php artisan tenants:check-status
+php artisan tenants:check-status --user-id=123
+```
+Use this to diagnose tenancy issues in production.
+
+### 3. Improved AssignMissingTenantIds Command
+- Better error handling for users without `current_tenant_id`
+- Reports records that couldn't be assigned
+- Safer with `whereExists` checks
+
+## Production Deployment Steps
+
+### Step 1: Check Current State
+```bash
+php artisan tenants:check-status
+```
+
+This will show:
+- How many users have `current_tenant_id` set
+- How many tenants exist
+- Which tables have NULL `tenant_id` records
+
+### Step 2: Ensure Migrations Have Run
+
+Check that these migrations have been executed:
+- `2026_01_19_*_create_tenants_table`
+- `2026_01_19_*_create_tenant_members_table`
+- `2026_01_19_*_add_current_tenant_id_to_users_table`
+- `2026_01_19_*_add_tenant_id_to_all_tables`
+- `2026_01_19_*_assign_existing_data_to_default_tenants`
+
+```bash
+php artisan migrate:status
+```
+
+### Step 3: Fix Users Without Tenants
+
+If users don't have `current_tenant_id` set:
+
+**Option A: Use Tinker (for small numbers)**
+```bash
+php artisan tinker
+```
+```php
+User::whereNull('current_tenant_id')->each(function($user) {
+    $tenant = $user->ownedTenants()->first() ?? $user->tenants()->first();
+    if ($tenant) {
+        $user->update(['current_tenant_id' => $tenant->id]);
+        echo "Set user {$user->id} to tenant {$tenant->id}\n";
+    } else {
+        echo "User {$user->id} has no tenants!\n";
+    }
+});
+```
+
+**Option B: Create Default Tenants (if users have no tenants)**
+```bash
+php artisan tinker
+```
+```php
+use Illuminate\Support\Str;
+
+User::whereNull('current_tenant_id')->each(function($user) {
+    // Create personal tenant
+    $tenant = \App\Models\Tenant::create([
+        'name' => "{$user->name}'s Personal Account",
+        'slug' => Str::slug($user->name) . '-personal-' . Str::random(6),
+        'owner_id' => $user->id,
+    ]);
+
+    // Add as admin member
+    $tenant->members()->attach($user->id, ['role' => 'admin']);
+
+    // Set as current
+    $user->update(['current_tenant_id' => $tenant->id]);
+
+    echo "Created tenant {$tenant->id} for user {$user->id}\n";
+});
+```
+
+### Step 4: Assign Data to Tenants
+
+```bash
+# Preview what will be updated
+php artisan tenants:assign-missing --dry-run
+
+# Apply the changes
+php artisan tenants:assign-missing
+```
+
+### Step 5: Verify Everything
+
+```bash
+php artisan tenants:check-status
+```
+
+Should show:
+- ✓ All users have `current_tenant_id`
+- ✓ All data tables have `tenant_id` assigned
+- ✓ No warnings
+
+### Step 6: Test in Production
+
+1. Log in as a test user
+2. Verify they can see their data (expenses, invoices, etc.)
+3. Check that data counts match expected values
+4. Verify users can switch between tenants if they're members of multiple
+
+## Rollback Plan (if needed)
+
+If you need to rollback temporarily:
+
+```bash
+# This will temporarily allow NULL tenant_id records again
+# Edit app/Scopes/TenantScope.php and add back orWhereNull
+```
+
+However, **do not do this** unless absolutely necessary as it's a security risk.
+
+## Common Issues
+
+### Issue: "No data showing after deployment"
+**Cause**: Users have `current_tenant_id` set, but their data has NULL `tenant_id`
+**Fix**: Run `php artisan tenants:assign-missing`
+
+### Issue: "User can't see any data but used to"
+**Cause**: User's `current_tenant_id` doesn't match their data's `tenant_id`
+**Fix**: Check with `php artisan tenants:check-status --user-id=X` and reassign if needed
+
+### Issue: "Some tables still have NULL tenant_id"
+**Cause**: Data created after migration but before tenant assignment
+**Fix**: Run `php artisan tenants:assign-missing` again
+
+## Long-term Solution
+
+Going forward, all new records will automatically get `tenant_id` assigned via the `BelongsToTenant` trait. The NULL `tenant_id` issue should not recur.
+
+## Support Commands Reference
+
+```bash
+# Check overall tenancy status
+php artisan tenants:check-status
+
+# Check specific user
+php artisan tenants:check-status --user-id=123
+
+# Preview tenant assignment
+php artisan tenants:assign-missing --dry-run
+
+# Fix missing tenant assignments
+php artisan tenants:assign-missing
+```

--- a/app/Console/Commands/CheckTenancyStatus.php
+++ b/app/Console/Commands/CheckTenancyStatus.php
@@ -1,0 +1,166 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+
+class CheckTenancyStatus extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'tenants:check-status {--user-id= : Check specific user ID}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Check the current state of tenancy setup and data assignment';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): int
+    {
+        $this->info('=== Tenancy Status Check ===');
+        $this->newLine();
+
+        // Check users
+        $totalUsers = DB::table('users')->count();
+        $usersWithTenant = DB::table('users')->whereNotNull('current_tenant_id')->count();
+        $usersWithoutTenant = $totalUsers - $usersWithTenant;
+
+        $this->info("Users:");
+        $this->line("  Total users: {$totalUsers}");
+        $this->line("  Users with current_tenant_id: {$usersWithTenant}");
+        if ($usersWithoutTenant > 0) {
+            $this->warn("  Users WITHOUT current_tenant_id: {$usersWithoutTenant}");
+        }
+        $this->newLine();
+
+        // Check tenants
+        $totalTenants = DB::table('tenants')->count();
+        $this->info("Tenants:");
+        $this->line("  Total tenants: {$totalTenants}");
+        $this->newLine();
+
+        // Check tenant members
+        $totalMembers = DB::table('tenant_members')->count();
+        $this->info("Tenant Members:");
+        $this->line("  Total memberships: {$totalMembers}");
+        $this->newLine();
+
+        // Check data tables for NULL tenant_id
+        $tablesWithTenantId = [
+            'budgets', 'subscriptions', 'contracts', 'warranties',
+            'investments', 'investment_goals', 'investment_dividends', 'investment_transactions',
+            'expenses', 'utility_bills', 'ious',
+            'job_applications', 'job_application_status_histories', 'job_application_interviews', 'job_application_offers',
+            'cycle_menus', 'cycle_menu_days', 'cycle_menu_items',
+            'project_investments', 'project_investment_transactions',
+            'gmail_connections', 'processed_emails',
+            'customers', 'invoices', 'tax_rates', 'discounts', 'invoice_items',
+            'payments', 'credit_notes', 'credit_note_applications', 'refunds',
+            'sequences', 'recurring_invoices', 'recurring_invoice_items', 'invoice_reminders',
+        ];
+
+        $this->info("Data Tables with NULL tenant_id:");
+        $foundNulls = false;
+
+        foreach ($tablesWithTenantId as $table) {
+            $nullCount = DB::table($table)->whereNull('tenant_id')->count();
+            $totalCount = DB::table($table)->count();
+
+            if ($nullCount > 0) {
+                $this->warn("  {$table}: {$nullCount}/{$totalCount} records have NULL tenant_id");
+                $foundNulls = true;
+            }
+        }
+
+        if (!$foundNulls) {
+            $this->info("  ✓ All data tables have tenant_id assigned!");
+        }
+        $this->newLine();
+
+        // If specific user requested, show their details
+        if ($userId = $this->option('user-id')) {
+            $this->checkUserDetails($userId);
+        }
+
+        // Recommendations
+        $this->info('=== Recommendations ===');
+        if ($usersWithoutTenant > 0) {
+            $this->warn("⚠ Some users don't have current_tenant_id set.");
+            $this->line("  Run: php artisan tinker");
+            $this->line("       User::whereNull('current_tenant_id')->each(fn(\$u) => \$u->update(['current_tenant_id' => \$u->ownedTenants()->first()?->id ?? \$u->tenants()->first()?->id]))");
+        }
+
+        if ($foundNulls) {
+            $this->warn("⚠ Some data records have NULL tenant_id.");
+            $this->line("  Run: php artisan tenants:assign-missing --dry-run  (to preview)");
+            $this->line("       php artisan tenants:assign-missing              (to fix)");
+        }
+
+        if (!$foundNulls && $usersWithoutTenant === 0) {
+            $this->info("✓ Tenancy appears to be properly configured!");
+        }
+
+        return Command::SUCCESS;
+    }
+
+    protected function checkUserDetails(int $userId): void
+    {
+        $this->info("=== User #{$userId} Details ===");
+
+        $user = DB::table('users')->where('id', $userId)->first();
+        if (!$user) {
+            $this->error("User not found!");
+            return;
+        }
+
+        $this->line("Name: {$user->name}");
+        $this->line("Email: {$user->email}");
+        $this->line("Current Tenant ID: " . ($user->current_tenant_id ?? 'NULL'));
+        $this->newLine();
+
+        // Owned tenants
+        $ownedTenants = DB::table('tenants')->where('owner_id', $userId)->get();
+        $this->info("Owned Tenants: " . $ownedTenants->count());
+        foreach ($ownedTenants as $tenant) {
+            $this->line("  - [{$tenant->id}] {$tenant->name}");
+        }
+        $this->newLine();
+
+        // Member of tenants
+        $memberTenants = DB::table('tenant_members')
+            ->where('user_id', $userId)
+            ->join('tenants', 'tenants.id', '=', 'tenant_members.tenant_id')
+            ->select('tenants.*', 'tenant_members.role')
+            ->get();
+        $this->info("Member of Tenants: " . $memberTenants->count());
+        foreach ($memberTenants as $tenant) {
+            $this->line("  - [{$tenant->id}] {$tenant->name} (role: {$tenant->role})");
+        }
+        $this->newLine();
+
+        // Data counts for this user
+        $this->info("Data Records:");
+        $expenses = DB::table('expenses')->where('user_id', $userId)->count();
+        $expensesWithTenant = DB::table('expenses')->where('user_id', $userId)->whereNotNull('tenant_id')->count();
+        $this->line("  Expenses: {$expenses} total, {$expensesWithTenant} with tenant_id");
+
+        $invoices = DB::table('invoices')->where('user_id', $userId)->count();
+        $invoicesWithTenant = DB::table('invoices')->where('user_id', $userId)->whereNotNull('tenant_id')->count();
+        $this->line("  Invoices: {$invoices} total, {$invoicesWithTenant} with tenant_id");
+
+        $customers = DB::table('customers')->where('user_id', $userId)->count();
+        $customersWithTenant = DB::table('customers')->where('user_id', $userId)->whereNotNull('tenant_id')->count();
+        $this->line("  Customers: {$customers} total, {$customersWithTenant} with tenant_id");
+
+        $this->newLine();
+    }
+}

--- a/app/Scopes/TenantScope.php
+++ b/app/Scopes/TenantScope.php
@@ -19,11 +19,7 @@ class TenantScope implements Scope
             return;
         }
 
-        // Include both tenant-assigned data AND legacy data with NULL tenant_id
-        // This is safe because controllers filter by user_id separately
-        $builder->where(function($query) use ($model) {
-            $query->where($model->getTable().'.tenant_id', auth()->user()->current_tenant_id)
-                  ->orWhereNull($model->getTable().'.tenant_id');
-        });
+        // Enforce strict tenant isolation - only show records for current tenant
+        $builder->where($model->getTable().'.tenant_id', auth()->user()->current_tenant_id);
     }
 }


### PR DESCRIPTION
Problem:
- Previous TenantScope included ALL records with NULL tenant_id regardless
  of user ownership, creating a security vulnerability
- Production data not showing because strict isolation reveals missing
  tenant_id assignments
- No diagnostic tools to identify tenancy issues

Changes:
- Removed insecure orWhereNull() clause from TenantScope
- Now enforces strict tenant isolation (fail-closed security)
- Added CheckTenancyStatus command to diagnose tenancy setup issues
- Improved AssignMissingTenantIds with better error handling
- Added TENANCY_PRODUCTION_FIX.md with deployment steps

Production Fix:
1. Run: php artisan tenants:check-status
2. Ensure users have current_tenant_id set
3. Run: php artisan tenants:assign-missing
4. Verify with: php artisan tenants:check-status

This change enforces proper multi-tenant data isolation while providing
tools to fix existing data assignment issues.