### PR TITLE
feat: add subscriptions CSV import

### DIFF
--- a/app/Http/Controllers/SubscriptionController.php
+++ b/app/Http/Controllers/SubscriptionController.php
@@ -2,11 +2,15 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Requests\ImportSubscriptionCsvRequest;
 use App\Http\Requests\StoreSubscriptionRequest;
 use App\Http\Requests\UpdateSubscriptionRequest;
+use App\Jobs\ImportSubscriptionsCsv;
 use App\Models\Subscription;
 use App\Services\CurrencyService;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
 use Inertia\Inertia;
 
 class SubscriptionController extends Controller
@@ -346,5 +350,44 @@ class SubscriptionController extends Controller
         })->values(); // Convert to indexed array for JSON
 
         return response()->json(['data' => $data]);
+    }
+
+    /**
+     * Show the import CSV form page.
+     */
+    public function importForm()
+    {
+        return Inertia::render('Subscriptions/Import');
+    }
+
+    /**
+     * Queue an import of subscriptions from an uploaded CSV.
+     */
+    public function importCsv(ImportSubscriptionCsvRequest $request)
+    {
+        $userId = auth()->id();
+        $tenantId = auth()->user()->current_tenant_id;
+        $file = $request->file('file');
+
+        $storedPath = $file->storeAs('imports/'.$userId, uniqid('subscriptions_').'.csv');
+
+        ImportSubscriptionsCsv::dispatch($userId, $tenantId, $storedPath)->onQueue('imports');
+
+        if ($request->expectsJson()) {
+            return new JsonResponse(['status' => 'queued']);
+        }
+
+        return redirect()->route('subscriptions.index')
+            ->with('success', 'Your CSV import has been queued and will be processed shortly.');
+    }
+
+    /**
+     * Return the current import progress for the authenticated user.
+     */
+    public function importProgress(): JsonResponse
+    {
+        $progress = Cache::get('subscription_import_progress:'.auth()->id());
+
+        return new JsonResponse($progress ?? ['status' => 'idle']);
     }
 }

--- a/app/Http/Requests/ImportSubscriptionCsvRequest.php
+++ b/app/Http/Requests/ImportSubscriptionCsvRequest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ImportSubscriptionCsvRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, array<int, string>>
+     */
+    public function rules(): array
+    {
+        return [
+            'file' => ['required', 'file', 'mimes:csv,txt', 'max:10240'],
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'file.required' => 'Please upload a CSV file to import.',
+            'file.mimes' => 'The import file must be a CSV (or TXT) file.',
+            'file.max' => 'The CSV file may not be greater than 10MB.',
+        ];
+    }
+}

--- a/app/Jobs/ImportSubscriptionsCsv.php
+++ b/app/Jobs/ImportSubscriptionsCsv.php
@@ -1,0 +1,342 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Jobs;
+
+use App\Models\Subscription;
+use App\Scopes\TenantScope;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
+
+class ImportSubscriptionsCsv implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public int $timeout = 300;
+
+    public int $tries = 3;
+
+    private const HEADER_ALIASES = [
+        'service_name' => ['name', 'service', 'subscription', 'subscription_name'],
+        'cost' => ['price', 'amount', 'total'],
+        'billing_cycle' => ['cycle', 'frequency', 'billing_frequency', 'billing cycle'],
+        'next_billing_date' => ['next_date', 'renewal_date', 'next billing date', 'next_renewal'],
+        'currency' => ['currency_code'],
+        'category' => ['type', 'subscription_category'],
+        'status' => ['state', 'subscription_status'],
+        'auto_renewal' => ['auto_renew', 'auto renewal', 'renews_automatically'],
+        'payment_method' => ['payment', 'method', 'payment method', 'payment_type'],
+        'start_date' => ['started', 'start date', 'subscription_start'],
+        'description' => ['desc', 'memo'],
+        'notes' => ['comment', 'comments', 'additional_notes'],
+        'tags' => ['labels'],
+        'url' => ['link', 'website'],
+    ];
+
+    public function __construct(
+        public int $userId,
+        public int $tenantId,
+        public string $storedPath,
+    ) {}
+
+    public function handle(): void
+    {
+        if (! Storage::exists($this->storedPath)) {
+            Log::error('ImportSubscriptionsCsv: CSV file does not exist', [
+                'user_id' => $this->userId,
+                'path' => $this->storedPath,
+            ]);
+
+            return;
+        }
+
+        $content = Storage::get($this->storedPath);
+        $lines = array_values(array_filter(explode("\n", $content), fn ($line) => trim($line) !== ''));
+
+        if (empty($lines)) {
+            Log::warning('ImportSubscriptionsCsv: Empty CSV file', [
+                'user_id' => $this->userId,
+                'path' => $this->storedPath,
+            ]);
+
+            return;
+        }
+
+        $header = str_getcsv(array_shift($lines));
+        if (! $header) {
+            Log::warning('ImportSubscriptionsCsv: Empty CSV header', [
+                'user_id' => $this->userId,
+                'path' => $this->storedPath,
+            ]);
+
+            return;
+        }
+
+        $index = $this->buildHeaderIndex($header);
+
+        $totalRows = count($lines);
+        $created = 0;
+        $skipped = 0;
+        $failed = 0;
+        $cacheKey = 'subscription_import_progress:'.$this->userId;
+
+        $this->updateProgress($cacheKey, 'processing', $totalRows, $created, $skipped, $failed);
+
+        foreach ($lines as $line) {
+            $row = str_getcsv($line);
+
+            if (count(array_filter($row, fn ($v) => $v !== null && $v !== '')) === 0) {
+                continue;
+            }
+
+            try {
+                $serviceName = (string) $this->getValue($row, $index, 'service_name');
+                $cost = (string) $this->getValue($row, $index, 'cost');
+                $billingCycle = (string) $this->getValue($row, $index, 'billing_cycle');
+                $nextBillingDate = (string) $this->getValue($row, $index, 'next_billing_date');
+
+                if (! $serviceName || ! $cost || ! $billingCycle || ! $nextBillingDate) {
+                    $skipped++;
+                    $this->updateProgress($cacheKey, 'processing', $totalRows, $created, $skipped, $failed);
+                    Log::warning('ImportSubscriptionsCsv: skipped row due to missing required fields', [
+                        'service_name' => $serviceName,
+                        'cost' => $cost,
+                        'billing_cycle' => $billingCycle,
+                        'next_billing_date' => $nextBillingDate,
+                    ]);
+
+                    continue;
+                }
+
+                $parsedCost = $this->parseDecimal($cost);
+                $parsedNextBillingDate = $this->parseDate($nextBillingDate);
+                $uniqueKey = 'csv-import:'.md5($serviceName.$cost.$billingCycle.$nextBillingDate);
+
+                $exists = Subscription::withoutGlobalScope(TenantScope::class)
+                    ->where('user_id', $this->userId)
+                    ->where(function ($query) use ($uniqueKey, $serviceName, $parsedCost, $billingCycle, $parsedNextBillingDate) {
+                        $query->where('unique_key', $uniqueKey)
+                            ->orWhere(function ($query) use ($serviceName, $parsedCost, $billingCycle, $parsedNextBillingDate) {
+                                $query->where('service_name', $serviceName)
+                                    ->where('cost', round($parsedCost, 2))
+                                    ->where('billing_cycle', strtolower($billingCycle))
+                                    ->whereDate('next_billing_date', $parsedNextBillingDate);
+                            });
+                    })
+                    ->exists();
+
+                if ($exists) {
+                    $skipped++;
+                    $this->updateProgress($cacheKey, 'processing', $totalRows, $created, $skipped, $failed);
+
+                    continue;
+                }
+
+                $currency = $this->normalizeCurrency((string) $this->getValue($row, $index, 'currency', 'MKD'));
+                $category = (string) $this->getValue($row, $index, 'category', 'Other');
+                $status = strtolower((string) $this->getValue($row, $index, 'status', 'active'));
+                $autoRenewal = $this->parseBoolean((string) $this->getValue($row, $index, 'auto_renewal', 'true'));
+                $paymentMethod = (string) $this->getValue($row, $index, 'payment_method', '');
+                $startDateRaw = (string) $this->getValue($row, $index, 'start_date', '');
+                $description = (string) $this->getValue($row, $index, 'description', '');
+                $notes = (string) $this->getValue($row, $index, 'notes', '');
+                $tagsRaw = (string) $this->getValue($row, $index, 'tags', '');
+                $url = (string) $this->getValue($row, $index, 'url', '');
+
+                if (! in_array($status, ['active', 'cancelled', 'paused'], true)) {
+                    $status = 'active';
+                }
+
+                $normalizedBillingCycle = strtolower($billingCycle);
+                if (! in_array($normalizedBillingCycle, ['monthly', 'yearly', 'weekly', 'custom'], true)) {
+                    $normalizedBillingCycle = 'monthly';
+                }
+
+                $tags = $tagsRaw !== ''
+                    ? array_map('trim', explode(',', $tagsRaw))
+                    : null;
+
+                $startDate = $startDateRaw !== '' ? $this->parseDate($startDateRaw) : $parsedNextBillingDate;
+
+                $subscription = new Subscription([
+                    'tenant_id' => $this->tenantId,
+                    'user_id' => $this->userId,
+                    'service_name' => $serviceName,
+                    'description' => $description ?: null,
+                    'category' => $category,
+                    'cost' => $parsedCost,
+                    'billing_cycle' => $normalizedBillingCycle,
+                    'currency' => $currency,
+                    'start_date' => $startDate,
+                    'next_billing_date' => $parsedNextBillingDate,
+                    'payment_method' => $paymentMethod ?: null,
+                    'merchant_info' => $url ?: null,
+                    'auto_renewal' => $autoRenewal,
+                    'notes' => $notes ?: null,
+                    'tags' => $tags,
+                    'status' => $status,
+                    'unique_key' => $uniqueKey,
+                ]);
+                $subscription->save();
+
+                $created++;
+                $this->updateProgress($cacheKey, 'processing', $totalRows, $created, $skipped, $failed);
+            } catch (\Throwable $e) {
+                $failed++;
+                $this->updateProgress($cacheKey, 'processing', $totalRows, $created, $skipped, $failed);
+                Log::error('ImportSubscriptionsCsv: row import failed', [
+                    'message' => $e->getMessage(),
+                    'trace' => $e->getTraceAsString(),
+                ]);
+            }
+        }
+
+        try {
+            Storage::delete($this->storedPath);
+        } catch (\Throwable $e) {
+            // Ignore cleanup errors
+        }
+
+        $this->updateProgress($cacheKey, 'completed', $totalRows, $created, $skipped, $failed);
+
+        Log::info('ImportSubscriptionsCsv: import finished', [
+            'user_id' => $this->userId,
+            'created' => $created,
+            'skipped' => $skipped,
+            'failed' => $failed,
+        ]);
+    }
+
+    /**
+     * @param  array<int, string>  $header
+     * @return array<string, int>
+     */
+    private function buildHeaderIndex(array $header): array
+    {
+        $index = [];
+        foreach ($header as $i => $col) {
+            $normalized = strtolower(trim((string) $col));
+            $index[$normalized] = $i;
+        }
+
+        return $index;
+    }
+
+    /**
+     * @param  array<int, string|null>  $row
+     * @param  array<string, int>  $index
+     */
+    private function getValue(array $row, array $index, string $name, mixed $default = null): mixed
+    {
+        foreach ([$name, trim($name), strtolower($name)] as $key) {
+            if (array_key_exists($key, $index)) {
+                $pos = $index[$key];
+
+                return isset($row[$pos]) ? trim((string) $row[$pos]) : $default;
+            }
+        }
+
+        foreach ((self::HEADER_ALIASES[$name] ?? []) as $alias) {
+            $alias = strtolower($alias);
+            if (array_key_exists($alias, $index)) {
+                $pos = $index[$alias];
+
+                return isset($row[$pos]) ? trim((string) $row[$pos]) : $default;
+            }
+        }
+
+        return $default;
+    }
+
+    private function parseDecimal(?string $value): float
+    {
+        if ($value === null) {
+            return 0.0;
+        }
+
+        $v = trim($value);
+        if ($v === '') {
+            return 0.0;
+        }
+
+        $negative = false;
+        if (str_starts_with($v, '(') && str_ends_with($v, ')')) {
+            $negative = true;
+            $v = substr($v, 1, -1);
+        }
+        $v = str_replace([',', ' '], ['', ''], $v);
+
+        $num = (float) $v;
+
+        return $negative ? -$num : $num;
+    }
+
+    private function normalizeCurrency(?string $code): string
+    {
+        $code = strtoupper(substr((string) ($code ?: 'MKD'), 0, 3));
+
+        return $code ?: 'MKD';
+    }
+
+    private function parseDate(?string $value): string
+    {
+        if ($value) {
+            try {
+                return Carbon::parse($value)->toDateString();
+            } catch (\Throwable $e) {
+                // fall back below
+            }
+
+            $timestamp = strtotime($value);
+            if ($timestamp !== false) {
+                return date('Y-m-d', $timestamp);
+            }
+        }
+
+        return now()->toDateString();
+    }
+
+    private function parseBoolean(?string $value): bool
+    {
+        if ($value === null) {
+            return false;
+        }
+
+        return in_array(strtolower(trim($value)), ['true', '1', 'yes'], true);
+    }
+
+    private function updateProgress(string $cacheKey, string $status, int $total, int $created, int $skipped, int $failed): void
+    {
+        Cache::put($cacheKey, [
+            'status' => $status,
+            'total' => $total,
+            'created' => $created,
+            'skipped' => $skipped,
+            'failed' => $failed,
+        ], 300);
+    }
+
+    public function failed(\Throwable $exception): void
+    {
+        Cache::put('subscription_import_progress:'.$this->userId, [
+            'status' => 'failed',
+            'total' => 0,
+            'created' => 0,
+            'skipped' => 0,
+            'failed' => 0,
+            'error' => $exception->getMessage(),
+        ], 300);
+
+        Log::error('ImportSubscriptionsCsv failed', [
+            'exception' => $exception->getMessage(),
+        ]);
+    }
+}

--- a/app/Models/Subscription.php
+++ b/app/Models/Subscription.php
@@ -3,13 +3,14 @@
 namespace App\Models;
 
 use App\Traits\BelongsToTenant;
+use Database\Factories\SubscriptionFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class Subscription extends Model
 {
-    /** @use HasFactory<\Database\Factories\SubscriptionFactory> */
+    /** @use HasFactory<SubscriptionFactory> */
     use BelongsToTenant, HasFactory;
 
     protected $fillable = [
@@ -33,6 +34,7 @@ class Subscription extends Model
         'notes',
         'tags',
         'status',
+        'unique_key',
     ];
 
     protected function casts(): array

--- a/database/migrations/2026_03_30_152110_add_unique_key_to_subscriptions_table.php
+++ b/database/migrations/2026_03_30_152110_add_unique_key_to_subscriptions_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('subscriptions', function (Blueprint $table) {
+            $table->string('unique_key')->nullable()->unique()->after('status');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('subscriptions', function (Blueprint $table) {
+            $table->dropColumn('unique_key');
+        });
+    }
+};

--- a/resources/js/pages/Subscriptions/Import.tsx
+++ b/resources/js/pages/Subscriptions/Import.tsx
@@ -1,0 +1,301 @@
+import { Head, Link, router } from '@inertiajs/react'
+import { useState, useEffect, useRef, useCallback, type FormEvent, type ChangeEvent } from 'react'
+import AppLayout from '@/components/shared/app-layout'
+import { PageHeader } from '@/components/shared/page-header'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Progress } from '@/components/ui/progress'
+import { Upload, CheckCircle2, AlertCircle, Loader2 } from 'lucide-react'
+
+type ImportStage = 'idle' | 'uploading' | 'processing' | 'completed' | 'failed'
+
+interface ImportProgress {
+    status: 'idle' | 'processing' | 'completed' | 'failed'
+    total: number
+    created: number
+    skipped: number
+    failed: number
+    error?: string
+}
+
+export default function SubscriptionImport() {
+    const [file, setFile] = useState<File | null>(null)
+    const [stage, setStage] = useState<ImportStage>('idle')
+    const [uploadProgress, setUploadProgress] = useState(0)
+    const [importProgress, setImportProgress] = useState<ImportProgress | null>(null)
+    const [fileError, setFileError] = useState<string | null>(null)
+    const pollingRef = useRef<ReturnType<typeof setInterval> | null>(null)
+
+    const stopPolling = useCallback(() => {
+        if (pollingRef.current) {
+            clearInterval(pollingRef.current)
+            pollingRef.current = null
+        }
+    }, [])
+
+    const pollProgress = useCallback(() => {
+        pollingRef.current = setInterval(async () => {
+            try {
+                const response = await fetch('/subscriptions/import/progress')
+                const data: ImportProgress = await response.json()
+
+                if (data.status === 'processing' || data.status === 'completed' || data.status === 'failed') {
+                    setImportProgress(data)
+                }
+
+                if (data.status === 'completed') {
+                    setStage('completed')
+                    stopPolling()
+                } else if (data.status === 'failed') {
+                    setStage('failed')
+                    stopPolling()
+                }
+            } catch {
+                // Ignore transient fetch errors, retry on next tick
+            }
+        }, 2000)
+    }, [stopPolling])
+
+    useEffect(() => {
+        return () => stopPolling()
+    }, [stopPolling])
+
+    function handleFileChange(e: ChangeEvent<HTMLInputElement>) {
+        setFile(e.target.files?.[0] ?? null)
+        setFileError(null)
+    }
+
+    function handleSubmit(e: FormEvent) {
+        e.preventDefault()
+        if (!file) return
+
+        setStage('uploading')
+        setFileError(null)
+
+        const formData = new FormData()
+        formData.append('file', file)
+
+        const xsrfToken = decodeURIComponent(
+            document.cookie.split('; ').find(row => row.startsWith('XSRF-TOKEN='))?.split('=')[1] ?? ''
+        )
+
+        const xhr = new XMLHttpRequest()
+        xhr.open('POST', '/subscriptions/import')
+        xhr.setRequestHeader('X-XSRF-TOKEN', xsrfToken)
+        xhr.setRequestHeader('Accept', 'application/json')
+        xhr.setRequestHeader('X-Requested-With', 'XMLHttpRequest')
+
+        xhr.upload.onprogress = (event) => {
+            if (event.lengthComputable) {
+                setUploadProgress(Math.round((event.loaded / event.total) * 100))
+            }
+        }
+
+        xhr.onload = () => {
+            if (xhr.status >= 200 && xhr.status < 300) {
+                setStage('processing')
+                setUploadProgress(100)
+                pollProgress()
+            } else {
+                setStage('idle')
+                try {
+                    const errorData = JSON.parse(xhr.responseText)
+                    setFileError(errorData.errors?.file?.[0] ?? errorData.message ?? 'Upload failed.')
+                } catch {
+                    setFileError('Upload failed. Please try again.')
+                }
+            }
+        }
+
+        xhr.onerror = () => {
+            setStage('idle')
+            setFileError('Network error. Please try again.')
+        }
+
+        xhr.send(formData)
+    }
+
+    const processed = importProgress
+        ? importProgress.created + importProgress.skipped + importProgress.failed
+        : 0
+    const progressPercent = importProgress && importProgress.total > 0
+        ? Math.round((processed / importProgress.total) * 100)
+        : 0
+
+    return (
+        <AppLayout>
+            <Head title="Import Subscriptions" />
+
+            <PageHeader title="Import Subscriptions" description="Upload a CSV file to bulk import subscriptions">
+                <Button variant="outline" asChild>
+                    <Link href="/subscriptions">Back to List</Link>
+                </Button>
+            </PageHeader>
+
+            <Card className="mx-auto max-w-2xl">
+                <CardHeader>
+                    <CardTitle>CSV Import</CardTitle>
+                </CardHeader>
+                <CardContent>
+                    {stage === 'idle' || stage === 'uploading' ? (
+                        <form onSubmit={handleSubmit} className="space-y-6">
+                            <div className="space-y-2">
+                                <Label htmlFor="file">CSV File</Label>
+                                <div className="flex items-center gap-4">
+                                    <Input
+                                        id="file"
+                                        type="file"
+                                        accept=".csv"
+                                        onChange={handleFileChange}
+                                        className="flex-1"
+                                        disabled={stage === 'uploading'}
+                                    />
+                                </div>
+                                {fileError ? (
+                                    <p className="text-sm text-destructive">{fileError}</p>
+                                ) : null}
+                                {stage === 'uploading' ? (
+                                    <div className="mt-2">
+                                        <Progress value={uploadProgress} />
+                                        <p className="mt-1 text-xs text-muted-foreground">{uploadProgress}% uploaded</p>
+                                    </div>
+                                ) : null}
+                            </div>
+
+                            <div className="rounded-md border border-border bg-muted p-4">
+                                <h3 className="mb-2 text-sm font-medium">Expected CSV Format</h3>
+                                <p className="text-xs text-muted-foreground">
+                                    Your CSV file should include the following columns. Required columns are marked with *.
+                                </p>
+                                <div className="mt-2 space-y-1">
+                                    <code className="block text-xs text-muted-foreground">
+                                        service_name*, cost*, billing_cycle*, next_billing_date*
+                                    </code>
+                                    <code className="block text-xs text-muted-foreground">
+                                        currency, category, status, auto_renewal, payment_method,
+                                    </code>
+                                    <code className="block text-xs text-muted-foreground">
+                                        start_date, description, notes, tags, url
+                                    </code>
+                                </div>
+                                <p className="mt-3 text-xs text-muted-foreground">
+                                    <strong>Example row:</strong>
+                                </p>
+                                <code className="mt-1 block text-xs text-muted-foreground">
+                                    Netflix,15.99,monthly,2026-04-15,USD,Entertainment,active,true,Credit Card,2024-01-01,Premium plan,,&quot;streaming,entertainment&quot;,https://netflix.com
+                                </code>
+                            </div>
+
+                            <div className="flex justify-end gap-3">
+                                <Button type="button" variant="outline" asChild>
+                                    <Link href="/subscriptions">Cancel</Link>
+                                </Button>
+                                <Button type="submit" disabled={stage === 'uploading' || !file}>
+                                    <Upload className="mr-2 h-4 w-4" />
+                                    {stage === 'uploading' ? 'Uploading...' : 'Import CSV'}
+                                </Button>
+                            </div>
+                        </form>
+                    ) : null}
+
+                    {stage === 'processing' ? (
+                        <div className="space-y-6">
+                            <div className="flex items-center gap-3">
+                                <Loader2 className="h-5 w-5 animate-spin text-primary" />
+                                <p className="text-sm font-medium">
+                                    {importProgress ? 'Processing your import...' : 'Waiting for import to start...'}
+                                </p>
+                            </div>
+
+                            {importProgress ? (
+                                <>
+                                    <Progress value={progressPercent} />
+
+                                    <div className="grid grid-cols-3 gap-4 text-center">
+                                        <div>
+                                            <p className="text-2xl font-bold text-primary">{importProgress.created}</p>
+                                            <p className="text-xs text-muted-foreground">Created</p>
+                                        </div>
+                                        <div>
+                                            <p className="text-2xl font-bold text-muted-foreground">{importProgress.skipped}</p>
+                                            <p className="text-xs text-muted-foreground">Skipped</p>
+                                        </div>
+                                        <div>
+                                            <p className="text-2xl font-bold text-destructive">{importProgress.failed}</p>
+                                            <p className="text-xs text-muted-foreground">Failed</p>
+                                        </div>
+                                    </div>
+
+                                    <p className="text-xs text-muted-foreground text-center">
+                                        {processed} of {importProgress.total} rows processed ({progressPercent}%)
+                                    </p>
+                                </>
+                            ) : (
+                                <p className="text-xs text-muted-foreground text-center">
+                                    Your import has been queued. Make sure the queue worker is running.
+                                </p>
+                            )}
+                        </div>
+                    ) : null}
+
+                    {stage === 'completed' ? (
+                        <div className="space-y-6">
+                            <div className="flex items-center gap-3">
+                                <CheckCircle2 className="h-5 w-5 text-green-600" />
+                                <p className="text-sm font-medium">Import completed!</p>
+                            </div>
+
+                            <div className="grid grid-cols-3 gap-4 text-center">
+                                <div>
+                                    <p className="text-2xl font-bold text-primary">{importProgress?.created ?? 0}</p>
+                                    <p className="text-xs text-muted-foreground">Created</p>
+                                </div>
+                                <div>
+                                    <p className="text-2xl font-bold text-muted-foreground">{importProgress?.skipped ?? 0}</p>
+                                    <p className="text-xs text-muted-foreground">Skipped</p>
+                                </div>
+                                <div>
+                                    <p className="text-2xl font-bold text-destructive">{importProgress?.failed ?? 0}</p>
+                                    <p className="text-xs text-muted-foreground">Failed</p>
+                                </div>
+                            </div>
+
+                            <div className="flex justify-end gap-3">
+                                <Button variant="outline" onClick={() => { setStage('idle'); setFile(null); setImportProgress(null) }}>
+                                    Import Another
+                                </Button>
+                                <Button asChild>
+                                    <Link href="/subscriptions">View Subscriptions</Link>
+                                </Button>
+                            </div>
+                        </div>
+                    ) : null}
+
+                    {stage === 'failed' ? (
+                        <div className="space-y-6">
+                            <div className="flex items-center gap-3">
+                                <AlertCircle className="h-5 w-5 text-destructive" />
+                                <p className="text-sm font-medium">Import failed</p>
+                            </div>
+
+                            <p className="text-sm text-muted-foreground">
+                                {importProgress?.error ?? 'An unexpected error occurred while processing the import.'}
+                            </p>
+
+                            <div className="flex justify-end gap-3">
+                                <Button variant="outline" onClick={() => { setStage('idle'); setFile(null); setImportProgress(null) }}>
+                                    Try Again
+                                </Button>
+                                <Button variant="outline" asChild>
+                                    <Link href="/subscriptions">Back to Subscriptions</Link>
+                                </Button>
+                            </div>
+                        </div>
+                    ) : null}
+                </CardContent>
+            </Card>
+        </AppLayout>
+    )
+}

--- a/resources/js/pages/Subscriptions/Index.tsx
+++ b/resources/js/pages/Subscriptions/Index.tsx
@@ -29,7 +29,7 @@ import {
     DropdownMenuItem,
     DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
-import { CreditCard, Plus, Search, MoreHorizontal, Eye, Pencil, Pause, Play, X } from 'lucide-react'
+import { CreditCard, Plus, Search, MoreHorizontal, Eye, Pencil, Pause, Play, X, Upload } from 'lucide-react'
 import { formatCurrency, formatDate } from '@/lib/utils'
 import type { Subscription } from '@/types/models'
 import type { PaginatedData } from '@/types'
@@ -104,12 +104,20 @@ export default function SubscriptionIndex({ subscriptions, filters = {} }: Subsc
             <Head title="Subscriptions" />
 
             <PageHeader title="Subscriptions" description="Manage your recurring subscriptions">
-                <Button asChild>
-                    <Link href="/subscriptions/create">
-                        <Plus className="mr-2 h-4 w-4" />
-                        Add Subscription
-                    </Link>
-                </Button>
+                <div className="flex gap-2">
+                    <Button variant="outline" asChild>
+                        <Link href="/subscriptions/import">
+                            <Upload className="mr-2 h-4 w-4" />
+                            Import CSV
+                        </Link>
+                    </Button>
+                    <Button asChild>
+                        <Link href="/subscriptions/create">
+                            <Plus className="mr-2 h-4 w-4" />
+                            Add Subscription
+                        </Link>
+                    </Button>
+                </div>
             </PageHeader>
 
             {subscriptions.total > 0 ? (

--- a/routes/web.php
+++ b/routes/web.php
@@ -216,6 +216,10 @@ Route::middleware('auth')->group(function () {
         Route::get('subscriptions/analytics/spending', [SubscriptionController::class, 'spendingAnalytics'])->name('subscriptions.analytics.spending');
         Route::get('subscriptions/analytics/category-breakdown', [SubscriptionController::class, 'categoryBreakdown'])->name('subscriptions.analytics.category-breakdown');
 
+        Route::get('subscriptions/import', [SubscriptionController::class, 'importForm'])->name('subscriptions.import');
+        Route::post('subscriptions/import', [SubscriptionController::class, 'importCsv'])->name('subscriptions.import-csv');
+        Route::get('subscriptions/import/progress', [SubscriptionController::class, 'importProgress'])->name('subscriptions.import-progress');
+
         Route::resource('subscriptions', SubscriptionController::class);
         Route::patch('subscriptions/{subscription}/pause', [SubscriptionController::class, 'pause'])->name('subscriptions.pause');
         Route::patch('subscriptions/{subscription}/resume', [SubscriptionController::class, 'resume'])->name('subscriptions.resume');

--- a/tests/Feature/ImportSubscriptionsCsvTest.php
+++ b/tests/Feature/ImportSubscriptionsCsvTest.php
@@ -1,0 +1,371 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Jobs\ImportSubscriptionsCsv;
+use App\Models\Subscription;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class ImportSubscriptionsCsvTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_import_form_requires_authentication(): void
+    {
+        $response = $this->get('/subscriptions/import');
+
+        $response->assertRedirect('/login');
+    }
+
+    public function test_import_form_renders_for_authenticated_user(): void
+    {
+        $this->setupTenantContext();
+
+        $response = $this->get('/subscriptions/import');
+
+        $response->assertStatus(200);
+        $response->assertInertia(fn ($page) => $page->component('Subscriptions/Import'));
+    }
+
+    public function test_import_requires_a_file(): void
+    {
+        $this->setupTenantContext();
+
+        $response = $this->post('/subscriptions/import', []);
+
+        $response->assertSessionHasErrors('file');
+    }
+
+    public function test_import_rejects_non_csv_file(): void
+    {
+        $this->setupTenantContext();
+
+        $file = UploadedFile::fake()->create('subscriptions.pdf', 100, 'application/pdf');
+
+        $response = $this->post('/subscriptions/import', ['file' => $file]);
+
+        $response->assertSessionHasErrors('file');
+    }
+
+    public function test_import_rejects_file_exceeding_max_size(): void
+    {
+        $this->setupTenantContext();
+
+        $file = UploadedFile::fake()->create('subscriptions.csv', 11000, 'text/csv');
+
+        $response = $this->post('/subscriptions/import', ['file' => $file]);
+
+        $response->assertSessionHasErrors('file');
+    }
+
+    public function test_import_dispatches_job_on_imports_queue(): void
+    {
+        Queue::fake();
+        Storage::fake();
+
+        ['user' => $user, 'tenant' => $tenant] = $this->setupTenantContext();
+
+        $csvContent = "service_name,cost,billing_cycle,next_billing_date\nNetflix,15.99,monthly,2026-04-15";
+        $file = UploadedFile::fake()->createWithContent('subscriptions.csv', $csvContent);
+
+        $response = $this->postJson('/subscriptions/import', ['file' => $file]);
+
+        $response->assertOk();
+        $response->assertJson(['status' => 'queued']);
+
+        Queue::assertPushedOn('imports', ImportSubscriptionsCsv::class, function ($job) use ($user, $tenant) {
+            return $job->userId === $user->id && $job->tenantId === $tenant->id;
+        });
+    }
+
+    public function test_job_creates_subscriptions_from_valid_csv(): void
+    {
+        Storage::fake();
+
+        ['user' => $user, 'tenant' => $tenant] = $this->setupTenantContext();
+
+        $csvContent = implode("\n", [
+            'service_name,cost,billing_cycle,next_billing_date,currency,category,status,auto_renewal,payment_method',
+            'Netflix,15.99,monthly,2026-04-15,USD,Entertainment,active,true,Credit Card',
+            'Spotify,9.99,monthly,2026-04-20,USD,Entertainment,active,true,PayPal',
+        ]);
+
+        $storedPath = 'imports/'.$user->id.'/test_subscriptions.csv';
+        Storage::put($storedPath, $csvContent);
+
+        $job = new ImportSubscriptionsCsv($user->id, $tenant->id, $storedPath);
+        $job->handle();
+
+        $this->assertDatabaseCount('subscriptions', 2);
+
+        $this->assertDatabaseHas('subscriptions', [
+            'user_id' => $user->id,
+            'tenant_id' => $tenant->id,
+            'service_name' => 'Netflix',
+            'cost' => 15.99,
+            'currency' => 'USD',
+            'billing_cycle' => 'monthly',
+            'category' => 'Entertainment',
+            'status' => 'active',
+            'auto_renewal' => true,
+            'payment_method' => 'Credit Card',
+        ]);
+
+        $this->assertDatabaseHas('subscriptions', [
+            'user_id' => $user->id,
+            'service_name' => 'Spotify',
+            'cost' => 9.99,
+            'payment_method' => 'PayPal',
+        ]);
+
+        Storage::assertMissing($storedPath);
+    }
+
+    public function test_job_skips_duplicate_rows_via_unique_key(): void
+    {
+        Storage::fake();
+
+        ['user' => $user, 'tenant' => $tenant] = $this->setupTenantContext();
+
+        $csvContent = implode("\n", [
+            'service_name,cost,billing_cycle,next_billing_date',
+            'Netflix,15.99,monthly,2026-04-15',
+        ]);
+
+        $uniqueKey = 'csv-import:'.md5('Netflix15.99monthly2026-04-15');
+
+        Subscription::create([
+            'user_id' => $user->id,
+            'tenant_id' => $tenant->id,
+            'service_name' => 'Netflix',
+            'cost' => 15.99,
+            'billing_cycle' => 'monthly',
+            'currency' => 'USD',
+            'category' => 'Entertainment',
+            'start_date' => '2026-04-15',
+            'next_billing_date' => '2026-04-15',
+            'status' => 'active',
+            'unique_key' => $uniqueKey,
+        ]);
+
+        $storedPath = 'imports/'.$user->id.'/test_subscriptions.csv';
+        Storage::put($storedPath, $csvContent);
+
+        $job = new ImportSubscriptionsCsv($user->id, $tenant->id, $storedPath);
+        $job->handle();
+
+        $this->assertDatabaseCount('subscriptions', 1);
+    }
+
+    public function test_job_skips_duplicate_rows_matching_manually_created_subscriptions(): void
+    {
+        Storage::fake();
+
+        ['user' => $user, 'tenant' => $tenant] = $this->setupTenantContext();
+
+        $csvContent = implode("\n", [
+            'service_name,cost,billing_cycle,next_billing_date',
+            'Netflix,15.99,monthly,2026-04-15',
+        ]);
+
+        Subscription::create([
+            'user_id' => $user->id,
+            'tenant_id' => $tenant->id,
+            'service_name' => 'Netflix',
+            'cost' => 15.99,
+            'billing_cycle' => 'monthly',
+            'currency' => 'USD',
+            'category' => 'Entertainment',
+            'start_date' => '2026-04-15',
+            'next_billing_date' => '2026-04-15',
+            'status' => 'active',
+        ]);
+
+        $storedPath = 'imports/'.$user->id.'/test_subscriptions.csv';
+        Storage::put($storedPath, $csvContent);
+
+        $job = new ImportSubscriptionsCsv($user->id, $tenant->id, $storedPath);
+        $job->handle();
+
+        $this->assertDatabaseCount('subscriptions', 1);
+    }
+
+    public function test_job_skips_rows_missing_required_fields(): void
+    {
+        Storage::fake();
+
+        ['user' => $user, 'tenant' => $tenant] = $this->setupTenantContext();
+
+        $csvContent = implode("\n", [
+            'service_name,cost,billing_cycle,next_billing_date',
+            ',15.99,monthly,2026-04-15',             // missing service_name
+            'Netflix,,monthly,2026-04-15',            // missing cost
+            'Netflix,15.99,,2026-04-15',              // missing billing_cycle
+            'Netflix,15.99,monthly,',                 // missing next_billing_date
+            'Spotify,9.99,monthly,2026-04-20',        // valid row
+        ]);
+
+        $storedPath = 'imports/'.$user->id.'/test_subscriptions.csv';
+        Storage::put($storedPath, $csvContent);
+
+        $job = new ImportSubscriptionsCsv($user->id, $tenant->id, $storedPath);
+        $job->handle();
+
+        $this->assertDatabaseCount('subscriptions', 1);
+        $this->assertDatabaseHas('subscriptions', [
+            'service_name' => 'Spotify',
+        ]);
+    }
+
+    public function test_job_applies_defaults_for_optional_columns(): void
+    {
+        Storage::fake();
+
+        ['user' => $user, 'tenant' => $tenant] = $this->setupTenantContext();
+
+        $csvContent = implode("\n", [
+            'service_name,cost,billing_cycle,next_billing_date',
+            'Netflix,15.99,monthly,2026-04-15',
+        ]);
+
+        $storedPath = 'imports/'.$user->id.'/test_subscriptions.csv';
+        Storage::put($storedPath, $csvContent);
+
+        $job = new ImportSubscriptionsCsv($user->id, $tenant->id, $storedPath);
+        $job->handle();
+
+        $subscription = Subscription::first();
+        $this->assertEquals('MKD', $subscription->currency);
+        $this->assertEquals('Other', $subscription->category);
+        $this->assertEquals('active', $subscription->status);
+        $this->assertTrue($subscription->auto_renewal);
+        $this->assertNull($subscription->payment_method);
+        $this->assertNull($subscription->notes);
+        $this->assertNull($subscription->description);
+    }
+
+    public function test_job_supports_header_aliases(): void
+    {
+        Storage::fake();
+
+        ['user' => $user, 'tenant' => $tenant] = $this->setupTenantContext();
+
+        $csvContent = implode("\n", [
+            'name,price,frequency,renewal_date',
+            'Netflix,15.99,monthly,2026-04-15',
+        ]);
+
+        $storedPath = 'imports/'.$user->id.'/test_subscriptions.csv';
+        Storage::put($storedPath, $csvContent);
+
+        $job = new ImportSubscriptionsCsv($user->id, $tenant->id, $storedPath);
+        $job->handle();
+
+        $this->assertDatabaseCount('subscriptions', 1);
+        $this->assertDatabaseHas('subscriptions', [
+            'service_name' => 'Netflix',
+            'cost' => 15.99,
+            'billing_cycle' => 'monthly',
+        ]);
+    }
+
+    public function test_job_handles_empty_csv_gracefully(): void
+    {
+        Storage::fake();
+
+        ['user' => $user, 'tenant' => $tenant] = $this->setupTenantContext();
+
+        $storedPath = 'imports/'.$user->id.'/test_subscriptions.csv';
+        Storage::put($storedPath, '');
+
+        $job = new ImportSubscriptionsCsv($user->id, $tenant->id, $storedPath);
+        $job->handle();
+
+        $this->assertDatabaseCount('subscriptions', 0);
+    }
+
+    public function test_job_handles_missing_file_gracefully(): void
+    {
+        Storage::fake();
+
+        ['user' => $user, 'tenant' => $tenant] = $this->setupTenantContext();
+
+        $job = new ImportSubscriptionsCsv($user->id, $tenant->id, 'imports/nonexistent.csv');
+        $job->handle();
+
+        $this->assertDatabaseCount('subscriptions', 0);
+    }
+
+    public function test_job_writes_progress_to_cache(): void
+    {
+        Storage::fake();
+
+        ['user' => $user, 'tenant' => $tenant] = $this->setupTenantContext();
+
+        $csvContent = implode("\n", [
+            'service_name,cost,billing_cycle,next_billing_date',
+            'Netflix,15.99,monthly,2026-04-15',
+            'Spotify,9.99,monthly,2026-04-20',
+        ]);
+
+        $storedPath = 'imports/'.$user->id.'/test_subscriptions.csv';
+        Storage::put($storedPath, $csvContent);
+
+        $job = new ImportSubscriptionsCsv($user->id, $tenant->id, $storedPath);
+        $job->handle();
+
+        $progress = Cache::get('subscription_import_progress:'.$user->id);
+        $this->assertNotNull($progress);
+        $this->assertEquals('completed', $progress['status']);
+        $this->assertEquals(2, $progress['total']);
+        $this->assertEquals(2, $progress['created']);
+        $this->assertEquals(0, $progress['skipped']);
+        $this->assertEquals(0, $progress['failed']);
+    }
+
+    public function test_progress_endpoint_returns_cached_data(): void
+    {
+        ['user' => $user] = $this->setupTenantContext();
+
+        Cache::put('subscription_import_progress:'.$user->id, [
+            'status' => 'processing',
+            'total' => 10,
+            'created' => 5,
+            'skipped' => 1,
+            'failed' => 0,
+        ], 300);
+
+        $response = $this->getJson('/subscriptions/import/progress');
+
+        $response->assertOk();
+        $response->assertJson([
+            'status' => 'processing',
+            'total' => 10,
+            'created' => 5,
+            'skipped' => 1,
+            'failed' => 0,
+        ]);
+    }
+
+    public function test_progress_endpoint_returns_idle_when_no_import(): void
+    {
+        $this->setupTenantContext();
+
+        $response = $this->getJson('/subscriptions/import/progress');
+
+        $response->assertOk();
+        $response->assertJson(['status' => 'idle']);
+    }
+
+    public function test_progress_endpoint_requires_authentication(): void
+    {
+        $response = $this->getJson('/subscriptions/import/progress');
+
+        $response->assertUnauthorized();
+    }
+}

--- a/tests/Unit/SubscriptionTest.php
+++ b/tests/Unit/SubscriptionTest.php
@@ -12,6 +12,7 @@ class SubscriptionTest extends TestCase
     use RefreshDatabase;
 
     protected $user;
+
     protected $tenant;
 
     protected function setUp(): void
@@ -53,6 +54,7 @@ class SubscriptionTest extends TestCase
             'notes',
             'tags',
             'status',
+            'unique_key',
         ];
 
         $this->assertEquals($expectedFillable, $subscription->getFillable());


### PR DESCRIPTION
## Summary
- Add CSV import feature for subscriptions, following the expenses CSV import pattern
- Queued job with duplicate detection (unique_key + field matching on service_name/cost/billing_cycle/next_billing_date)
- Progress tracking via cache with polling UI
- Migration adds `unique_key` column to subscriptions table

## Changes
- **New**: `ImportSubscriptionsCsv` job, `ImportSubscriptionCsvRequest`, Import page, 18 tests
- **New**: Migration for `unique_key` column on subscriptions
- **Modified**: `SubscriptionController` — import methods, routes, Index page button

## Test plan
- [x] All 18 import tests pass
- [ ] Upload a CSV via `/subscriptions/import` and verify subscriptions appear
- [ ] Verify duplicate rows are skipped on re-import

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CSV bulk import for subscriptions with client/server validation (CSV, 10MB), upload UI, and polling-based progress display.
  * Import form with expected-format help panel and an "Import CSV" action on the subscriptions page.

* **Database**
  * Added nullable unique_key column with a uniqueness constraint.

* **Model**
  * Subscriptions now accept a unique_key field for deduplication.

* **Tests**
  * Comprehensive feature and unit tests covering upload, parsing, dedupe, progress, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->