### PR TITLE
fix: Use correct column name 'issued_at' in invoices query

### DIFF
--- a/app/Console/Commands/TenantStatistics.php
+++ b/app/Console/Commands/TenantStatistics.php
@@ -236,7 +236,7 @@ class TenantStatistics extends Command
     {
         $invoices = DB::table('invoices')
             ->where('tenant_id', $tenant->id)
-            ->orderBy('invoice_date', 'desc')
+            ->orderBy('issued_at', 'desc')
             ->limit(5)
             ->get();
 


### PR DESCRIPTION
The tenant statistics command was referencing a non-existent 'invoice_date'
column. The invoices table uses 'issued_at' for the invoice issue date.