### PR TITLE
feat: Add tenant-specific default currency support

### DIFF
--- a/app/Models/Tenant.php
+++ b/app/Models/Tenant.php
@@ -15,6 +15,7 @@ class Tenant extends Model
     protected $fillable = [
         'name',
         'slug',
+        'default_currency',
         'owner_id',
     ];
 

--- a/app/Services/CurrencyService.php
+++ b/app/Services/CurrencyService.php
@@ -2,6 +2,7 @@
 
 namespace App\Services;
 
+use App\Models\Tenant;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
@@ -14,6 +15,18 @@ class CurrencyService
     public function getDefaultCurrency(): string
     {
         return config('currency.default', 'MKD');
+    }
+
+    /**
+     * Get the default currency for a specific tenant.
+     */
+    public function getTenantDefaultCurrency(?Tenant $tenant): string
+    {
+        if ($tenant && $tenant->default_currency) {
+            return $tenant->default_currency;
+        }
+
+        return $this->getDefaultCurrency();
     }
 
     /**
@@ -410,6 +423,36 @@ class CurrencyService
         $defaultCurrency = $this->getDefaultCurrency();
 
         return $this->convert($amount, $defaultCurrency, $toCurrency);
+    }
+
+    /**
+     * Convert amount to tenant's default currency.
+     */
+    public function convertToTenantCurrency(float $amount, string $fromCurrency, Tenant $tenant): float
+    {
+        $tenantCurrency = $this->getTenantDefaultCurrency($tenant);
+
+        return $this->convert($amount, $fromCurrency, $tenantCurrency);
+    }
+
+    /**
+     * Convert amount from tenant's default currency to target currency.
+     */
+    public function convertFromTenantCurrency(float $amount, string $toCurrency, Tenant $tenant): float
+    {
+        $tenantCurrency = $this->getTenantDefaultCurrency($tenant);
+
+        return $this->convert($amount, $tenantCurrency, $toCurrency);
+    }
+
+    /**
+     * Format amount with tenant's default currency.
+     */
+    public function formatForTenant(float $amount, Tenant $tenant, bool $showSymbol = true): string
+    {
+        $tenantCurrency = $this->getTenantDefaultCurrency($tenant);
+
+        return $this->format($amount, $tenantCurrency, $showSymbol);
     }
 
     /**

--- a/database/factories/TenantFactory.php
+++ b/database/factories/TenantFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Tenant>
+ */
+class TenantFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'name' => fake()->company(),
+            'slug' => fake()->unique()->slug(),
+            'default_currency' => fake()->randomElement(['MKD', 'USD', 'EUR', 'GBP']),
+            'owner_id' => User::factory(),
+        ];
+    }
+}

--- a/database/migrations/2026_01_21_184713_add_default_currency_to_tenants_table.php
+++ b/database/migrations/2026_01_21_184713_add_default_currency_to_tenants_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('tenants', function (Blueprint $table) {
+            $table->string('default_currency', 3)->nullable()->after('slug');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('tenants', function (Blueprint $table) {
+            $table->dropColumn('default_currency');
+        });
+    }
+};


### PR DESCRIPTION
- Add default_currency field to tenants table (nullable)
- Update Tenant model to include default_currency in fillable fields
- Extend CurrencyService with tenant-specific methods:
  - getTenantDefaultCurrency: Get default currency for a tenant
  - convertToTenantCurrency: Convert amounts to tenant's currency
  - convertFromTenantCurrency: Convert from tenant's currency
  - formatForTenant: Format amounts with tenant's currency
- Create TenantFactory for testing
- Add comprehensive tests for tenant currency conversion

This allows each tenant to have their own default currency for
automatic currency conversion and formatting throughout the application.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tenants can now configure and use their own default currency for all financial operations
  * Currency conversions between different currencies now respect each tenant's configured default
  * Currency formatting automatically applies the appropriate currency format for each tenant's default setting

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->