### PR TITLE
fix: Use correct column name 'expense_date' in tenant statistics query

### DIFF
--- a/app/Console/Commands/TenantStatistics.php
+++ b/app/Console/Commands/TenantStatistics.php
@@ -216,14 +216,14 @@ class TenantStatistics extends Command
     {
         $expenses = DB::table('expenses')
             ->where('tenant_id', $tenant->id)
-            ->orderBy('date', 'desc')
+            ->orderBy('expense_date', 'desc')
             ->limit(5)
             ->get();
 
         if ($expenses->isNotEmpty()) {
             $this->line('    <fg=cyan>Expenses:</> (Latest 5)');
             foreach ($expenses as $expense) {
-                $this->line("      - {$expense->date}: {$expense->description} - " . number_format($expense->amount, 2) . " {$expense->currency}");
+                $this->line("      - {$expense->expense_date}: {$expense->description} - " . number_format($expense->amount, 2) . " {$expense->currency}");
             }
             $this->newLine();
         }


### PR DESCRIPTION
The displayExpensesSample method was referencing a non-existent 'date'
column. Fixed to use the correct 'expense_date' column name in both the
orderBy clause and the output display.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected expense ordering and display in tenant statistics to use the proper date field, ensuring accurate and consistent reporting of expenses.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->