### PR TITLE
feat: set up React 19, Inertia v3, TypeScript, shadcn/ui infrastructure

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.4'
+          php-version: '8.5'
           extensions: mbstring, intl, pdo_mysql, pcntl, bcmath
           coverage: none
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 
 # Learn more about the Server Side Up PHP Docker Images at:
 # https://serversideup.net/open-source/docker-php/
-FROM serversideup/php:8.4-fpm-nginx-alpine AS base
+FROM serversideup/php:8.5-fpm-nginx-alpine AS base
 
 ## Uncomment if you need to install additional PHP extensions
 USER root
@@ -34,7 +34,7 @@ USER www-data
 ############################################
 # Development Image
 ############################################
-FROM serversideup/php:8.4-cli AS development-cli
+FROM serversideup/php:8.5-cli AS development-cli
 
 # Switch to root so we can set the user ID and group ID
 USER root

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "keywords": ["laravel", "framework"],
     "license": "MIT",
     "require": {
-        "php": "^8.4",
+        "php": "^8.5",
         "barryvdh/laravel-dompdf": "^3.1",
         "google/apiclient": "^2.19",
         "laravel/framework": "^13.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b34b971e1ca51fa3cb0466831b48b7c3",
+    "content-hash": "c0a58c1038f6cee5ad233f4db747fe29",
     "packages": [
         {
             "name": "barryvdh/laravel-dompdf",
@@ -9991,7 +9991,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.4"
+        "php": "^8.5"
     },
     "platform-dev": {},
     "plugin-api-version": "2.9.0"


### PR DESCRIPTION
- Install React 19, Inertia v3 (Laravel + React adapters), TypeScript 6, Vite 8
- Add shadcn/ui dependencies (Radix, lucide-react, tailwind-merge, CVA)
- Add Recharts, TanStack Table, dnd-kit, next-themes, sonner
- Configure TypeScript with strict mode and @/* path alias
- Rewrite Vite config for React + TypeScript entry point
- Add shadcn/ui CSS variables (light + dark) mapped to LifeOS design tokens
- Create HandleInertiaRequests middleware with shared auth/tenant/flash data
- Create Inertia root Blade template (app.blade.php)
- Create React entry point (app.tsx) with ThemeProvider and Toaster
- Set up directory structure for components, pages, types, hooks

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>