### PR TITLE
Fix queue jobs to bypass TenantScope in multi-tenant context

### DIFF
--- a/app/Jobs/SendUtilityBillDueNotifications.php
+++ b/app/Jobs/SendUtilityBillDueNotifications.php
@@ -4,6 +4,7 @@ namespace App\Jobs;
 
 use App\Events\UtilityBillDueSoon;
 use App\Models\UtilityBill;
+use App\Scopes\TenantScope;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
@@ -53,7 +54,9 @@ class SendUtilityBillDueNotifications implements ShouldQueue
         $targetDate = now()->addDays($days)->toDateString();
         $today = now()->toDateString();
 
-        $query = UtilityBill::with('user')
+        // Note: withoutGlobalScope is needed because this job runs in queue context without auth
+        $query = UtilityBill::withoutGlobalScope(TenantScope::class)
+            ->with('user')
             ->where('payment_status', 'pending');
 
         if ($days === 0) {

--- a/app/Jobs/SendWarrantyExpirationNotifications.php
+++ b/app/Jobs/SendWarrantyExpirationNotifications.php
@@ -4,6 +4,7 @@ namespace App\Jobs;
 
 use App\Events\WarrantyExpirationDue;
 use App\Models\Warranty;
+use App\Scopes\TenantScope;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
@@ -53,7 +54,9 @@ class SendWarrantyExpirationNotifications implements ShouldQueue
         $targetDate = now()->addDays($days)->toDateString();
         $today = now()->toDateString();
 
-        $query = Warranty::with('user')
+        // Note: withoutGlobalScope is needed because this job runs in queue context without auth
+        $query = Warranty::withoutGlobalScope(TenantScope::class)
+            ->with('user')
             ->where('current_status', 'active');
 
         if ($days === 0) {


### PR DESCRIPTION
## Summary

This PR fixes queue jobs that were failing in multi-tenant environments by bypassing the `TenantScope` global scope. Queue jobs run without an authenticated user context, causing tenant scope filters to prevent access to necessary data.

## Problem

Queue jobs (`SendContractExpirationNotifications`, `SendCycleMenuDailyNotifications`, `SendSubscriptionRenewalNotifications`, `SendUtilityBillDueNotifications`, `SendWarrantyExpirationNotifications`) were unable to access data because:

1. Global `TenantScope` automatically filters queries to the current tenant
2. Queue jobs have no authenticated user context
3. This caused queries to return empty results or fail silently

## Solution

Added `withoutGlobalScope(TenantScope::class)` to all model queries in queue jobs with explanatory comments. This allows jobs to access all tenant data while still maintaining security through proper event dispatching to authenticated users.

## Changes Made

### Queue Jobs Modified (5 files)
- **SendContractExpirationNotifications.php**: Bypass scope on Contract queries (2 locations)
- **SendCycleMenuDailyNotifications.php**: Bypass scope on CycleMenu and CycleMenuDay queries; refactored to notify only tenant members
- **SendSubscriptionRenewalNotifications.php**: Bypass scope on Subscription queries (3 locations)
- **SendUtilityBillDueNotifications.php**: Bypass scope on UtilityBill queries
- **SendWarrantyExpirationNotifications.php**: Bypass scope on Warranty queries

### Key Improvements in SendCycleMenuDailyNotifications
- Changed from notifying all users to only notifying tenant members
- Eager load `tenant.members` relationship
- Filter notifications per menu's tenant
- Improved logging with user count

### Tests Updated (2 files)
- **CycleMenuNotifyCommandTest.php**: 
  - Added tenant context setup with `setupTenantContext()`
  - Updated all factories to include `tenant_id`
  - Added test for tenant isolation (`test_notifications_only_sent_to_tenant_members`)
  - Verified only tenant members receive notifications

- **NotificationControllerTest.php**:
  - Updated to use `setupTenantContext()`
  - Added `tenant_id` to subscription factory calls
  - Fixed test for cross-tenant isolation

## Technical Details

### Pattern Used
```php
// Before
$query = Model::with('relationship')->where(...);

// After
$query = Model::withoutGlobalScope(TenantScope::class)
    ->with('relationship')
    ->where(...);
```

### Security Maintained
- Jobs still respect user authorization when dispatching events
- Notifications only sent to appropriate users
- Tenant isolation enforced at notification level
- No data leakage between tenants

## Testing

All tests updated to:
- Use proper tenant context setup
- Create resources with correct `tenant_id`
- Verify tenant isolation
- Test multi-tenant scenarios

## Files Changed
- 5 queue job files
- 2 test files
- All changes maintain backward compatibility

## Notes

- Added inline comments explaining why `withoutGlobalScope` is needed
- No breaking changes to existing functionality
- Improves reliability of scheduled notification jobs in multi-tenant deployments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed notification delivery for contracts, cycle menus, subscriptions, utility bills, and warranties in background job processing to work correctly in multi-tenant environments.
  * Improved tenant isolation to ensure notifications are only sent to intended recipients.

* **Tests**
  * Enhanced test coverage for multi-tenant notification scenarios and cross-tenant isolation.
  * Improved test reliability for background notification jobs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->