### PR TITLE
fix: Use correct column names in tenant statistics --with-data option

### DIFF
--- a/app/Console/Commands/TenantStatistics.php
+++ b/app/Console/Commands/TenantStatistics.php
@@ -243,7 +243,8 @@ class TenantStatistics extends Command
         if ($invoices->isNotEmpty()) {
             $this->line('    <fg=cyan>Invoices:</> (Latest 5)');
             foreach ($invoices as $invoice) {
-                $this->line("      - #{$invoice->invoice_number}: {$invoice->status} - Total: " . number_format($invoice->total, 2) . " {$invoice->currency}");
+                $invoiceNumber = $invoice->number ?? 'Draft';
+                $this->line("      - #{$invoiceNumber}: {$invoice->status} - Total: " . number_format($invoice->total / 100, 2) . " {$invoice->currency}");
             }
             $this->newLine();
         }
@@ -263,7 +264,8 @@ class TenantStatistics extends Command
         if ($customers->isNotEmpty()) {
             $this->line('    <fg=cyan>Customers:</> (Latest 5)');
             foreach ($customers as $customer) {
-                $this->line("      - {$customer->name} ({$customer->email})");
+                $email = $customer->email ?? 'No email';
+                $this->line("      - {$customer->name} ({$email})");
             }
             $this->newLine();
         }
@@ -303,7 +305,8 @@ class TenantStatistics extends Command
         if ($contracts->isNotEmpty()) {
             $this->line('    <fg=cyan>Contracts:</> (Latest 5)');
             foreach ($contracts as $contract) {
-                $this->line("      - {$contract->title}: {$contract->status} (${contract->start_date} - {$contract->end_date})");
+                $endDate = $contract->end_date ?? 'Ongoing';
+                $this->line("      - {$contract->title}: {$contract->status} ({$contract->start_date} - {$endDate})");
             }
             $this->newLine();
         }
@@ -323,7 +326,9 @@ class TenantStatistics extends Command
         if ($investments->isNotEmpty()) {
             $this->line('    <fg=cyan>Investments:</> (Latest 5)');
             foreach ($investments as $investment) {
-                $this->line("      - {$investment->name} ({$investment->investment_type}): " . number_format($investment->purchase_price, 2) . " {$investment->currency}");
+                $price = $investment->purchase_price !== null ? number_format($investment->purchase_price, 2) : 'N/A';
+                $currency = $investment->currency ?? 'N/A';
+                $this->line("      - {$investment->name} ({$investment->investment_type}): {$price} {$currency}");
             }
             $this->newLine();
         }

--- a/app/Console/Commands/TenantStatistics.php
+++ b/app/Console/Commands/TenantStatistics.php
@@ -283,7 +283,7 @@ class TenantStatistics extends Command
         if ($subscriptions->isNotEmpty()) {
             $this->line('    <fg=cyan>Subscriptions:</> (Latest 5)');
             foreach ($subscriptions as $subscription) {
-                $this->line("      - {$subscription->name}: {$subscription->status} - " . number_format($subscription->amount, 2) . " {$subscription->currency}/{$subscription->billing_cycle}");
+                $this->line("      - {$subscription->service_name}: {$subscription->status} - " . number_format($subscription->cost, 2) . " {$subscription->currency}/{$subscription->billing_cycle}");
             }
             $this->newLine();
         }
@@ -303,7 +303,7 @@ class TenantStatistics extends Command
         if ($contracts->isNotEmpty()) {
             $this->line('    <fg=cyan>Contracts:</> (Latest 5)');
             foreach ($contracts as $contract) {
-                $this->line("      - {$contract->name}: {$contract->status} (${contract->start_date} - {$contract->end_date})");
+                $this->line("      - {$contract->title}: {$contract->status} (${contract->start_date} - {$contract->end_date})");
             }
             $this->newLine();
         }
@@ -323,7 +323,7 @@ class TenantStatistics extends Command
         if ($investments->isNotEmpty()) {
             $this->line('    <fg=cyan>Investments:</> (Latest 5)');
             foreach ($investments as $investment) {
-                $this->line("      - {$investment->name} ({$investment->type}): " . number_format($investment->initial_investment, 2) . " {$investment->currency}");
+                $this->line("      - {$investment->name} ({$investment->investment_type}): " . number_format($investment->purchase_price, 2) . " {$investment->currency}");
             }
             $this->newLine();
         }
@@ -343,7 +343,7 @@ class TenantStatistics extends Command
         if ($applications->isNotEmpty()) {
             $this->line('    <fg=cyan>Job Applications:</> (Latest 5)');
             foreach ($applications as $application) {
-                $this->line("      - {$application->job_title} at {$application->company}: {$application->status}");
+                $this->line("      - {$application->job_title} at {$application->company_name}: {$application->status}");
             }
             $this->newLine();
         }


### PR DESCRIPTION
Fixed column name mismatches that were causing the --with-data option to fail:
- Subscriptions: name → service_name, amount → cost
- Contracts: name → title
- Investments: type → investment_type, initial_investment → purchase_price
- Job Applications: company → company_name