### PR TITLE
fix: Fix tenant statistics command and migration compatibility

### DIFF
--- a/app/Console/Commands/TenantStatistics.php
+++ b/app/Console/Commands/TenantStatistics.php
@@ -15,8 +15,7 @@ class TenantStatistics extends Command
      */
     protected $signature = 'tenants:statistics
                             {--tenant-id= : Show statistics for specific tenant ID only}
-                            {--with-data : Include sample data records}
-                            {--verbose : Show detailed information}';
+                            {--with-data : Include sample data records}';
 
     /**
      * The console command description.
@@ -123,7 +122,7 @@ class TenantStatistics extends Command
         $membersCount = $tenant->members()->count();
         $this->line("  <fg=cyan>Members Count:</>  {$membersCount}");
 
-        if ($this->option('verbose') && $membersCount > 0) {
+        if ($this->getOutput()->isVerbose() && $membersCount > 0) {
             $this->line("  <fg=cyan>Members:</>");
             $members = $tenant->members;
             foreach ($members as $member) {


### PR DESCRIPTION
- Fixed TenantStatistics command by removing duplicate --verbose option
  that conflicted with Laravel's built-in verbose flag
- Updated command to use $this->getOutput()->isVerbose() to check verbosity
- Fixed migration to work with SQLite by removing MySQL-specific
  information_schema queries and using try-catch for index creation
- Verbose option now works correctly to display detailed member information

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed the `--verbose` option from the TenantStatistics command. Detailed information display now depends on the actual console output verbosity level instead of a separate flag.
  * Updated index creation handling in database migrations to use exception-based approach for improved robustness.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->