### PR TITLE
Upgrade PHP to 8.5 across Docker and CI

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.4'
+          php-version: '8.5'
           extensions: mbstring, intl, pdo_mysql, pcntl, bcmath
           coverage: none
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 
 # Learn more about the Server Side Up PHP Docker Images at:
 # https://serversideup.net/open-source/docker-php/
-FROM serversideup/php:8.4-fpm-nginx-alpine AS base
+FROM serversideup/php:8.5-fpm-nginx-alpine AS base
 
 ## Uncomment if you need to install additional PHP extensions
 USER root
@@ -34,7 +34,7 @@ USER www-data
 ############################################
 # Development Image
 ############################################
-FROM serversideup/php:8.4-cli AS development-cli
+FROM serversideup/php:8.5-cli AS development-cli
 
 # Switch to root so we can set the user ID and group ID
 USER root

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "keywords": ["laravel", "framework"],
     "license": "MIT",
     "require": {
-        "php": "^8.4",
+        "php": "^8.5",
         "barryvdh/laravel-dompdf": "^3.1",
         "google/apiclient": "^2.19",
         "laravel/framework": "^13.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b34b971e1ca51fa3cb0466831b48b7c3",
+    "content-hash": "c0a58c1038f6cee5ad233f4db747fe29",
     "packages": [
         {
             "name": "barryvdh/laravel-dompdf",
@@ -9991,7 +9991,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.4"
+        "php": "^8.5"
     },
     "platform-dev": {},
     "plugin-api-version": "2.9.0"


### PR DESCRIPTION
## Summary
- Update Dockerfile base images from PHP 8.4 to 8.5 (fpm-nginx-alpine and cli)
- Update CI workflow PHP version from 8.4 to 8.5
- Update composer.json minimum PHP requirement from ^8.4 to ^8.5
- Matches production environment which already runs PHP 8.5

## Test plan
- [x] All 659 tests pass locally on PHP 8.5
- [ ] CI passes with PHP 8.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application's PHP version requirement to 8.5, including CI/CD pipelines and containerized environment configurations to support the latest PHP version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->