### PR TITLE
feat: add utility bills CSV import

### DIFF
--- a/app/Http/Controllers/UtilityBillController.php
+++ b/app/Http/Controllers/UtilityBillController.php
@@ -2,11 +2,15 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Requests\ImportUtilityBillCsvRequest;
 use App\Http\Requests\StoreUtilityBillRequest;
 use App\Http\Requests\UpdateUtilityBillRequest;
+use App\Jobs\ImportUtilityBillsCsv;
 use App\Models\UtilityBill;
 use App\Services\CurrencyService;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Inertia\Inertia;
 
@@ -993,5 +997,44 @@ class UtilityBillController extends Controller
 
         return redirect()->route('utility-bills.show', $utilityBill)
             ->with('success', 'Auto-pay setting updated successfully.');
+    }
+
+    /**
+     * Show the CSV import form.
+     */
+    public function importForm()
+    {
+        return Inertia::render('UtilityBills/Import');
+    }
+
+    /**
+     * Queue an import of utility bills from an uploaded CSV.
+     */
+    public function importCsv(ImportUtilityBillCsvRequest $request)
+    {
+        $userId = auth()->id();
+        $tenantId = auth()->user()->current_tenant_id;
+        $file = $request->file('file');
+
+        $storedPath = $file->storeAs('imports/'.$userId, uniqid('utility_bills_').'.csv');
+
+        ImportUtilityBillsCsv::dispatch($userId, $tenantId, $storedPath)->onQueue('imports');
+
+        if ($request->expectsJson()) {
+            return new JsonResponse(['status' => 'queued']);
+        }
+
+        return redirect()->route('utility-bills.index')
+            ->with('success', 'Your CSV import has been queued and will be processed shortly.');
+    }
+
+    /**
+     * Return the current import progress for the authenticated user.
+     */
+    public function importProgress(): JsonResponse
+    {
+        $progress = Cache::get('utility_bill_import_progress:'.auth()->id());
+
+        return new JsonResponse($progress ?? ['status' => 'idle']);
     }
 }

--- a/app/Http/Requests/ImportUtilityBillCsvRequest.php
+++ b/app/Http/Requests/ImportUtilityBillCsvRequest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ImportUtilityBillCsvRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, array<int, string>>
+     */
+    public function rules(): array
+    {
+        return [
+            'file' => ['required', 'file', 'mimes:csv,txt', 'max:10240'],
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'file.required' => 'Please upload a CSV file to import.',
+            'file.mimes' => 'The import file must be a CSV (or TXT) file.',
+            'file.max' => 'The CSV file may not be greater than 10MB.',
+        ];
+    }
+}

--- a/app/Jobs/ImportUtilityBillsCsv.php
+++ b/app/Jobs/ImportUtilityBillsCsv.php
@@ -1,0 +1,356 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Jobs;
+
+use App\Models\UtilityBill;
+use App\Scopes\TenantScope;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
+
+class ImportUtilityBillsCsv implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public int $timeout = 300;
+
+    public int $tries = 3;
+
+    private const HEADER_ALIASES = [
+        'utility_type' => ['type', 'utility', 'service_type', 'service type'],
+        'service_provider' => ['provider', 'company', 'vendor', 'supplier'],
+        'account_number' => ['account', 'account_no', 'acct'],
+        'service_address' => ['address', 'location'],
+        'bill_amount' => ['amount', 'total', 'cost', 'price'],
+        'currency' => ['currency_code'],
+        'usage_amount' => ['usage', 'consumption'],
+        'usage_unit' => ['unit', 'measure'],
+        'rate_per_unit' => ['rate', 'unit_rate', 'unit_price'],
+        'bill_period_start' => ['period_start', 'start_date', 'billing_start'],
+        'bill_period_end' => ['period_end', 'end_date', 'billing_end'],
+        'due_date' => ['due', 'payment_due', 'pay_by'],
+        'payment_status' => ['status', 'paid_status'],
+        'payment_date' => ['paid_date', 'date_paid'],
+        'service_plan' => ['plan', 'tariff'],
+        'contract_terms' => ['terms', 'contract'],
+        'auto_pay_enabled' => ['auto_pay', 'autopay'],
+        'budget_alert_threshold' => ['budget_threshold', 'threshold', 'budget'],
+        'notes' => ['note', 'comment', 'comments', 'memo'],
+    ];
+
+    public function __construct(
+        public int $userId,
+        public int $tenantId,
+        public string $storedPath,
+    ) {}
+
+    public function handle(): void
+    {
+        if (! Storage::exists($this->storedPath)) {
+            Log::error('ImportUtilityBillsCsv: CSV file does not exist', [
+                'user_id' => $this->userId,
+                'path' => $this->storedPath,
+            ]);
+
+            return;
+        }
+
+        $content = Storage::get($this->storedPath);
+        $lines = array_values(array_filter(explode("\n", $content), fn ($line) => trim($line) !== ''));
+
+        if (empty($lines)) {
+            Log::warning('ImportUtilityBillsCsv: Empty CSV file', [
+                'user_id' => $this->userId,
+                'path' => $this->storedPath,
+            ]);
+
+            return;
+        }
+
+        $header = str_getcsv(array_shift($lines));
+        if (! $header) {
+            Log::warning('ImportUtilityBillsCsv: Empty CSV header', [
+                'user_id' => $this->userId,
+                'path' => $this->storedPath,
+            ]);
+
+            return;
+        }
+
+        $index = $this->buildHeaderIndex($header);
+
+        $totalRows = count($lines);
+        $created = 0;
+        $skipped = 0;
+        $failed = 0;
+        $cacheKey = 'utility_bill_import_progress:'.$this->userId;
+
+        $this->updateProgress($cacheKey, 'processing', $totalRows, $created, $skipped, $failed);
+
+        foreach ($lines as $line) {
+            $row = str_getcsv($line);
+
+            if (count(array_filter($row, fn ($v) => $v !== null && $v !== '')) === 0) {
+                continue;
+            }
+
+            try {
+                $utilityType = (string) $this->getValue($row, $index, 'utility_type');
+                $serviceProvider = (string) $this->getValue($row, $index, 'service_provider');
+                $billAmount = (string) $this->getValue($row, $index, 'bill_amount');
+                $dueDateRaw = (string) $this->getValue($row, $index, 'due_date');
+
+                if (! $utilityType || ! $serviceProvider || ! $billAmount || ! $dueDateRaw) {
+                    $skipped++;
+                    $this->updateProgress($cacheKey, 'processing', $totalRows, $created, $skipped, $failed);
+                    Log::warning('ImportUtilityBillsCsv: skipped row due to missing required fields', [
+                        'utility_type' => $utilityType,
+                        'service_provider' => $serviceProvider,
+                        'bill_amount' => $billAmount,
+                        'due_date' => $dueDateRaw,
+                    ]);
+
+                    continue;
+                }
+
+                $parsedAmount = $this->parseDecimal($billAmount);
+                $parsedDueDate = $this->parseDate($dueDateRaw);
+                $billPeriodStartRaw = (string) $this->getValue($row, $index, 'bill_period_start', '');
+                $parsedBillDate = $billPeriodStartRaw ? $this->parseDate($billPeriodStartRaw) : $parsedDueDate;
+
+                $uniqueKey = 'csv-import:'.md5($serviceProvider.$parsedBillDate.$billAmount.$utilityType);
+
+                $exists = UtilityBill::withoutGlobalScope(TenantScope::class)
+                    ->where('user_id', $this->userId)
+                    ->where(function ($query) use ($uniqueKey, $parsedDueDate, $parsedAmount, $serviceProvider, $utilityType) {
+                        $query->where('unique_key', $uniqueKey)
+                            ->orWhere(function ($query) use ($parsedDueDate, $parsedAmount, $serviceProvider, $utilityType) {
+                                $query->whereDate('due_date', $parsedDueDate)
+                                    ->where('bill_amount', round($parsedAmount, 2))
+                                    ->where('service_provider', $serviceProvider)
+                                    ->where('utility_type', $utilityType);
+                            });
+                    })
+                    ->exists();
+
+                if ($exists) {
+                    $skipped++;
+                    $this->updateProgress($cacheKey, 'processing', $totalRows, $created, $skipped, $failed);
+
+                    continue;
+                }
+
+                $currency = $this->normalizeCurrency((string) $this->getValue($row, $index, 'currency', 'MKD'));
+                $accountNumber = (string) $this->getValue($row, $index, 'account_number', '');
+                $serviceAddress = (string) $this->getValue($row, $index, 'service_address', '');
+                $usageAmount = (string) $this->getValue($row, $index, 'usage_amount', '');
+                $usageUnit = (string) $this->getValue($row, $index, 'usage_unit', '');
+                $ratePerUnit = (string) $this->getValue($row, $index, 'rate_per_unit', '');
+                $billPeriodEndRaw = (string) $this->getValue($row, $index, 'bill_period_end', '');
+                $paymentStatus = strtolower((string) $this->getValue($row, $index, 'payment_status', 'pending'));
+                $paymentDateRaw = (string) $this->getValue($row, $index, 'payment_date', '');
+                $servicePlan = (string) $this->getValue($row, $index, 'service_plan', '');
+                $contractTerms = (string) $this->getValue($row, $index, 'contract_terms', '');
+                $autoPayEnabled = $this->parseBoolean((string) $this->getValue($row, $index, 'auto_pay_enabled', 'false'));
+                $budgetThreshold = (string) $this->getValue($row, $index, 'budget_alert_threshold', '');
+                $notes = (string) $this->getValue($row, $index, 'notes', '');
+
+                if (! in_array($paymentStatus, ['pending', 'paid', 'overdue', 'disputed'], true)) {
+                    $paymentStatus = 'pending';
+                }
+
+                $billPeriodStart = $billPeriodStartRaw ? $this->parseDate($billPeriodStartRaw) : null;
+                $billPeriodEnd = $billPeriodEndRaw ? $this->parseDate($billPeriodEndRaw) : null;
+                $paymentDate = $paymentDateRaw ? $this->parseDate($paymentDateRaw) : null;
+
+                // bill_period_start/end and account_number/service_address are NOT NULL in schema
+                $effectiveBillPeriodStart = $billPeriodStart ?? $parsedDueDate;
+                $effectiveBillPeriodEnd = $billPeriodEnd ?? $parsedDueDate;
+
+                $bill = new UtilityBill([
+                    'tenant_id' => $this->tenantId,
+                    'user_id' => $this->userId,
+                    'utility_type' => $utilityType,
+                    'service_provider' => $serviceProvider,
+                    'account_number' => $accountNumber ?: '',
+                    'service_address' => $serviceAddress ?: '',
+                    'bill_amount' => $parsedAmount,
+                    'currency' => $currency,
+                    'usage_amount' => $usageAmount ? $this->parseDecimal($usageAmount) : null,
+                    'usage_unit' => $usageUnit ?: null,
+                    'rate_per_unit' => $ratePerUnit ? $this->parseDecimal($ratePerUnit) : null,
+                    'bill_period_start' => $effectiveBillPeriodStart,
+                    'bill_period_end' => $effectiveBillPeriodEnd,
+                    'due_date' => $parsedDueDate,
+                    'payment_status' => $paymentStatus,
+                    'payment_date' => $paymentDate,
+                    'service_plan' => $servicePlan ?: null,
+                    'contract_terms' => $contractTerms ?: null,
+                    'auto_pay_enabled' => $autoPayEnabled,
+                    'budget_alert_threshold' => $budgetThreshold ? $this->parseDecimal($budgetThreshold) : null,
+                    'notes' => $notes ?: null,
+                    'unique_key' => $uniqueKey,
+                ]);
+                $bill->save();
+
+                $created++;
+                $this->updateProgress($cacheKey, 'processing', $totalRows, $created, $skipped, $failed);
+            } catch (\Throwable $e) {
+                $failed++;
+                $this->updateProgress($cacheKey, 'processing', $totalRows, $created, $skipped, $failed);
+                Log::error('ImportUtilityBillsCsv: row import failed', [
+                    'message' => $e->getMessage(),
+                    'trace' => $e->getTraceAsString(),
+                ]);
+            }
+        }
+
+        try {
+            Storage::delete($this->storedPath);
+        } catch (\Throwable $e) {
+            // Ignore cleanup errors
+        }
+
+        $this->updateProgress($cacheKey, 'completed', $totalRows, $created, $skipped, $failed);
+
+        Log::info('ImportUtilityBillsCsv: import finished', [
+            'user_id' => $this->userId,
+            'created' => $created,
+            'skipped' => $skipped,
+            'failed' => $failed,
+        ]);
+    }
+
+    /**
+     * @param  array<int, string>  $header
+     * @return array<string, int>
+     */
+    private function buildHeaderIndex(array $header): array
+    {
+        $index = [];
+        foreach ($header as $i => $col) {
+            $normalized = strtolower(trim((string) $col));
+            $index[$normalized] = $i;
+        }
+
+        return $index;
+    }
+
+    /**
+     * @param  array<int, string|null>  $row
+     * @param  array<string, int>  $index
+     */
+    private function getValue(array $row, array $index, string $name, mixed $default = null): mixed
+    {
+        foreach ([$name, trim($name), strtolower($name)] as $key) {
+            if (array_key_exists($key, $index)) {
+                $pos = $index[$key];
+
+                return isset($row[$pos]) ? trim((string) $row[$pos]) : $default;
+            }
+        }
+
+        foreach ((self::HEADER_ALIASES[$name] ?? []) as $alias) {
+            $alias = strtolower($alias);
+            if (array_key_exists($alias, $index)) {
+                $pos = $index[$alias];
+
+                return isset($row[$pos]) ? trim((string) $row[$pos]) : $default;
+            }
+        }
+
+        return $default;
+    }
+
+    private function parseDecimal(?string $value): float
+    {
+        if ($value === null) {
+            return 0.0;
+        }
+
+        $v = trim($value);
+        if ($v === '') {
+            return 0.0;
+        }
+
+        $negative = false;
+        if (str_starts_with($v, '(') && str_ends_with($v, ')')) {
+            $negative = true;
+            $v = substr($v, 1, -1);
+        }
+        $v = str_replace([',', ' '], ['', ''], $v);
+
+        $num = (float) $v;
+
+        return $negative ? -$num : $num;
+    }
+
+    private function normalizeCurrency(?string $code): string
+    {
+        $code = strtoupper(substr((string) ($code ?: 'MKD'), 0, 3));
+
+        return $code ?: 'MKD';
+    }
+
+    private function parseDate(?string $value): string
+    {
+        if ($value) {
+            try {
+                return Carbon::parse($value)->toDateString();
+            } catch (\Throwable $e) {
+                // fall back below
+            }
+
+            $timestamp = strtotime($value);
+            if ($timestamp !== false) {
+                return date('Y-m-d', $timestamp);
+            }
+        }
+
+        return now()->toDateString();
+    }
+
+    private function parseBoolean(?string $value): bool
+    {
+        if ($value === null) {
+            return false;
+        }
+
+        return in_array(strtolower(trim($value)), ['true', '1', 'yes'], true);
+    }
+
+    private function updateProgress(string $cacheKey, string $status, int $total, int $created, int $skipped, int $failed): void
+    {
+        Cache::put($cacheKey, [
+            'status' => $status,
+            'total' => $total,
+            'created' => $created,
+            'skipped' => $skipped,
+            'failed' => $failed,
+        ], 300);
+    }
+
+    public function failed(\Throwable $exception): void
+    {
+        Cache::put('utility_bill_import_progress:'.$this->userId, [
+            'status' => 'failed',
+            'total' => 0,
+            'created' => 0,
+            'skipped' => 0,
+            'failed' => 0,
+            'error' => $exception->getMessage(),
+        ], 300);
+
+        Log::error('ImportUtilityBillsCsv failed', [
+            'exception' => $exception->getMessage(),
+        ]);
+    }
+}

--- a/database/migrations/2026_03_30_152113_add_unique_key_to_utility_bills_table.php
+++ b/database/migrations/2026_03_30_152113_add_unique_key_to_utility_bills_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('utility_bills', function (Blueprint $table) {
+            $table->string('unique_key')->nullable()->after('id');
+            $table->unique('unique_key');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('utility_bills', function (Blueprint $table) {
+            $table->dropUnique(['unique_key']);
+            $table->dropColumn('unique_key');
+        });
+    }
+};

--- a/resources/js/pages/UtilityBills/Import.tsx
+++ b/resources/js/pages/UtilityBills/Import.tsx
@@ -1,0 +1,304 @@
+import { Head, Link, router } from '@inertiajs/react'
+import { useState, useEffect, useRef, useCallback, type FormEvent, type ChangeEvent } from 'react'
+import AppLayout from '@/components/shared/app-layout'
+import { PageHeader } from '@/components/shared/page-header'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Progress } from '@/components/ui/progress'
+import { Upload, CheckCircle2, AlertCircle, Loader2 } from 'lucide-react'
+
+type ImportStage = 'idle' | 'uploading' | 'processing' | 'completed' | 'failed'
+
+interface ImportProgress {
+    status: 'idle' | 'processing' | 'completed' | 'failed'
+    total: number
+    created: number
+    skipped: number
+    failed: number
+    error?: string
+}
+
+export default function UtilityBillImport() {
+    const [file, setFile] = useState<File | null>(null)
+    const [stage, setStage] = useState<ImportStage>('idle')
+    const [uploadProgress, setUploadProgress] = useState(0)
+    const [importProgress, setImportProgress] = useState<ImportProgress | null>(null)
+    const [fileError, setFileError] = useState<string | null>(null)
+    const pollingRef = useRef<ReturnType<typeof setInterval> | null>(null)
+
+    const stopPolling = useCallback(() => {
+        if (pollingRef.current) {
+            clearInterval(pollingRef.current)
+            pollingRef.current = null
+        }
+    }, [])
+
+    const pollProgress = useCallback(() => {
+        pollingRef.current = setInterval(async () => {
+            try {
+                const response = await fetch('/utility-bills/import/progress')
+                const data: ImportProgress = await response.json()
+
+                if (data.status === 'processing' || data.status === 'completed' || data.status === 'failed') {
+                    setImportProgress(data)
+                }
+
+                if (data.status === 'completed') {
+                    setStage('completed')
+                    stopPolling()
+                } else if (data.status === 'failed') {
+                    setStage('failed')
+                    stopPolling()
+                }
+            } catch {
+                // Ignore transient fetch errors, retry on next tick
+            }
+        }, 2000)
+    }, [stopPolling])
+
+    useEffect(() => {
+        return () => stopPolling()
+    }, [stopPolling])
+
+    function handleFileChange(e: ChangeEvent<HTMLInputElement>) {
+        setFile(e.target.files?.[0] ?? null)
+        setFileError(null)
+    }
+
+    function handleSubmit(e: FormEvent) {
+        e.preventDefault()
+        if (!file) return
+
+        setStage('uploading')
+        setFileError(null)
+
+        const formData = new FormData()
+        formData.append('file', file)
+
+        const xsrfToken = decodeURIComponent(
+            document.cookie.split('; ').find(row => row.startsWith('XSRF-TOKEN='))?.split('=')[1] ?? ''
+        )
+
+        const xhr = new XMLHttpRequest()
+        xhr.open('POST', '/utility-bills/import')
+        xhr.setRequestHeader('X-XSRF-TOKEN', xsrfToken)
+        xhr.setRequestHeader('Accept', 'application/json')
+        xhr.setRequestHeader('X-Requested-With', 'XMLHttpRequest')
+
+        xhr.upload.onprogress = (event) => {
+            if (event.lengthComputable) {
+                setUploadProgress(Math.round((event.loaded / event.total) * 100))
+            }
+        }
+
+        xhr.onload = () => {
+            if (xhr.status >= 200 && xhr.status < 300) {
+                setStage('processing')
+                setUploadProgress(100)
+                pollProgress()
+            } else {
+                setStage('idle')
+                try {
+                    const errorData = JSON.parse(xhr.responseText)
+                    setFileError(errorData.errors?.file?.[0] ?? errorData.message ?? 'Upload failed.')
+                } catch {
+                    setFileError('Upload failed. Please try again.')
+                }
+            }
+        }
+
+        xhr.onerror = () => {
+            setStage('idle')
+            setFileError('Network error. Please try again.')
+        }
+
+        xhr.send(formData)
+    }
+
+    const processed = importProgress
+        ? importProgress.created + importProgress.skipped + importProgress.failed
+        : 0
+    const progressPercent = importProgress && importProgress.total > 0
+        ? Math.round((processed / importProgress.total) * 100)
+        : 0
+
+    return (
+        <AppLayout>
+            <Head title="Import Utility Bills" />
+
+            <PageHeader title="Import Utility Bills" description="Upload a CSV file to bulk import utility bills">
+                <Button variant="outline" asChild>
+                    <Link href="/utility-bills">Back to List</Link>
+                </Button>
+            </PageHeader>
+
+            <Card className="mx-auto max-w-2xl">
+                <CardHeader>
+                    <CardTitle>CSV Import</CardTitle>
+                </CardHeader>
+                <CardContent>
+                    {stage === 'idle' || stage === 'uploading' ? (
+                        <form onSubmit={handleSubmit} className="space-y-6">
+                            <div className="space-y-2">
+                                <Label htmlFor="file">CSV File</Label>
+                                <div className="flex items-center gap-4">
+                                    <Input
+                                        id="file"
+                                        type="file"
+                                        accept=".csv"
+                                        onChange={handleFileChange}
+                                        className="flex-1"
+                                        disabled={stage === 'uploading'}
+                                    />
+                                </div>
+                                {fileError ? (
+                                    <p className="text-sm text-destructive">{fileError}</p>
+                                ) : null}
+                                {stage === 'uploading' ? (
+                                    <div className="mt-2">
+                                        <Progress value={uploadProgress} />
+                                        <p className="mt-1 text-xs text-muted-foreground">{uploadProgress}% uploaded</p>
+                                    </div>
+                                ) : null}
+                            </div>
+
+                            <div className="rounded-md border border-border bg-muted p-4">
+                                <h3 className="mb-2 text-sm font-medium">Expected CSV Format</h3>
+                                <p className="text-xs text-muted-foreground">
+                                    Your CSV file should include the following columns. Required columns are marked with *.
+                                </p>
+                                <div className="mt-2 space-y-1">
+                                    <code className="block text-xs text-muted-foreground">
+                                        utility_type*, service_provider*, bill_amount*, due_date*
+                                    </code>
+                                    <code className="block text-xs text-muted-foreground">
+                                        currency, account_number, service_address, usage_amount, usage_unit,
+                                    </code>
+                                    <code className="block text-xs text-muted-foreground">
+                                        rate_per_unit, bill_period_start, bill_period_end, payment_status,
+                                    </code>
+                                    <code className="block text-xs text-muted-foreground">
+                                        payment_date, auto_pay_enabled, budget_alert_threshold, notes
+                                    </code>
+                                </div>
+                                <p className="mt-3 text-xs text-muted-foreground">
+                                    <strong>Example row:</strong>
+                                </p>
+                                <code className="mt-1 block text-xs text-muted-foreground">
+                                    electricity,PG&amp;E,125.50,2026-04-15,MKD,1234567890,123 Main St,500,kWh,0.25,2026-03-01,2026-03-31,pending,,false,,Monthly bill
+                                </code>
+                            </div>
+
+                            <div className="flex justify-end gap-3">
+                                <Button type="button" variant="outline" asChild>
+                                    <Link href="/utility-bills">Cancel</Link>
+                                </Button>
+                                <Button type="submit" disabled={stage === 'uploading' || !file}>
+                                    <Upload className="mr-2 h-4 w-4" />
+                                    {stage === 'uploading' ? 'Uploading...' : 'Import CSV'}
+                                </Button>
+                            </div>
+                        </form>
+                    ) : null}
+
+                    {stage === 'processing' ? (
+                        <div className="space-y-6">
+                            <div className="flex items-center gap-3">
+                                <Loader2 className="h-5 w-5 animate-spin text-primary" />
+                                <p className="text-sm font-medium">
+                                    {importProgress ? 'Processing your import...' : 'Waiting for import to start...'}
+                                </p>
+                            </div>
+
+                            {importProgress ? (
+                                <>
+                                    <Progress value={progressPercent} />
+
+                                    <div className="grid grid-cols-3 gap-4 text-center">
+                                        <div>
+                                            <p className="text-2xl font-bold text-primary">{importProgress.created}</p>
+                                            <p className="text-xs text-muted-foreground">Created</p>
+                                        </div>
+                                        <div>
+                                            <p className="text-2xl font-bold text-muted-foreground">{importProgress.skipped}</p>
+                                            <p className="text-xs text-muted-foreground">Skipped</p>
+                                        </div>
+                                        <div>
+                                            <p className="text-2xl font-bold text-destructive">{importProgress.failed}</p>
+                                            <p className="text-xs text-muted-foreground">Failed</p>
+                                        </div>
+                                    </div>
+
+                                    <p className="text-xs text-muted-foreground text-center">
+                                        {processed} of {importProgress.total} rows processed ({progressPercent}%)
+                                    </p>
+                                </>
+                            ) : (
+                                <p className="text-xs text-muted-foreground text-center">
+                                    Your import has been queued. Make sure the queue worker is running.
+                                </p>
+                            )}
+                        </div>
+                    ) : null}
+
+                    {stage === 'completed' ? (
+                        <div className="space-y-6">
+                            <div className="flex items-center gap-3">
+                                <CheckCircle2 className="h-5 w-5 text-green-600" />
+                                <p className="text-sm font-medium">Import completed!</p>
+                            </div>
+
+                            <div className="grid grid-cols-3 gap-4 text-center">
+                                <div>
+                                    <p className="text-2xl font-bold text-primary">{importProgress?.created ?? 0}</p>
+                                    <p className="text-xs text-muted-foreground">Created</p>
+                                </div>
+                                <div>
+                                    <p className="text-2xl font-bold text-muted-foreground">{importProgress?.skipped ?? 0}</p>
+                                    <p className="text-xs text-muted-foreground">Skipped</p>
+                                </div>
+                                <div>
+                                    <p className="text-2xl font-bold text-destructive">{importProgress?.failed ?? 0}</p>
+                                    <p className="text-xs text-muted-foreground">Failed</p>
+                                </div>
+                            </div>
+
+                            <div className="flex justify-end gap-3">
+                                <Button variant="outline" onClick={() => { setStage('idle'); setFile(null); setImportProgress(null) }}>
+                                    Import Another
+                                </Button>
+                                <Button asChild>
+                                    <Link href="/utility-bills">View Utility Bills</Link>
+                                </Button>
+                            </div>
+                        </div>
+                    ) : null}
+
+                    {stage === 'failed' ? (
+                        <div className="space-y-6">
+                            <div className="flex items-center gap-3">
+                                <AlertCircle className="h-5 w-5 text-destructive" />
+                                <p className="text-sm font-medium">Import failed</p>
+                            </div>
+
+                            <p className="text-sm text-muted-foreground">
+                                {importProgress?.error ?? 'An unexpected error occurred while processing the import.'}
+                            </p>
+
+                            <div className="flex justify-end gap-3">
+                                <Button variant="outline" onClick={() => { setStage('idle'); setFile(null); setImportProgress(null) }}>
+                                    Try Again
+                                </Button>
+                                <Button variant="outline" asChild>
+                                    <Link href="/utility-bills">Back to Utility Bills</Link>
+                                </Button>
+                            </div>
+                        </div>
+                    ) : null}
+                </CardContent>
+            </Card>
+        </AppLayout>
+    )
+}

--- a/resources/js/pages/UtilityBills/Index.tsx
+++ b/resources/js/pages/UtilityBills/Index.tsx
@@ -29,7 +29,7 @@ import {
     DropdownMenuItem,
     DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
-import { Zap, Plus, Search, MoreHorizontal, Eye, Pencil, Check, ToggleLeft, ToggleRight, Copy, Trash2 } from 'lucide-react'
+import { Zap, Plus, Search, MoreHorizontal, Eye, Pencil, Check, ToggleLeft, ToggleRight, Copy, Trash2, Upload } from 'lucide-react'
 import { formatCurrency, formatDate } from '@/lib/utils'
 import type { UtilityBill } from '@/types/models'
 import type { PaginatedData } from '@/types'
@@ -163,12 +163,20 @@ export default function UtilityBillIndex({ utilityBills, filters = {} }: Utility
             <Head title="Utility Bills" />
 
             <PageHeader title="Utility Bills" description="Track your utility bills and monitor usage patterns">
-                <Button asChild>
-                    <Link href="/utility-bills/create">
-                        <Plus className="mr-2 h-4 w-4" />
-                        Add Utility Bill
-                    </Link>
-                </Button>
+                <div className="flex gap-2">
+                    <Button variant="outline" asChild>
+                        <Link href="/utility-bills/import">
+                            <Upload className="mr-2 h-4 w-4" />
+                            Import CSV
+                        </Link>
+                    </Button>
+                    <Button asChild>
+                        <Link href="/utility-bills/create">
+                            <Plus className="mr-2 h-4 w-4" />
+                            Add Utility Bill
+                        </Link>
+                    </Button>
+                </div>
             </PageHeader>
 
             {utilityBills.total > 0 ? (

--- a/routes/web.php
+++ b/routes/web.php
@@ -298,6 +298,9 @@ Route::middleware('auth')->group(function () {
         Route::get('utility-bills/analytics/spending', [UtilityBillController::class, 'spendingAnalytics'])->name('utility-bills.spending-analytics');
         Route::get('utility-bills/analytics/due-date', [UtilityBillController::class, 'dueDateAnalytics'])->name('utility-bills.due-date-analytics');
 
+        Route::get('utility-bills/import', [UtilityBillController::class, 'importForm'])->name('utility-bills.import');
+        Route::post('utility-bills/import', [UtilityBillController::class, 'importCsv'])->name('utility-bills.import-csv');
+        Route::get('utility-bills/import/progress', [UtilityBillController::class, 'importProgress'])->name('utility-bills.import-progress');
         Route::resource('utility-bills', UtilityBillController::class);
         Route::patch('utility-bills/{utility_bill}/mark-paid', [UtilityBillController::class, 'markPaid'])->name('utility-bills.mark-paid');
         Route::patch('utility-bills/{utility_bill}/set-auto-pay', [UtilityBillController::class, 'setAutoPay'])->name('utility-bills.set-auto-pay');

--- a/tests/Feature/ImportUtilityBillsCsvTest.php
+++ b/tests/Feature/ImportUtilityBillsCsvTest.php
@@ -1,0 +1,375 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Jobs\ImportUtilityBillsCsv;
+use App\Models\UtilityBill;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class ImportUtilityBillsCsvTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_import_form_requires_authentication(): void
+    {
+        $response = $this->get('/utility-bills/import');
+
+        $response->assertRedirect('/login');
+    }
+
+    public function test_import_form_renders_for_authenticated_user(): void
+    {
+        $this->setupTenantContext();
+
+        $response = $this->get('/utility-bills/import');
+
+        $response->assertStatus(200);
+        $response->assertInertia(fn ($page) => $page->component('UtilityBills/Import'));
+    }
+
+    public function test_import_requires_a_file(): void
+    {
+        $this->setupTenantContext();
+
+        $response = $this->post('/utility-bills/import', []);
+
+        $response->assertSessionHasErrors('file');
+    }
+
+    public function test_import_rejects_non_csv_file(): void
+    {
+        $this->setupTenantContext();
+
+        $file = UploadedFile::fake()->create('bills.pdf', 100, 'application/pdf');
+
+        $response = $this->post('/utility-bills/import', ['file' => $file]);
+
+        $response->assertSessionHasErrors('file');
+    }
+
+    public function test_import_rejects_file_exceeding_max_size(): void
+    {
+        $this->setupTenantContext();
+
+        $file = UploadedFile::fake()->create('bills.csv', 11000, 'text/csv');
+
+        $response = $this->post('/utility-bills/import', ['file' => $file]);
+
+        $response->assertSessionHasErrors('file');
+    }
+
+    public function test_import_dispatches_job_on_imports_queue(): void
+    {
+        Queue::fake();
+        Storage::fake();
+
+        ['user' => $user, 'tenant' => $tenant] = $this->setupTenantContext();
+
+        $csvContent = "utility_type,service_provider,bill_amount,due_date\nelectricity,PG&E,125.50,2026-04-15";
+        $file = UploadedFile::fake()->createWithContent('bills.csv', $csvContent);
+
+        $response = $this->postJson('/utility-bills/import', ['file' => $file]);
+
+        $response->assertOk();
+        $response->assertJson(['status' => 'queued']);
+
+        Queue::assertPushedOn('imports', ImportUtilityBillsCsv::class, function ($job) use ($user, $tenant) {
+            return $job->userId === $user->id && $job->tenantId === $tenant->id;
+        });
+    }
+
+    public function test_job_creates_utility_bills_from_valid_csv(): void
+    {
+        Storage::fake();
+
+        ['user' => $user, 'tenant' => $tenant] = $this->setupTenantContext();
+
+        $csvContent = implode("\n", [
+            'utility_type,service_provider,bill_amount,currency,due_date,bill_period_start,bill_period_end,payment_status,auto_pay_enabled',
+            'electricity,PG&E,125.50,MKD,2026-04-15,2026-03-01,2026-03-31,pending,false',
+            'water,City Water,45.00,MKD,2026-04-20,2026-03-01,2026-03-31,paid,true',
+        ]);
+
+        $storedPath = 'imports/'.$user->id.'/test_bills.csv';
+        Storage::put($storedPath, $csvContent);
+
+        $job = new ImportUtilityBillsCsv($user->id, $tenant->id, $storedPath);
+        $job->handle();
+
+        $this->assertDatabaseCount('utility_bills', 2);
+
+        $this->assertDatabaseHas('utility_bills', [
+            'user_id' => $user->id,
+            'tenant_id' => $tenant->id,
+            'utility_type' => 'electricity',
+            'service_provider' => 'PG&E',
+            'bill_amount' => 125.50,
+            'currency' => 'MKD',
+            'payment_status' => 'pending',
+        ]);
+
+        $this->assertDatabaseHas('utility_bills', [
+            'user_id' => $user->id,
+            'utility_type' => 'water',
+            'service_provider' => 'City Water',
+            'bill_amount' => 45.00,
+            'payment_status' => 'paid',
+        ]);
+
+        Storage::assertMissing($storedPath);
+    }
+
+    public function test_job_skips_duplicate_rows_via_unique_key(): void
+    {
+        Storage::fake();
+
+        ['user' => $user, 'tenant' => $tenant] = $this->setupTenantContext();
+
+        $csvContent = implode("\n", [
+            'utility_type,service_provider,bill_amount,due_date,bill_period_start',
+            'electricity,PG&E,125.50,2026-04-15,2026-03-01',
+        ]);
+
+        $uniqueKey = 'csv-import:'.md5('PG&E2026-03-01125.50electricity');
+
+        UtilityBill::create([
+            'user_id' => $user->id,
+            'tenant_id' => $tenant->id,
+            'utility_type' => 'electricity',
+            'service_provider' => 'PG&E',
+            'account_number' => '',
+            'service_address' => '',
+            'bill_amount' => 125.50,
+            'currency' => 'MKD',
+            'due_date' => '2026-04-15',
+            'bill_period_start' => '2026-03-01',
+            'bill_period_end' => '2026-03-31',
+            'payment_status' => 'pending',
+            'unique_key' => $uniqueKey,
+        ]);
+
+        $storedPath = 'imports/'.$user->id.'/test_bills.csv';
+        Storage::put($storedPath, $csvContent);
+
+        $job = new ImportUtilityBillsCsv($user->id, $tenant->id, $storedPath);
+        $job->handle();
+
+        $this->assertDatabaseCount('utility_bills', 1);
+    }
+
+    public function test_job_skips_duplicate_rows_matching_manually_created_bills(): void
+    {
+        Storage::fake();
+
+        ['user' => $user, 'tenant' => $tenant] = $this->setupTenantContext();
+
+        $csvContent = implode("\n", [
+            'utility_type,service_provider,bill_amount,due_date',
+            'electricity,PG&E,125.50,2026-04-15',
+        ]);
+
+        UtilityBill::create([
+            'user_id' => $user->id,
+            'tenant_id' => $tenant->id,
+            'utility_type' => 'electricity',
+            'service_provider' => 'PG&E',
+            'account_number' => '',
+            'service_address' => '',
+            'bill_amount' => 125.50,
+            'currency' => 'MKD',
+            'due_date' => '2026-04-15',
+            'bill_period_start' => '2026-03-01',
+            'bill_period_end' => '2026-03-31',
+            'payment_status' => 'pending',
+        ]);
+
+        $storedPath = 'imports/'.$user->id.'/test_bills.csv';
+        Storage::put($storedPath, $csvContent);
+
+        $job = new ImportUtilityBillsCsv($user->id, $tenant->id, $storedPath);
+        $job->handle();
+
+        $this->assertDatabaseCount('utility_bills', 1);
+    }
+
+    public function test_job_skips_rows_missing_required_fields(): void
+    {
+        Storage::fake();
+
+        ['user' => $user, 'tenant' => $tenant] = $this->setupTenantContext();
+
+        $csvContent = implode("\n", [
+            'utility_type,service_provider,bill_amount,due_date',
+            ',PG&E,125.50,2026-04-15',                       // missing utility_type
+            'electricity,,125.50,2026-04-15',                  // missing service_provider
+            'electricity,PG&E,,2026-04-15',                    // missing bill_amount
+            'electricity,PG&E,125.50,',                        // missing due_date
+            'water,City Water,45.00,2026-04-20',               // valid row
+        ]);
+
+        $storedPath = 'imports/'.$user->id.'/test_bills.csv';
+        Storage::put($storedPath, $csvContent);
+
+        $job = new ImportUtilityBillsCsv($user->id, $tenant->id, $storedPath);
+        $job->handle();
+
+        $this->assertDatabaseCount('utility_bills', 1);
+        $this->assertDatabaseHas('utility_bills', [
+            'utility_type' => 'water',
+            'service_provider' => 'City Water',
+        ]);
+    }
+
+    public function test_job_applies_defaults_for_optional_columns(): void
+    {
+        Storage::fake();
+
+        ['user' => $user, 'tenant' => $tenant] = $this->setupTenantContext();
+
+        $csvContent = implode("\n", [
+            'utility_type,service_provider,bill_amount,due_date',
+            'electricity,PG&E,125.50,2026-04-15',
+        ]);
+
+        $storedPath = 'imports/'.$user->id.'/test_bills.csv';
+        Storage::put($storedPath, $csvContent);
+
+        $job = new ImportUtilityBillsCsv($user->id, $tenant->id, $storedPath);
+        $job->handle();
+
+        $bill = UtilityBill::first();
+        $this->assertNotNull($bill);
+        $this->assertEquals('MKD', $bill->currency);
+        $this->assertEquals('pending', $bill->payment_status);
+        $this->assertFalse($bill->auto_pay_enabled);
+        $this->assertEquals('', $bill->account_number);
+        $this->assertEquals('', $bill->service_address);
+        $this->assertNull($bill->usage_amount);
+        $this->assertNull($bill->notes);
+    }
+
+    public function test_job_supports_header_aliases(): void
+    {
+        Storage::fake();
+
+        ['user' => $user, 'tenant' => $tenant] = $this->setupTenantContext();
+
+        $csvContent = implode("\n", [
+            'type,provider,amount,due',
+            'electricity,PG&E,125.50,2026-04-15',
+        ]);
+
+        $storedPath = 'imports/'.$user->id.'/test_bills.csv';
+        Storage::put($storedPath, $csvContent);
+
+        $job = new ImportUtilityBillsCsv($user->id, $tenant->id, $storedPath);
+        $job->handle();
+
+        $this->assertDatabaseCount('utility_bills', 1);
+        $this->assertDatabaseHas('utility_bills', [
+            'utility_type' => 'electricity',
+            'service_provider' => 'PG&E',
+            'bill_amount' => 125.50,
+        ]);
+    }
+
+    public function test_job_handles_empty_csv_gracefully(): void
+    {
+        Storage::fake();
+
+        ['user' => $user, 'tenant' => $tenant] = $this->setupTenantContext();
+
+        $storedPath = 'imports/'.$user->id.'/test_bills.csv';
+        Storage::put($storedPath, '');
+
+        $job = new ImportUtilityBillsCsv($user->id, $tenant->id, $storedPath);
+        $job->handle();
+
+        $this->assertDatabaseCount('utility_bills', 0);
+    }
+
+    public function test_job_handles_missing_file_gracefully(): void
+    {
+        Storage::fake();
+
+        ['user' => $user, 'tenant' => $tenant] = $this->setupTenantContext();
+
+        $job = new ImportUtilityBillsCsv($user->id, $tenant->id, 'imports/nonexistent.csv');
+        $job->handle();
+
+        $this->assertDatabaseCount('utility_bills', 0);
+    }
+
+    public function test_job_writes_progress_to_cache(): void
+    {
+        Storage::fake();
+
+        ['user' => $user, 'tenant' => $tenant] = $this->setupTenantContext();
+
+        $csvContent = implode("\n", [
+            'utility_type,service_provider,bill_amount,due_date',
+            'electricity,PG&E,125.50,2026-04-15',
+            'water,City Water,45.00,2026-04-20',
+        ]);
+
+        $storedPath = 'imports/'.$user->id.'/test_bills.csv';
+        Storage::put($storedPath, $csvContent);
+
+        $job = new ImportUtilityBillsCsv($user->id, $tenant->id, $storedPath);
+        $job->handle();
+
+        $progress = Cache::get('utility_bill_import_progress:'.$user->id);
+        $this->assertNotNull($progress);
+        $this->assertEquals('completed', $progress['status']);
+        $this->assertEquals(2, $progress['total']);
+        $this->assertEquals(2, $progress['created']);
+        $this->assertEquals(0, $progress['skipped']);
+        $this->assertEquals(0, $progress['failed']);
+    }
+
+    public function test_progress_endpoint_returns_cached_data(): void
+    {
+        ['user' => $user] = $this->setupTenantContext();
+
+        Cache::put('utility_bill_import_progress:'.$user->id, [
+            'status' => 'processing',
+            'total' => 10,
+            'created' => 5,
+            'skipped' => 1,
+            'failed' => 0,
+        ], 300);
+
+        $response = $this->getJson('/utility-bills/import/progress');
+
+        $response->assertOk();
+        $response->assertJson([
+            'status' => 'processing',
+            'total' => 10,
+            'created' => 5,
+            'skipped' => 1,
+            'failed' => 0,
+        ]);
+    }
+
+    public function test_progress_endpoint_returns_idle_when_no_import(): void
+    {
+        $this->setupTenantContext();
+
+        $response = $this->getJson('/utility-bills/import/progress');
+
+        $response->assertOk();
+        $response->assertJson(['status' => 'idle']);
+    }
+
+    public function test_progress_endpoint_requires_authentication(): void
+    {
+        $response = $this->getJson('/utility-bills/import/progress');
+
+        $response->assertUnauthorized();
+    }
+}


### PR DESCRIPTION
## Summary
- Add CSV import feature for utility bills, following the expenses CSV import pattern
- Queued job with duplicate detection (unique_key + field matching on provider/due_date/amount/utility_type)
- Progress tracking via cache with polling UI
- Migration adds `unique_key` column to utility_bills table

## Changes
- **New**: `ImportUtilityBillsCsv` job, `ImportUtilityBillCsvRequest`, Import page, 18 tests
- **New**: Migration for `unique_key` column on utility_bills
- **Modified**: `UtilityBillController` — import methods, routes, Index page button

## Test plan
- [x] All 18 import tests pass
- [ ] Upload a CSV via `/utility-bills/import` and verify bills appear
- [ ] Verify duplicate rows are skipped on re-import

🤖 Generated with [Claude Code](https://claude.com/claude-code)