### PR TITLE
feat: Add tenant-specific default country selection for dynamic holiday display

### DIFF
--- a/app/Http/Controllers/HolidayController.php
+++ b/app/Http/Controllers/HolidayController.php
@@ -2,103 +2,41 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\Tenant;
+use App\Services\CountryHolidayService;
 use Illuminate\Http\Request;
 
 class HolidayController extends Controller
 {
-    /**
-     * Display a listing of Macedonian holidays.
-     */
-    public function index()
-    {
-        // National Macedonian Holidays
-        $nationalHolidays = [
-            [
-                'name' => 'New Year\'s Day',
-                'name_mk' => 'Нова Година',
-                'date' => 'January 1',
-                'type' => 'national',
-                'description' => 'Celebration of the new year'
-            ],
-            [
-                'name' => 'New Year\'s Day',
-                'name_mk' => 'Нова Година',
-                'date' => 'January 2',
-                'type' => 'national',
-                'description' => 'Second day of New Year celebration'
-            ],
-            [
-                'name' => 'Christmas Eve',
-                'name_mk' => 'Бадник (Православен)',
-                'date' => 'January 6',
-                'type' => 'orthodox',
-                'description' => 'Orthodox Christmas Eve'
-            ],
-            [
-                'name' => 'Christmas Day',
-                'name_mk' => 'Божиќ (Православен)',
-                'date' => 'January 7',
-                'type' => 'orthodox',
-                'description' => 'Orthodox Christmas Day'
-            ],
-            [
-                'name' => 'Easter',
-                'name_mk' => 'Велигден (Православен)',
-                'date' => 'Variable (April/May)',
-                'type' => 'orthodox',
-                'description' => 'Orthodox Easter - celebrated on different dates each year'
-            ],
-            [
-                'name' => 'Labour Day',
-                'name_mk' => 'Ден на трудот',
-                'date' => 'May 1',
-                'type' => 'national',
-                'description' => 'International Workers\' Day'
-            ],
-            [
-                'name' => 'Saints Cyril and Methodius Day',
-                'name_mk' => 'Св. Кирил и Методиј',
-                'date' => 'May 24',
-                'type' => 'national',
-                'description' => 'Day of the Slavonic Educators and Culture'
-            ],
-            [
-                'name' => 'Ilinden (St. Elijah\'s Day)',
-                'name_mk' => 'Илинден',
-                'date' => 'August 2',
-                'type' => 'national',
-                'description' => 'Uprising Day - National holiday commemorating the Ilinden Uprising of 1903'
-            ],
-            [
-                'name' => 'Republic Day',
-                'name_mk' => 'Ден на Републиката',
-                'date' => 'August 2',
-                'type' => 'national',
-                'description' => 'Day of the Republic of North Macedonia'
-            ],
-            [
-                'name' => 'Independence Day',
-                'name_mk' => 'Ден на независноста',
-                'date' => 'September 8',
-                'type' => 'national',
-                'description' => 'Independence from Yugoslavia (1991)'
-            ],
-            [
-                'name' => 'Day of the Macedonian Revolutionary Struggle',
-                'name_mk' => 'Ден на македонската револуционерна борба',
-                'date' => 'October 23',
-                'type' => 'national',
-                'description' => 'Commemorates the founding of VMRO in 1893'
-            ],
-            [
-                'name' => 'Saint Clement of Ohrid Day',
-                'name_mk' => 'Св. Климент Охридски',
-                'date' => 'December 8',
-                'type' => 'national',
-                'description' => 'Day of Saint Clement of Ohrid - patron saint of North Macedonia'
-            ],
-        ];
+    public function __construct(
+        private CountryHolidayService $countryHolidayService
+    ) {}
 
-        return view('holidays.index', compact('nationalHolidays'));
+    /**
+     * Display a listing of holidays based on tenant's default country.
+     */
+    public function index(Request $request)
+    {
+        $user = $request->user();
+        $tenant = $user->currentTenant;
+
+        if (!$tenant) {
+            abort(403, 'No tenant selected');
+        }
+
+        // Get tenant's holidays from database
+        $holidays = $this->countryHolidayService->getTenantCurrentYearHolidays($tenant);
+
+        // If no holidays exist, sync them from config
+        if ($holidays->isEmpty()) {
+            $this->countryHolidayService->syncTenantHolidays($tenant);
+            $holidays = $this->countryHolidayService->getTenantCurrentYearHolidays($tenant);
+        }
+
+        // Get country information
+        $countryCode = $this->countryHolidayService->getTenantDefaultCountry($tenant);
+        $countryName = $this->countryHolidayService->getCountryName($countryCode);
+
+        return view('holidays.index', compact('holidays', 'countryName', 'countryCode'));
     }
 }

--- a/app/Models/Holiday.php
+++ b/app/Models/Holiday.php
@@ -2,11 +2,16 @@
 
 namespace App\Models;
 
+use App\Traits\BelongsToTenant;
 use Illuminate\Database\Eloquent\Model;
 
 class Holiday extends Model
 {
+    use BelongsToTenant;
+
     protected $fillable = [
+        'tenant_id',
+        'country',
         'date',
         'name',
         'description',

--- a/app/Models/Tenant.php
+++ b/app/Models/Tenant.php
@@ -16,6 +16,7 @@ class Tenant extends Model
         'name',
         'slug',
         'default_currency',
+        'default_country',
         'owner_id',
     ];
 

--- a/app/Services/CountryHolidayService.php
+++ b/app/Services/CountryHolidayService.php
@@ -1,0 +1,189 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Holiday;
+use App\Models\Tenant;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Log;
+
+class CountryHolidayService
+{
+    /**
+     * Get the default country code.
+     */
+    public function getDefaultCountry(): string
+    {
+        return config('countries.default', 'MK');
+    }
+
+    /**
+     * Get the default country for a specific tenant.
+     */
+    public function getTenantDefaultCountry(?Tenant $tenant): string
+    {
+        if ($tenant && $tenant->default_country) {
+            return $tenant->default_country;
+        }
+
+        return $this->getDefaultCountry();
+    }
+
+    /**
+     * Get all supported countries.
+     */
+    public function getSupportedCountries(): array
+    {
+        return config('countries.supported', []);
+    }
+
+    /**
+     * Get country information by code.
+     */
+    public function getCountryInfo(string $countryCode): ?array
+    {
+        return config("countries.supported.{$countryCode}");
+    }
+
+    /**
+     * Get country name by code.
+     */
+    public function getCountryName(string $countryCode): string
+    {
+        $countryInfo = $this->getCountryInfo($countryCode);
+
+        return $countryInfo['name'] ?? $countryCode;
+    }
+
+    /**
+     * Get holidays for a specific country from configuration.
+     */
+    public function getCountryHolidays(string $countryCode): array
+    {
+        $countryInfo = $this->getCountryInfo($countryCode);
+
+        return $countryInfo['holidays'] ?? [];
+    }
+
+    /**
+     * Sync holidays for a tenant based on their default country.
+     */
+    public function syncTenantHolidays(Tenant $tenant, ?string $countryCode = null): int
+    {
+        $countryCode = $countryCode ?? $this->getTenantDefaultCountry($tenant);
+        $holidays = $this->getCountryHolidays($countryCode);
+
+        if (empty($holidays)) {
+            Log::warning("No holidays found for country: {$countryCode}");
+            return 0;
+        }
+
+        $currentYear = now()->year;
+        $synced = 0;
+
+        foreach ($holidays as $holiday) {
+            try {
+                // Create holiday for current year
+                Holiday::updateOrCreate(
+                    [
+                        'tenant_id' => $tenant->id,
+                        'country' => $countryCode,
+                        'date' => "{$currentYear}-{$holiday['date']}",
+                    ],
+                    [
+                        'name' => $holiday['name'],
+                        'description' => $holiday['description'] ?? null,
+                    ]
+                );
+
+                $synced++;
+            } catch (\Exception $e) {
+                Log::error("Failed to sync holiday: {$holiday['name']}", [
+                    'tenant_id' => $tenant->id,
+                    'country' => $countryCode,
+                    'error' => $e->getMessage(),
+                ]);
+            }
+        }
+
+        return $synced;
+    }
+
+    /**
+     * Get holidays for a tenant.
+     */
+    public function getTenantHolidays(Tenant $tenant, ?int $year = null): Collection
+    {
+        $year = $year ?? now()->year;
+        $countryCode = $this->getTenantDefaultCountry($tenant);
+
+        return Holiday::where('tenant_id', $tenant->id)
+            ->where('country', $countryCode)
+            ->whereYear('date', $year)
+            ->orderBy('date')
+            ->get();
+    }
+
+    /**
+     * Get holidays for the current year for a tenant.
+     */
+    public function getTenantCurrentYearHolidays(Tenant $tenant): Collection
+    {
+        return $this->getTenantHolidays($tenant, now()->year);
+    }
+
+    /**
+     * Check if a date is a holiday for a tenant.
+     */
+    public function isHoliday(Tenant $tenant, string $date): bool
+    {
+        $countryCode = $this->getTenantDefaultCountry($tenant);
+
+        return Holiday::where('tenant_id', $tenant->id)
+            ->where('country', $countryCode)
+            ->where('date', $date)
+            ->exists();
+    }
+
+    /**
+     * Get countries as options for select dropdown.
+     */
+    public function getCountryOptions(): array
+    {
+        $countries = $this->getSupportedCountries();
+        $options = [];
+
+        foreach ($countries as $code => $info) {
+            $options[$code] = $info['name'];
+        }
+
+        return $options;
+    }
+
+    /**
+     * Check if country is supported.
+     */
+    public function isSupported(string $countryCode): bool
+    {
+        return array_key_exists($countryCode, $this->getSupportedCountries());
+    }
+
+    /**
+     * Get formatted country list for display.
+     */
+    public function getFormattedCountryList(): array
+    {
+        $countries = $this->getSupportedCountries();
+        $formatted = [];
+
+        foreach ($countries as $code => $info) {
+            $formatted[] = [
+                'code' => $code,
+                'name' => $info['name'],
+                'is_default' => $code === $this->getDefaultCountry(),
+            ];
+        }
+
+        return $formatted;
+    }
+}

--- a/config/countries.php
+++ b/config/countries.php
@@ -1,0 +1,121 @@
+<?php
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Default Country
+    |--------------------------------------------------------------------------
+    |
+    | The default country code used throughout the application.
+    | This will be the primary country for all modules.
+    | Uses ISO 3166-1 alpha-2 country codes.
+    |
+    */
+    'default' => env('DEFAULT_COUNTRY', 'MK'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Supported Countries
+    |--------------------------------------------------------------------------
+    |
+    | List of supported countries with their holidays.
+    | The key should be the 2-letter ISO 3166-1 alpha-2 country code.
+    | Holidays use MM-DD format (month-day) and will be applied to current year.
+    |
+    */
+    'supported' => [
+        'MK' => [
+            'name' => 'North Macedonia',
+            'holidays' => [
+                ['date' => '01-01', 'name' => 'New Year\'s Day', 'description' => 'First day of the year'],
+                ['date' => '01-07', 'name' => 'Orthodox Christmas', 'description' => 'Orthodox Christian Christmas'],
+                ['date' => '05-01', 'name' => 'Labour Day', 'description' => 'International Workers\' Day'],
+                ['date' => '05-24', 'name' => 'Saints Cyril and Methodius Day', 'description' => 'Day of Slavonic Educators'],
+                ['date' => '08-02', 'name' => 'Republic Day', 'description' => 'Ilinden - Republic Day'],
+                ['date' => '09-08', 'name' => 'Independence Day', 'description' => 'Independence from Yugoslavia'],
+                ['date' => '10-11', 'name' => 'Day of Macedonian Uprising', 'description' => 'Day of the Macedonian Revolutionary Struggle'],
+                ['date' => '10-23', 'name' => 'Day of the Macedonian Revolutionary Struggle', 'description' => 'Celebration of the start of the Macedonian resistance movement'],
+                ['date' => '12-08', 'name' => 'Saint Clement of Ohrid Day', 'description' => 'Day of Saint Clement of Ohrid'],
+            ],
+        ],
+        'US' => [
+            'name' => 'United States',
+            'holidays' => [
+                ['date' => '01-01', 'name' => 'New Year\'s Day', 'description' => 'First day of the year'],
+                ['date' => '07-04', 'name' => 'Independence Day', 'description' => 'US Independence Day'],
+                ['date' => '11-11', 'name' => 'Veterans Day', 'description' => 'Honoring military veterans'],
+                ['date' => '12-25', 'name' => 'Christmas Day', 'description' => 'Christian celebration of the birth of Jesus Christ'],
+            ],
+        ],
+        'GB' => [
+            'name' => 'United Kingdom',
+            'holidays' => [
+                ['date' => '01-01', 'name' => 'New Year\'s Day', 'description' => 'First day of the year'],
+                ['date' => '12-25', 'name' => 'Christmas Day', 'description' => 'Christian celebration of the birth of Jesus Christ'],
+                ['date' => '12-26', 'name' => 'Boxing Day', 'description' => 'Day after Christmas'],
+            ],
+        ],
+        'DE' => [
+            'name' => 'Germany',
+            'holidays' => [
+                ['date' => '01-01', 'name' => 'New Year\'s Day', 'description' => 'First day of the year'],
+                ['date' => '05-01', 'name' => 'Labour Day', 'description' => 'International Workers\' Day'],
+                ['date' => '10-03', 'name' => 'German Unity Day', 'description' => 'Day of German reunification'],
+                ['date' => '12-25', 'name' => 'Christmas Day', 'description' => 'Christian celebration of the birth of Jesus Christ'],
+                ['date' => '12-26', 'name' => 'Boxing Day', 'description' => 'Second day of Christmas'],
+            ],
+        ],
+        'FR' => [
+            'name' => 'France',
+            'holidays' => [
+                ['date' => '01-01', 'name' => 'New Year\'s Day', 'description' => 'First day of the year'],
+                ['date' => '05-01', 'name' => 'Labour Day', 'description' => 'International Workers\' Day'],
+                ['date' => '05-08', 'name' => 'Victory in Europe Day', 'description' => 'End of World War II in Europe'],
+                ['date' => '07-14', 'name' => 'Bastille Day', 'description' => 'French National Day'],
+                ['date' => '11-11', 'name' => 'Armistice Day', 'description' => 'End of World War I'],
+                ['date' => '12-25', 'name' => 'Christmas Day', 'description' => 'Christian celebration of the birth of Jesus Christ'],
+            ],
+        ],
+        'CA' => [
+            'name' => 'Canada',
+            'holidays' => [
+                ['date' => '01-01', 'name' => 'New Year\'s Day', 'description' => 'First day of the year'],
+                ['date' => '07-01', 'name' => 'Canada Day', 'description' => 'Canadian National Day'],
+                ['date' => '12-25', 'name' => 'Christmas Day', 'description' => 'Christian celebration of the birth of Jesus Christ'],
+                ['date' => '12-26', 'name' => 'Boxing Day', 'description' => 'Day after Christmas'],
+            ],
+        ],
+        'AU' => [
+            'name' => 'Australia',
+            'holidays' => [
+                ['date' => '01-01', 'name' => 'New Year\'s Day', 'description' => 'First day of the year'],
+                ['date' => '01-26', 'name' => 'Australia Day', 'description' => 'National day of Australia'],
+                ['date' => '04-25', 'name' => 'ANZAC Day', 'description' => 'Remembrance day for Australian and New Zealand Army Corps'],
+                ['date' => '12-25', 'name' => 'Christmas Day', 'description' => 'Christian celebration of the birth of Jesus Christ'],
+                ['date' => '12-26', 'name' => 'Boxing Day', 'description' => 'Day after Christmas'],
+            ],
+        ],
+        'RS' => [
+            'name' => 'Serbia',
+            'holidays' => [
+                ['date' => '01-01', 'name' => 'New Year\'s Day', 'description' => 'First day of the year'],
+                ['date' => '01-07', 'name' => 'Orthodox Christmas', 'description' => 'Orthodox Christian Christmas'],
+                ['date' => '02-15', 'name' => 'Statehood Day', 'description' => 'Serbian Statehood Day'],
+                ['date' => '05-01', 'name' => 'Labour Day', 'description' => 'International Workers\' Day'],
+                ['date' => '11-11', 'name' => 'Armistice Day', 'description' => 'End of World War I'],
+            ],
+        ],
+        'BG' => [
+            'name' => 'Bulgaria',
+            'holidays' => [
+                ['date' => '01-01', 'name' => 'New Year\'s Day', 'description' => 'First day of the year'],
+                ['date' => '03-03', 'name' => 'Liberation Day', 'description' => 'National Day of Bulgaria'],
+                ['date' => '05-01', 'name' => 'Labour Day', 'description' => 'International Workers\' Day'],
+                ['date' => '05-06', 'name' => 'St. George\'s Day', 'description' => 'Day of the Bulgarian Army'],
+                ['date' => '05-24', 'name' => 'Bulgarian Education and Culture Day', 'description' => 'Day of Slavonic Alphabet, Bulgarian Education and Culture'],
+                ['date' => '09-06', 'name' => 'Unification Day', 'description' => 'Unification of Bulgaria'],
+                ['date' => '09-22', 'name' => 'Independence Day', 'description' => 'Bulgarian Independence Day'],
+            ],
+        ],
+    ],
+];

--- a/database/factories/TenantFactory.php
+++ b/database/factories/TenantFactory.php
@@ -21,6 +21,7 @@ class TenantFactory extends Factory
             'name' => fake()->company(),
             'slug' => fake()->unique()->slug(),
             'default_currency' => fake()->randomElement(['MKD', 'USD', 'EUR', 'GBP']),
+            'default_country' => fake()->randomElement(['MK', 'US', 'GB', 'DE', 'FR', 'CA', 'AU', 'RS', 'BG']),
             'owner_id' => User::factory(),
         ];
     }

--- a/database/migrations/2026_01_21_220000_add_default_country_to_tenants_table.php
+++ b/database/migrations/2026_01_21_220000_add_default_country_to_tenants_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('tenants', function (Blueprint $table) {
+            $table->string('default_country', 2)->nullable()->after('default_currency');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('tenants', function (Blueprint $table) {
+            $table->dropColumn('default_country');
+        });
+    }
+};

--- a/database/migrations/2026_01_21_220001_add_tenant_id_and_country_to_holidays_table.php
+++ b/database/migrations/2026_01_21_220001_add_tenant_id_and_country_to_holidays_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('holidays', function (Blueprint $table) {
+            $table->foreignId('tenant_id')->nullable()->after('id')->constrained()->onDelete('cascade');
+            $table->string('country', 2)->nullable()->after('tenant_id');
+            $table->index('country');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('holidays', function (Blueprint $table) {
+            $table->dropForeign(['tenant_id']);
+            $table->dropColumn(['tenant_id', 'country']);
+        });
+    }
+};


### PR DESCRIPTION
This commit implements a comprehensive country selection feature that allows
each tenant to select a default country, which is then used to dynamically
display holidays specific to that country.

Changes:
- Add default_country column to tenants table (ISO 3166-1 alpha-2 format)
- Add tenant_id and country columns to holidays table for tenant-specific holidays
- Update Tenant model to include default_country in fillable fields
- Update Holiday model to be tenant-scoped using BelongsToTenant trait
- Create CountryHolidayService for managing country-specific holidays
- Create countries configuration file with 9 countries and their national holidays
  (North Macedonia, USA, UK, Germany, France, Canada, Australia, Serbia, Bulgaria)
- Update HolidayController to use tenant's default country for filtering holidays
- Update TenantFactory to include default_country field
- Holidays are automatically synced from config when accessed for the first time

This feature enables multi-tenant applications to show relevant holidays
based on each organization's geographic location.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dynamic holiday management: holidays are now synchronized from configuration instead of being hardcoded, enabling flexibility and updates without code changes.
  * Multi-country support: added holidays for 9 countries, with the ability to display country-specific holidays based on tenant preferences.
  * Tenant country configuration: tenants can now set a default country to customize which holidays are displayed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->