### PR TITLE
feat: add cycle menu items CSV import

### DIFF
--- a/app/Http/Controllers/CycleMenuItemController.php
+++ b/app/Http/Controllers/CycleMenuItemController.php
@@ -1,13 +1,22 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Controllers;
 
 use App\Http\Requests\CycleMenus\StoreCycleMenuItemRequest;
 use App\Http\Requests\CycleMenus\UpdateCycleMenuItemRequest;
+use App\Http\Requests\ImportCycleMenuItemsCsvRequest;
+use App\Jobs\ImportCycleMenuItemsCsv;
+use App\Models\CycleMenu;
 use App\Models\CycleMenuDay;
 use App\Models\CycleMenuItem;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
+use Inertia\Inertia;
+use Inertia\Response;
 
 class CycleMenuItemController extends Controller
 {
@@ -74,5 +83,52 @@ class CycleMenuItemController extends Controller
 
         // Try to redirect back to the menu show page if referer includes it
         return back()->with('status', 'Items reordered.');
+    }
+
+    /**
+     * Show the import CSV form page.
+     */
+    public function importForm(): Response
+    {
+        $menus = CycleMenu::query()
+            ->where('user_id', auth()->id())
+            ->orderBy('name')
+            ->get(['id', 'name', 'cycle_length_days', 'is_active']);
+
+        return Inertia::render('CycleMenus/Import', [
+            'menus' => $menus,
+        ]);
+    }
+
+    /**
+     * Queue an import of cycle menu items from an uploaded CSV.
+     */
+    public function importCsv(ImportCycleMenuItemsCsvRequest $request): JsonResponse|RedirectResponse
+    {
+        $userId = auth()->id();
+        $tenantId = auth()->user()->current_tenant_id;
+        $cycleMenuId = (int) $request->validated('cycle_menu_id');
+        $file = $request->file('file');
+
+        $storedPath = $file->storeAs('imports/'.$userId, uniqid('cycle_menu_items_').'.csv');
+
+        ImportCycleMenuItemsCsv::dispatch($cycleMenuId, $userId, $tenantId, $storedPath)->onQueue('imports');
+
+        if ($request->expectsJson()) {
+            return new JsonResponse(['status' => 'queued']);
+        }
+
+        return redirect()->route('cycle-menus.index')
+            ->with('success', 'Your CSV import has been queued and will be processed shortly.');
+    }
+
+    /**
+     * Return the current import progress for the authenticated user.
+     */
+    public function importProgress(): JsonResponse
+    {
+        $progress = Cache::get('cycle_menu_items_import_progress:'.auth()->id());
+
+        return new JsonResponse($progress ?? ['status' => 'idle']);
     }
 }

--- a/app/Http/Requests/ImportCycleMenuItemsCsvRequest.php
+++ b/app/Http/Requests/ImportCycleMenuItemsCsvRequest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ImportCycleMenuItemsCsvRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, array<int, string>>
+     */
+    public function rules(): array
+    {
+        return [
+            'file' => ['required', 'file', 'mimes:csv,txt', 'max:10240'],
+            'cycle_menu_id' => ['required', 'integer', 'exists:cycle_menus,id'],
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'file.required' => 'Please upload a CSV file to import.',
+            'file.mimes' => 'The import file must be a CSV (or TXT) file.',
+            'file.max' => 'The CSV file may not be greater than 10MB.',
+            'cycle_menu_id.required' => 'Please select a cycle menu to import into.',
+            'cycle_menu_id.exists' => 'The selected cycle menu does not exist.',
+        ];
+    }
+}

--- a/app/Jobs/ImportCycleMenuItemsCsv.php
+++ b/app/Jobs/ImportCycleMenuItemsCsv.php
@@ -1,0 +1,301 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Jobs;
+
+use App\Enums\MealType;
+use App\Models\CycleMenu;
+use App\Models\CycleMenuDay;
+use App\Models\CycleMenuItem;
+use App\Scopes\TenantScope;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
+
+class ImportCycleMenuItemsCsv implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public int $timeout = 300;
+
+    public int $tries = 3;
+
+    private const HEADER_ALIASES = [
+        'day_index' => ['day', 'day_number', 'day number'],
+        'meal_type' => ['meal', 'type', 'meal type'],
+        'title' => ['name', 'item', 'item_name', 'item name', 'description'],
+        'time_of_day' => ['time', 'scheduled_time', 'scheduled time'],
+        'quantity' => ['qty', 'amount', 'serving'],
+        'notes' => ['note', 'comment', 'comments'],
+        'position' => ['order', 'sort_order', 'sort order'],
+    ];
+
+    public function __construct(
+        public int $cycleMenuId,
+        public int $userId,
+        public int $tenantId,
+        public string $storedPath,
+    ) {}
+
+    public function handle(): void
+    {
+        if (! Storage::exists($this->storedPath)) {
+            Log::error('ImportCycleMenuItemsCsv: CSV file does not exist', [
+                'user_id' => $this->userId,
+                'path' => $this->storedPath,
+            ]);
+
+            return;
+        }
+
+        $content = Storage::get($this->storedPath);
+        $lines = array_values(array_filter(explode("\n", $content), fn ($line) => trim($line) !== ''));
+
+        if (empty($lines)) {
+            Log::warning('ImportCycleMenuItemsCsv: Empty CSV file', [
+                'user_id' => $this->userId,
+                'path' => $this->storedPath,
+            ]);
+
+            return;
+        }
+
+        $header = str_getcsv(array_shift($lines));
+        if (! $header) {
+            Log::warning('ImportCycleMenuItemsCsv: Empty CSV header', [
+                'user_id' => $this->userId,
+                'path' => $this->storedPath,
+            ]);
+
+            return;
+        }
+
+        $index = $this->buildHeaderIndex($header);
+
+        $totalRows = count($lines);
+        $created = 0;
+        $skipped = 0;
+        $failed = 0;
+        $cacheKey = 'cycle_menu_items_import_progress:'.$this->userId;
+
+        $this->updateProgress($cacheKey, 'processing', $totalRows, $created, $skipped, $failed);
+
+        // Validate that the cycle menu exists
+        $cycleMenu = CycleMenu::withoutGlobalScope(TenantScope::class)
+            ->where('id', $this->cycleMenuId)
+            ->where('tenant_id', $this->tenantId)
+            ->first();
+
+        if (! $cycleMenu) {
+            Log::error('ImportCycleMenuItemsCsv: Cycle menu not found', [
+                'cycle_menu_id' => $this->cycleMenuId,
+                'tenant_id' => $this->tenantId,
+            ]);
+            $this->updateProgress($cacheKey, 'failed', $totalRows, $created, $skipped, $failed);
+
+            return;
+        }
+
+        // Collect valid meal type values
+        $validMealTypes = array_map(fn (MealType $case) => $case->value, MealType::cases());
+
+        foreach ($lines as $line) {
+            $row = str_getcsv($line);
+
+            if (count(array_filter($row, fn ($v) => $v !== null && $v !== '')) === 0) {
+                continue;
+            }
+
+            try {
+                $dayIndexRaw = (string) $this->getValue($row, $index, 'day_index');
+                $mealTypeRaw = (string) $this->getValue($row, $index, 'meal_type');
+                $title = (string) $this->getValue($row, $index, 'title');
+
+                if ($dayIndexRaw === '' || $mealTypeRaw === '' || $title === '') {
+                    $skipped++;
+                    $this->updateProgress($cacheKey, 'processing', $totalRows, $created, $skipped, $failed);
+                    Log::warning('ImportCycleMenuItemsCsv: skipped row due to missing required fields', [
+                        'day_index' => $dayIndexRaw,
+                        'meal_type' => $mealTypeRaw,
+                        'title' => $title,
+                    ]);
+
+                    continue;
+                }
+
+                // Parse day_index (CSV uses 1-based, model uses 0-based)
+                $dayIndex = (int) $dayIndexRaw - 1;
+                if ($dayIndex < 0) {
+                    $skipped++;
+                    $this->updateProgress($cacheKey, 'processing', $totalRows, $created, $skipped, $failed);
+
+                    continue;
+                }
+
+                // Normalize meal type to lowercase
+                $mealType = strtolower(trim($mealTypeRaw));
+                if (! in_array($mealType, $validMealTypes, true)) {
+                    $skipped++;
+                    $this->updateProgress($cacheKey, 'processing', $totalRows, $created, $skipped, $failed);
+                    Log::warning('ImportCycleMenuItemsCsv: invalid meal_type', [
+                        'meal_type' => $mealTypeRaw,
+                    ]);
+
+                    continue;
+                }
+
+                // Find or create the CycleMenuDay
+                $day = CycleMenuDay::withoutGlobalScope(TenantScope::class)
+                    ->firstOrCreate(
+                        [
+                            'cycle_menu_id' => $this->cycleMenuId,
+                            'day_index' => $dayIndex,
+                        ],
+                        [
+                            'tenant_id' => $this->tenantId,
+                        ]
+                    );
+
+                // Duplicate detection: skip if same day + meal_type + title already exists
+                $exists = CycleMenuItem::withoutGlobalScope(TenantScope::class)
+                    ->where('cycle_menu_day_id', $day->id)
+                    ->where('meal_type', $mealType)
+                    ->where('title', $title)
+                    ->exists();
+
+                if ($exists) {
+                    $skipped++;
+                    $this->updateProgress($cacheKey, 'processing', $totalRows, $created, $skipped, $failed);
+
+                    continue;
+                }
+
+                $timeOfDay = (string) $this->getValue($row, $index, 'time_of_day', '');
+                $quantity = (string) $this->getValue($row, $index, 'quantity', '');
+                $notes = (string) $this->getValue($row, $index, 'notes', '');
+                $positionRaw = (string) $this->getValue($row, $index, 'position', '');
+
+                // Auto-assign position if not provided
+                if ($positionRaw !== '') {
+                    $position = (int) $positionRaw;
+                } else {
+                    $maxPosition = CycleMenuItem::withoutGlobalScope(TenantScope::class)
+                        ->where('cycle_menu_day_id', $day->id)
+                        ->max('position');
+                    $position = is_null($maxPosition) ? 0 : $maxPosition + 1;
+                }
+
+                $item = new CycleMenuItem([
+                    'tenant_id' => $this->tenantId,
+                    'cycle_menu_day_id' => $day->id,
+                    'title' => $title,
+                    'meal_type' => $mealType,
+                    'time_of_day' => $timeOfDay ?: null,
+                    'quantity' => $quantity ?: null,
+                    'position' => $position,
+                ]);
+                $item->save();
+
+                $created++;
+                $this->updateProgress($cacheKey, 'processing', $totalRows, $created, $skipped, $failed);
+            } catch (\Throwable $e) {
+                $failed++;
+                $this->updateProgress($cacheKey, 'processing', $totalRows, $created, $skipped, $failed);
+                Log::error('ImportCycleMenuItemsCsv: row import failed', [
+                    'message' => $e->getMessage(),
+                    'trace' => $e->getTraceAsString(),
+                ]);
+            }
+        }
+
+        try {
+            Storage::delete($this->storedPath);
+        } catch (\Throwable $e) {
+            // Ignore cleanup errors
+        }
+
+        $this->updateProgress($cacheKey, 'completed', $totalRows, $created, $skipped, $failed);
+
+        Log::info('ImportCycleMenuItemsCsv: import finished', [
+            'user_id' => $this->userId,
+            'cycle_menu_id' => $this->cycleMenuId,
+            'created' => $created,
+            'skipped' => $skipped,
+            'failed' => $failed,
+        ]);
+    }
+
+    /**
+     * @param  array<int, string>  $header
+     * @return array<string, int>
+     */
+    private function buildHeaderIndex(array $header): array
+    {
+        $index = [];
+        foreach ($header as $i => $col) {
+            $normalized = strtolower(trim((string) $col));
+            $index[$normalized] = $i;
+        }
+
+        return $index;
+    }
+
+    /**
+     * @param  array<int, string|null>  $row
+     * @param  array<string, int>  $index
+     */
+    private function getValue(array $row, array $index, string $name, mixed $default = null): mixed
+    {
+        foreach ([$name, trim($name), strtolower($name)] as $key) {
+            if (array_key_exists($key, $index)) {
+                $pos = $index[$key];
+
+                return isset($row[$pos]) ? trim((string) $row[$pos]) : $default;
+            }
+        }
+
+        foreach ((self::HEADER_ALIASES[$name] ?? []) as $alias) {
+            $alias = strtolower($alias);
+            if (array_key_exists($alias, $index)) {
+                $pos = $index[$alias];
+
+                return isset($row[$pos]) ? trim((string) $row[$pos]) : $default;
+            }
+        }
+
+        return $default;
+    }
+
+    private function updateProgress(string $cacheKey, string $status, int $total, int $created, int $skipped, int $failed): void
+    {
+        Cache::put($cacheKey, [
+            'status' => $status,
+            'total' => $total,
+            'created' => $created,
+            'skipped' => $skipped,
+            'failed' => $failed,
+        ], 300);
+    }
+
+    public function failed(\Throwable $exception): void
+    {
+        Cache::put('cycle_menu_items_import_progress:'.$this->userId, [
+            'status' => 'failed',
+            'total' => 0,
+            'created' => 0,
+            'skipped' => 0,
+            'failed' => 0,
+            'error' => $exception->getMessage(),
+        ], 300);
+
+        Log::error('ImportCycleMenuItemsCsv failed', [
+            'exception' => $exception->getMessage(),
+        ]);
+    }
+}

--- a/resources/js/pages/CycleMenus/Import.tsx
+++ b/resources/js/pages/CycleMenus/Import.tsx
@@ -1,0 +1,346 @@
+import { Head, Link } from '@inertiajs/react'
+import { useState, useEffect, useRef, useCallback, type FormEvent, type ChangeEvent } from 'react'
+import AppLayout from '@/components/shared/app-layout'
+import { PageHeader } from '@/components/shared/page-header'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Progress } from '@/components/ui/progress'
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '@/components/ui/select'
+import { Upload, CheckCircle2, AlertCircle, Loader2 } from 'lucide-react'
+
+type ImportStage = 'idle' | 'uploading' | 'processing' | 'completed' | 'failed'
+
+interface ImportProgress {
+    status: 'idle' | 'processing' | 'completed' | 'failed'
+    total: number
+    created: number
+    skipped: number
+    failed: number
+    error?: string
+}
+
+interface CycleMenuOption {
+    id: number
+    name: string
+    cycle_length_days: number
+    is_active: boolean
+}
+
+interface CycleMenuImportProps {
+    menus: CycleMenuOption[]
+}
+
+export default function CycleMenuImport({ menus }: CycleMenuImportProps) {
+    const [file, setFile] = useState<File | null>(null)
+    const [cycleMenuId, setCycleMenuId] = useState<string>('')
+    const [stage, setStage] = useState<ImportStage>('idle')
+    const [uploadProgress, setUploadProgress] = useState(0)
+    const [importProgress, setImportProgress] = useState<ImportProgress | null>(null)
+    const [fileError, setFileError] = useState<string | null>(null)
+    const pollingRef = useRef<ReturnType<typeof setInterval> | null>(null)
+
+    const stopPolling = useCallback(() => {
+        if (pollingRef.current) {
+            clearInterval(pollingRef.current)
+            pollingRef.current = null
+        }
+    }, [])
+
+    const pollProgress = useCallback(() => {
+        pollingRef.current = setInterval(async () => {
+            try {
+                const response = await fetch('/cycle-menu-items/import/progress')
+                const data: ImportProgress = await response.json()
+
+                if (data.status === 'processing' || data.status === 'completed' || data.status === 'failed') {
+                    setImportProgress(data)
+                }
+
+                if (data.status === 'completed') {
+                    setStage('completed')
+                    stopPolling()
+                } else if (data.status === 'failed') {
+                    setStage('failed')
+                    stopPolling()
+                }
+            } catch {
+                // Ignore transient fetch errors, retry on next tick
+            }
+        }, 2000)
+    }, [stopPolling])
+
+    useEffect(() => {
+        return () => stopPolling()
+    }, [stopPolling])
+
+    function handleFileChange(e: ChangeEvent<HTMLInputElement>) {
+        setFile(e.target.files?.[0] ?? null)
+        setFileError(null)
+    }
+
+    function handleSubmit(e: FormEvent) {
+        e.preventDefault()
+        if (!file || !cycleMenuId) return
+
+        setStage('uploading')
+        setFileError(null)
+
+        const formData = new FormData()
+        formData.append('file', file)
+        formData.append('cycle_menu_id', cycleMenuId)
+
+        const xsrfToken = decodeURIComponent(
+            document.cookie.split('; ').find(row => row.startsWith('XSRF-TOKEN='))?.split('=')[1] ?? ''
+        )
+
+        const xhr = new XMLHttpRequest()
+        xhr.open('POST', '/cycle-menu-items/import')
+        xhr.setRequestHeader('X-XSRF-TOKEN', xsrfToken)
+        xhr.setRequestHeader('Accept', 'application/json')
+        xhr.setRequestHeader('X-Requested-With', 'XMLHttpRequest')
+
+        xhr.upload.onprogress = (event) => {
+            if (event.lengthComputable) {
+                setUploadProgress(Math.round((event.loaded / event.total) * 100))
+            }
+        }
+
+        xhr.onload = () => {
+            if (xhr.status >= 200 && xhr.status < 300) {
+                setStage('processing')
+                setUploadProgress(100)
+                pollProgress()
+            } else {
+                setStage('idle')
+                try {
+                    const errorData = JSON.parse(xhr.responseText)
+                    setFileError(errorData.errors?.file?.[0] ?? errorData.errors?.cycle_menu_id?.[0] ?? errorData.message ?? 'Upload failed.')
+                } catch {
+                    setFileError('Upload failed. Please try again.')
+                }
+            }
+        }
+
+        xhr.onerror = () => {
+            setStage('idle')
+            setFileError('Network error. Please try again.')
+        }
+
+        xhr.send(formData)
+    }
+
+    const processed = importProgress
+        ? importProgress.created + importProgress.skipped + importProgress.failed
+        : 0
+    const progressPercent = importProgress && importProgress.total > 0
+        ? Math.round((processed / importProgress.total) * 100)
+        : 0
+
+    return (
+        <AppLayout>
+            <Head title="Import Cycle Menu Items" />
+
+            <PageHeader title="Import Cycle Menu Items" description="Upload a CSV file to bulk import items into a cycle menu">
+                <Button variant="outline" asChild>
+                    <Link href="/cycle-menus">Back to Menus</Link>
+                </Button>
+            </PageHeader>
+
+            <Card className="mx-auto max-w-2xl">
+                <CardHeader>
+                    <CardTitle>CSV Import</CardTitle>
+                </CardHeader>
+                <CardContent>
+                    {stage === 'idle' || stage === 'uploading' ? (
+                        <form onSubmit={handleSubmit} className="space-y-6">
+                            <div className="space-y-2">
+                                <Label htmlFor="cycle_menu_id">Cycle Menu</Label>
+                                <Select value={cycleMenuId} onValueChange={setCycleMenuId} disabled={stage === 'uploading'}>
+                                    <SelectTrigger>
+                                        <SelectValue placeholder="Select a cycle menu..." />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                        {menus.map(menu => (
+                                            <SelectItem key={menu.id} value={String(menu.id)}>
+                                                {menu.name} ({menu.cycle_length_days} days){menu.is_active ? ' - Active' : ''}
+                                            </SelectItem>
+                                        ))}
+                                    </SelectContent>
+                                </Select>
+                            </div>
+
+                            <div className="space-y-2">
+                                <Label htmlFor="file">CSV File</Label>
+                                <div className="flex items-center gap-4">
+                                    <Input
+                                        id="file"
+                                        type="file"
+                                        accept=".csv"
+                                        onChange={handleFileChange}
+                                        className="flex-1"
+                                        disabled={stage === 'uploading'}
+                                    />
+                                </div>
+                                {fileError ? (
+                                    <p className="text-sm text-destructive">{fileError}</p>
+                                ) : null}
+                                {stage === 'uploading' ? (
+                                    <div className="mt-2">
+                                        <Progress value={uploadProgress} />
+                                        <p className="mt-1 text-xs text-muted-foreground">{uploadProgress}% uploaded</p>
+                                    </div>
+                                ) : null}
+                            </div>
+
+                            <div className="rounded-md border border-border bg-muted p-4">
+                                <h3 className="mb-2 text-sm font-medium">Expected CSV Format</h3>
+                                <p className="text-xs text-muted-foreground">
+                                    Your CSV file should include the following columns. Required columns are marked with *.
+                                </p>
+                                <div className="mt-2 space-y-1">
+                                    <code className="block text-xs text-muted-foreground">
+                                        day_index*, meal_type*, title*
+                                    </code>
+                                    <code className="block text-xs text-muted-foreground">
+                                        time_of_day, quantity, notes, position
+                                    </code>
+                                </div>
+                                <p className="mt-3 text-xs text-muted-foreground">
+                                    <strong>Notes:</strong> day_index is 1-based (Day 1 = first day). meal_type must be one of: Breakfast, Lunch, Dinner, Snack, Other.
+                                </p>
+                                <p className="mt-3 text-xs text-muted-foreground">
+                                    <strong>Example rows:</strong>
+                                </p>
+                                <code className="mt-1 block text-xs text-muted-foreground">
+                                    day_index,meal_type,title,time_of_day,quantity,notes
+                                </code>
+                                <code className="mt-1 block text-xs text-muted-foreground">
+                                    1,Breakfast,Oatmeal with berries,08:00,1 serving,High fiber
+                                </code>
+                                <code className="mt-1 block text-xs text-muted-foreground">
+                                    1,Lunch,Grilled chicken salad,12:30,1 serving,
+                                </code>
+                                <code className="mt-1 block text-xs text-muted-foreground">
+                                    2,Breakfast,Scrambled eggs,08:00,2 servings,With toast
+                                </code>
+                            </div>
+
+                            <div className="flex justify-end gap-3">
+                                <Button type="button" variant="outline" asChild>
+                                    <Link href="/cycle-menus">Cancel</Link>
+                                </Button>
+                                <Button type="submit" disabled={stage === 'uploading' || !file || !cycleMenuId}>
+                                    <Upload className="mr-2 h-4 w-4" />
+                                    {stage === 'uploading' ? 'Uploading...' : 'Import CSV'}
+                                </Button>
+                            </div>
+                        </form>
+                    ) : null}
+
+                    {stage === 'processing' ? (
+                        <div className="space-y-6">
+                            <div className="flex items-center gap-3">
+                                <Loader2 className="h-5 w-5 animate-spin text-primary" />
+                                <p className="text-sm font-medium">
+                                    {importProgress ? 'Processing your import...' : 'Waiting for import to start...'}
+                                </p>
+                            </div>
+
+                            {importProgress ? (
+                                <>
+                                    <Progress value={progressPercent} />
+
+                                    <div className="grid grid-cols-3 gap-4 text-center">
+                                        <div>
+                                            <p className="text-2xl font-bold text-primary">{importProgress.created}</p>
+                                            <p className="text-xs text-muted-foreground">Created</p>
+                                        </div>
+                                        <div>
+                                            <p className="text-2xl font-bold text-muted-foreground">{importProgress.skipped}</p>
+                                            <p className="text-xs text-muted-foreground">Skipped</p>
+                                        </div>
+                                        <div>
+                                            <p className="text-2xl font-bold text-destructive">{importProgress.failed}</p>
+                                            <p className="text-xs text-muted-foreground">Failed</p>
+                                        </div>
+                                    </div>
+
+                                    <p className="text-xs text-muted-foreground text-center">
+                                        {processed} of {importProgress.total} rows processed ({progressPercent}%)
+                                    </p>
+                                </>
+                            ) : (
+                                <p className="text-xs text-muted-foreground text-center">
+                                    Your import has been queued. Make sure the queue worker is running.
+                                </p>
+                            )}
+                        </div>
+                    ) : null}
+
+                    {stage === 'completed' ? (
+                        <div className="space-y-6">
+                            <div className="flex items-center gap-3">
+                                <CheckCircle2 className="h-5 w-5 text-green-600" />
+                                <p className="text-sm font-medium">Import completed!</p>
+                            </div>
+
+                            <div className="grid grid-cols-3 gap-4 text-center">
+                                <div>
+                                    <p className="text-2xl font-bold text-primary">{importProgress?.created ?? 0}</p>
+                                    <p className="text-xs text-muted-foreground">Created</p>
+                                </div>
+                                <div>
+                                    <p className="text-2xl font-bold text-muted-foreground">{importProgress?.skipped ?? 0}</p>
+                                    <p className="text-xs text-muted-foreground">Skipped</p>
+                                </div>
+                                <div>
+                                    <p className="text-2xl font-bold text-destructive">{importProgress?.failed ?? 0}</p>
+                                    <p className="text-xs text-muted-foreground">Failed</p>
+                                </div>
+                            </div>
+
+                            <div className="flex justify-end gap-3">
+                                <Button variant="outline" onClick={() => { setStage('idle'); setFile(null); setImportProgress(null) }}>
+                                    Import Another
+                                </Button>
+                                <Button asChild>
+                                    <Link href="/cycle-menus">View Cycle Menus</Link>
+                                </Button>
+                            </div>
+                        </div>
+                    ) : null}
+
+                    {stage === 'failed' ? (
+                        <div className="space-y-6">
+                            <div className="flex items-center gap-3">
+                                <AlertCircle className="h-5 w-5 text-destructive" />
+                                <p className="text-sm font-medium">Import failed</p>
+                            </div>
+
+                            <p className="text-sm text-muted-foreground">
+                                {importProgress?.error ?? 'An unexpected error occurred while processing the import.'}
+                            </p>
+
+                            <div className="flex justify-end gap-3">
+                                <Button variant="outline" onClick={() => { setStage('idle'); setFile(null); setImportProgress(null) }}>
+                                    Try Again
+                                </Button>
+                                <Button variant="outline" asChild>
+                                    <Link href="/cycle-menus">Back to Menus</Link>
+                                </Button>
+                            </div>
+                        </div>
+                    ) : null}
+                </CardContent>
+            </Card>
+        </AppLayout>
+    )
+}

--- a/resources/js/pages/CycleMenus/Index.tsx
+++ b/resources/js/pages/CycleMenus/Index.tsx
@@ -21,7 +21,7 @@ import {
     DropdownMenuItem,
     DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
-import { UtensilsCrossed, Plus, MoreHorizontal, Eye, Pencil, Trash2 } from 'lucide-react'
+import { UtensilsCrossed, Plus, MoreHorizontal, Eye, Pencil, Trash2, Upload } from 'lucide-react'
 import { formatDate } from '@/lib/utils'
 import type { CycleMenu } from '@/types/models'
 import type { PaginatedData } from '@/types'
@@ -45,6 +45,12 @@ export default function CycleMenuIndex({ menus }: CycleMenuIndexProps) {
             <Head title="Cycle Menus" />
 
             <PageHeader title="Cycle Menus" description="Plan meals in repeating cycles and see each day's items">
+                <Button variant="outline" asChild>
+                    <Link href="/cycle-menu-items/import">
+                        <Upload className="mr-2 h-4 w-4" />
+                        Import CSV
+                    </Link>
+                </Button>
                 <Button asChild>
                     <Link href="/cycle-menus/create">
                         <Plus className="mr-2 h-4 w-4" />

--- a/resources/js/pages/CycleMenus/Show.tsx
+++ b/resources/js/pages/CycleMenus/Show.tsx
@@ -14,7 +14,7 @@ import {
     SelectTrigger,
     SelectValue,
 } from '@/components/ui/select'
-import { Pencil, Trash2, ArrowLeft, Plus, GripVertical, X } from 'lucide-react'
+import { Pencil, Trash2, ArrowLeft, Plus, GripVertical, X, Upload } from 'lucide-react'
 import { formatDate } from '@/lib/utils'
 import { MealType } from '@/types/enums'
 import type { CycleMenu, CycleMenuDay, CycleMenuItem } from '@/types/models'
@@ -338,6 +338,11 @@ export default function CycleMenuShow({ menu, daysByIndex }: CycleMenuShowProps)
                 <Button variant="outline" size="sm" asChild>
                     <Link href={`/cycle-menus/${menu.id}/edit`}>
                         <Pencil className="mr-2 h-4 w-4" /> Edit
+                    </Link>
+                </Button>
+                <Button variant="outline" size="sm" asChild>
+                    <Link href="/cycle-menu-items/import">
+                        <Upload className="mr-2 h-4 w-4" /> Import CSV
                     </Link>
                 </Button>
                 <StatusBadge status={menu.is_active ? 'active' : 'paused'} />

--- a/routes/web.php
+++ b/routes/web.php
@@ -356,6 +356,9 @@ Route::middleware('auth')->group(function () {
         // Cycle Menu Routes
         Route::resource('cycle-menus', CycleMenuController::class);
         Route::put('cycle-menu-days/{cycle_menu_day}', [CycleMenuDayController::class, 'update'])->name('cycle-menu-days.update');
+        Route::get('cycle-menu-items/import', [CycleMenuItemController::class, 'importForm'])->name('cycle-menu-items.import');
+        Route::post('cycle-menu-items/import', [CycleMenuItemController::class, 'importCsv'])->name('cycle-menu-items.import-csv');
+        Route::get('cycle-menu-items/import/progress', [CycleMenuItemController::class, 'importProgress'])->name('cycle-menu-items.import-progress');
         Route::prefix('cycle-menu-items')->name('cycle-menu-items.')->group(function () {
             Route::post('/', [CycleMenuItemController::class, 'store'])->name('store');
             Route::put('{cycle_menu_item}', [CycleMenuItemController::class, 'update'])->name('update');

--- a/tests/Feature/ImportCycleMenuItemsCsvTest.php
+++ b/tests/Feature/ImportCycleMenuItemsCsvTest.php
@@ -1,0 +1,510 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Jobs\ImportCycleMenuItemsCsv;
+use App\Models\CycleMenu;
+use App\Models\CycleMenuDay;
+use App\Models\CycleMenuItem;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class ImportCycleMenuItemsCsvTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_import_form_requires_authentication(): void
+    {
+        $response = $this->get('/cycle-menu-items/import');
+
+        $response->assertRedirect('/login');
+    }
+
+    public function test_import_form_renders_for_authenticated_user(): void
+    {
+        $this->setupTenantContext();
+
+        $response = $this->get('/cycle-menu-items/import');
+
+        $response->assertStatus(200);
+        $response->assertInertia(fn ($page) => $page->component('CycleMenus/Import'));
+    }
+
+    public function test_import_requires_a_file(): void
+    {
+        ['tenant' => $tenant] = $this->setupTenantContext();
+
+        $menu = CycleMenu::factory()->create(['tenant_id' => $tenant->id]);
+
+        $response = $this->post('/cycle-menu-items/import', ['cycle_menu_id' => $menu->id]);
+
+        $response->assertSessionHasErrors('file');
+    }
+
+    public function test_import_requires_cycle_menu_id(): void
+    {
+        $this->setupTenantContext();
+
+        $csvContent = "day_index,meal_type,title\n1,Breakfast,Oatmeal";
+        $file = UploadedFile::fake()->createWithContent('items.csv', $csvContent);
+
+        $response = $this->post('/cycle-menu-items/import', ['file' => $file]);
+
+        $response->assertSessionHasErrors('cycle_menu_id');
+    }
+
+    public function test_import_rejects_non_csv_file(): void
+    {
+        ['tenant' => $tenant] = $this->setupTenantContext();
+
+        $menu = CycleMenu::factory()->create(['tenant_id' => $tenant->id]);
+        $file = UploadedFile::fake()->create('items.pdf', 100, 'application/pdf');
+
+        $response = $this->post('/cycle-menu-items/import', [
+            'file' => $file,
+            'cycle_menu_id' => $menu->id,
+        ]);
+
+        $response->assertSessionHasErrors('file');
+    }
+
+    public function test_import_rejects_file_exceeding_max_size(): void
+    {
+        ['tenant' => $tenant] = $this->setupTenantContext();
+
+        $menu = CycleMenu::factory()->create(['tenant_id' => $tenant->id]);
+        $file = UploadedFile::fake()->create('items.csv', 11000, 'text/csv');
+
+        $response = $this->post('/cycle-menu-items/import', [
+            'file' => $file,
+            'cycle_menu_id' => $menu->id,
+        ]);
+
+        $response->assertSessionHasErrors('file');
+    }
+
+    public function test_import_dispatches_job_on_imports_queue(): void
+    {
+        Queue::fake();
+        Storage::fake();
+
+        ['user' => $user, 'tenant' => $tenant] = $this->setupTenantContext();
+
+        $menu = CycleMenu::factory()->create([
+            'user_id' => $user->id,
+            'tenant_id' => $tenant->id,
+        ]);
+
+        $csvContent = "day_index,meal_type,title\n1,Breakfast,Oatmeal";
+        $file = UploadedFile::fake()->createWithContent('items.csv', $csvContent);
+
+        $response = $this->postJson('/cycle-menu-items/import', [
+            'file' => $file,
+            'cycle_menu_id' => $menu->id,
+        ]);
+
+        $response->assertOk();
+        $response->assertJson(['status' => 'queued']);
+
+        Queue::assertPushedOn('imports', ImportCycleMenuItemsCsv::class, function ($job) use ($user, $tenant, $menu) {
+            return $job->userId === $user->id
+                && $job->tenantId === $tenant->id
+                && $job->cycleMenuId === $menu->id;
+        });
+    }
+
+    public function test_job_creates_items_from_valid_csv(): void
+    {
+        Storage::fake();
+
+        ['user' => $user, 'tenant' => $tenant] = $this->setupTenantContext();
+
+        $menu = CycleMenu::factory()->create([
+            'user_id' => $user->id,
+            'tenant_id' => $tenant->id,
+            'cycle_length_days' => 7,
+        ]);
+
+        $csvContent = implode("\n", [
+            'day_index,meal_type,title,time_of_day,quantity,notes',
+            '1,Breakfast,Oatmeal with berries,08:00,1 serving,High fiber',
+            '1,Lunch,Grilled chicken salad,12:30,1 serving,',
+            '2,Breakfast,Scrambled eggs,08:00,2 servings,With toast',
+        ]);
+
+        $storedPath = 'imports/'.$user->id.'/test_items.csv';
+        Storage::put($storedPath, $csvContent);
+
+        $job = new ImportCycleMenuItemsCsv($menu->id, $user->id, $tenant->id, $storedPath);
+        $job->handle();
+
+        $this->assertDatabaseCount('cycle_menu_items', 3);
+
+        // Day 1 (day_index=0) should exist with 2 items
+        $day0 = CycleMenuDay::where('cycle_menu_id', $menu->id)->where('day_index', 0)->first();
+        $this->assertNotNull($day0);
+        $this->assertEquals(2, CycleMenuItem::where('cycle_menu_day_id', $day0->id)->count());
+
+        // Day 2 (day_index=1) should exist with 1 item
+        $day1 = CycleMenuDay::where('cycle_menu_id', $menu->id)->where('day_index', 1)->first();
+        $this->assertNotNull($day1);
+        $this->assertEquals(1, CycleMenuItem::where('cycle_menu_day_id', $day1->id)->count());
+
+        $this->assertDatabaseHas('cycle_menu_items', [
+            'cycle_menu_day_id' => $day0->id,
+            'title' => 'Oatmeal with berries',
+            'meal_type' => 'breakfast',
+            'time_of_day' => '08:00',
+            'quantity' => '1 serving',
+        ]);
+
+        $this->assertDatabaseHas('cycle_menu_items', [
+            'cycle_menu_day_id' => $day1->id,
+            'title' => 'Scrambled eggs',
+            'meal_type' => 'breakfast',
+        ]);
+
+        Storage::assertMissing($storedPath);
+    }
+
+    public function test_job_skips_duplicate_rows(): void
+    {
+        Storage::fake();
+
+        ['user' => $user, 'tenant' => $tenant] = $this->setupTenantContext();
+
+        $menu = CycleMenu::factory()->create([
+            'user_id' => $user->id,
+            'tenant_id' => $tenant->id,
+        ]);
+
+        $day = CycleMenuDay::factory()->create([
+            'cycle_menu_id' => $menu->id,
+            'day_index' => 0,
+            'tenant_id' => $tenant->id,
+        ]);
+
+        CycleMenuItem::factory()->create([
+            'cycle_menu_day_id' => $day->id,
+            'title' => 'Oatmeal with berries',
+            'meal_type' => 'breakfast',
+            'tenant_id' => $tenant->id,
+        ]);
+
+        $csvContent = implode("\n", [
+            'day_index,meal_type,title',
+            '1,Breakfast,Oatmeal with berries',
+        ]);
+
+        $storedPath = 'imports/'.$user->id.'/test_items.csv';
+        Storage::put($storedPath, $csvContent);
+
+        $job = new ImportCycleMenuItemsCsv($menu->id, $user->id, $tenant->id, $storedPath);
+        $job->handle();
+
+        $this->assertDatabaseCount('cycle_menu_items', 1);
+    }
+
+    public function test_job_skips_rows_missing_required_fields(): void
+    {
+        Storage::fake();
+
+        ['user' => $user, 'tenant' => $tenant] = $this->setupTenantContext();
+
+        $menu = CycleMenu::factory()->create([
+            'user_id' => $user->id,
+            'tenant_id' => $tenant->id,
+        ]);
+
+        $csvContent = implode("\n", [
+            'day_index,meal_type,title',
+            ',Breakfast,Oatmeal',        // missing day_index
+            '1,,Oatmeal',                // missing meal_type
+            '1,Breakfast,',              // missing title
+            '1,Breakfast,Valid item',    // valid row
+        ]);
+
+        $storedPath = 'imports/'.$user->id.'/test_items.csv';
+        Storage::put($storedPath, $csvContent);
+
+        $job = new ImportCycleMenuItemsCsv($menu->id, $user->id, $tenant->id, $storedPath);
+        $job->handle();
+
+        $this->assertDatabaseCount('cycle_menu_items', 1);
+        $this->assertDatabaseHas('cycle_menu_items', [
+            'title' => 'Valid item',
+        ]);
+    }
+
+    public function test_job_skips_invalid_meal_type(): void
+    {
+        Storage::fake();
+
+        ['user' => $user, 'tenant' => $tenant] = $this->setupTenantContext();
+
+        $menu = CycleMenu::factory()->create([
+            'user_id' => $user->id,
+            'tenant_id' => $tenant->id,
+        ]);
+
+        $csvContent = implode("\n", [
+            'day_index,meal_type,title',
+            '1,InvalidMeal,Oatmeal',
+            '1,Breakfast,Valid item',
+        ]);
+
+        $storedPath = 'imports/'.$user->id.'/test_items.csv';
+        Storage::put($storedPath, $csvContent);
+
+        $job = new ImportCycleMenuItemsCsv($menu->id, $user->id, $tenant->id, $storedPath);
+        $job->handle();
+
+        $this->assertDatabaseCount('cycle_menu_items', 1);
+        $this->assertDatabaseHas('cycle_menu_items', ['title' => 'Valid item']);
+    }
+
+    public function test_job_supports_header_aliases(): void
+    {
+        Storage::fake();
+
+        ['user' => $user, 'tenant' => $tenant] = $this->setupTenantContext();
+
+        $menu = CycleMenu::factory()->create([
+            'user_id' => $user->id,
+            'tenant_id' => $tenant->id,
+        ]);
+
+        $csvContent = implode("\n", [
+            'day,meal,name,time,qty',
+            '1,Breakfast,Oatmeal with berries,08:00,1 serving',
+        ]);
+
+        $storedPath = 'imports/'.$user->id.'/test_items.csv';
+        Storage::put($storedPath, $csvContent);
+
+        $job = new ImportCycleMenuItemsCsv($menu->id, $user->id, $tenant->id, $storedPath);
+        $job->handle();
+
+        $this->assertDatabaseCount('cycle_menu_items', 1);
+        $this->assertDatabaseHas('cycle_menu_items', [
+            'title' => 'Oatmeal with berries',
+            'meal_type' => 'breakfast',
+            'time_of_day' => '08:00',
+            'quantity' => '1 serving',
+        ]);
+    }
+
+    public function test_job_finds_or_creates_cycle_menu_days(): void
+    {
+        Storage::fake();
+
+        ['user' => $user, 'tenant' => $tenant] = $this->setupTenantContext();
+
+        $menu = CycleMenu::factory()->create([
+            'user_id' => $user->id,
+            'tenant_id' => $tenant->id,
+            'cycle_length_days' => 7,
+        ]);
+
+        // Pre-create day 0
+        CycleMenuDay::factory()->create([
+            'cycle_menu_id' => $menu->id,
+            'day_index' => 0,
+            'tenant_id' => $tenant->id,
+        ]);
+
+        $csvContent = implode("\n", [
+            'day_index,meal_type,title',
+            '1,Breakfast,Day 1 item',
+            '3,Lunch,Day 3 item',
+        ]);
+
+        $storedPath = 'imports/'.$user->id.'/test_items.csv';
+        Storage::put($storedPath, $csvContent);
+
+        $job = new ImportCycleMenuItemsCsv($menu->id, $user->id, $tenant->id, $storedPath);
+        $job->handle();
+
+        // Day 0 already existed, day 2 should be created for CSV day_index=3
+        $this->assertDatabaseHas('cycle_menu_days', [
+            'cycle_menu_id' => $menu->id,
+            'day_index' => 0,
+        ]);
+        $this->assertDatabaseHas('cycle_menu_days', [
+            'cycle_menu_id' => $menu->id,
+            'day_index' => 2,
+        ]);
+        $this->assertDatabaseCount('cycle_menu_items', 2);
+    }
+
+    public function test_job_handles_empty_csv_gracefully(): void
+    {
+        Storage::fake();
+
+        ['user' => $user, 'tenant' => $tenant] = $this->setupTenantContext();
+
+        $menu = CycleMenu::factory()->create([
+            'user_id' => $user->id,
+            'tenant_id' => $tenant->id,
+        ]);
+
+        $storedPath = 'imports/'.$user->id.'/test_items.csv';
+        Storage::put($storedPath, '');
+
+        $job = new ImportCycleMenuItemsCsv($menu->id, $user->id, $tenant->id, $storedPath);
+        $job->handle();
+
+        $this->assertDatabaseCount('cycle_menu_items', 0);
+    }
+
+    public function test_job_handles_missing_file_gracefully(): void
+    {
+        Storage::fake();
+
+        ['user' => $user, 'tenant' => $tenant] = $this->setupTenantContext();
+
+        $menu = CycleMenu::factory()->create([
+            'user_id' => $user->id,
+            'tenant_id' => $tenant->id,
+        ]);
+
+        $job = new ImportCycleMenuItemsCsv($menu->id, $user->id, $tenant->id, 'imports/nonexistent.csv');
+        $job->handle();
+
+        $this->assertDatabaseCount('cycle_menu_items', 0);
+    }
+
+    public function test_job_writes_progress_to_cache(): void
+    {
+        Storage::fake();
+
+        ['user' => $user, 'tenant' => $tenant] = $this->setupTenantContext();
+
+        $menu = CycleMenu::factory()->create([
+            'user_id' => $user->id,
+            'tenant_id' => $tenant->id,
+        ]);
+
+        $csvContent = implode("\n", [
+            'day_index,meal_type,title',
+            '1,Breakfast,Oatmeal',
+            '1,Lunch,Salad',
+        ]);
+
+        $storedPath = 'imports/'.$user->id.'/test_items.csv';
+        Storage::put($storedPath, $csvContent);
+
+        $job = new ImportCycleMenuItemsCsv($menu->id, $user->id, $tenant->id, $storedPath);
+        $job->handle();
+
+        $progress = Cache::get('cycle_menu_items_import_progress:'.$user->id);
+        $this->assertNotNull($progress);
+        $this->assertEquals('completed', $progress['status']);
+        $this->assertEquals(2, $progress['total']);
+        $this->assertEquals(2, $progress['created']);
+        $this->assertEquals(0, $progress['skipped']);
+        $this->assertEquals(0, $progress['failed']);
+    }
+
+    public function test_progress_endpoint_returns_cached_data(): void
+    {
+        ['user' => $user] = $this->setupTenantContext();
+
+        Cache::put('cycle_menu_items_import_progress:'.$user->id, [
+            'status' => 'processing',
+            'total' => 10,
+            'created' => 5,
+            'skipped' => 1,
+            'failed' => 0,
+        ], 300);
+
+        $response = $this->getJson('/cycle-menu-items/import/progress');
+
+        $response->assertOk();
+        $response->assertJson([
+            'status' => 'processing',
+            'total' => 10,
+            'created' => 5,
+            'skipped' => 1,
+            'failed' => 0,
+        ]);
+    }
+
+    public function test_progress_endpoint_returns_idle_when_no_import(): void
+    {
+        $this->setupTenantContext();
+
+        $response = $this->getJson('/cycle-menu-items/import/progress');
+
+        $response->assertOk();
+        $response->assertJson(['status' => 'idle']);
+    }
+
+    public function test_progress_endpoint_requires_authentication(): void
+    {
+        $response = $this->getJson('/cycle-menu-items/import/progress');
+
+        $response->assertUnauthorized();
+    }
+
+    public function test_job_auto_assigns_position_when_not_provided(): void
+    {
+        Storage::fake();
+
+        ['user' => $user, 'tenant' => $tenant] = $this->setupTenantContext();
+
+        $menu = CycleMenu::factory()->create([
+            'user_id' => $user->id,
+            'tenant_id' => $tenant->id,
+        ]);
+
+        $csvContent = implode("\n", [
+            'day_index,meal_type,title',
+            '1,Breakfast,First item',
+            '1,Lunch,Second item',
+            '1,Dinner,Third item',
+        ]);
+
+        $storedPath = 'imports/'.$user->id.'/test_items.csv';
+        Storage::put($storedPath, $csvContent);
+
+        $job = new ImportCycleMenuItemsCsv($menu->id, $user->id, $tenant->id, $storedPath);
+        $job->handle();
+
+        $items = CycleMenuItem::orderBy('position')->get();
+        $this->assertCount(3, $items);
+        $this->assertEquals(0, $items[0]->position);
+        $this->assertEquals(1, $items[1]->position);
+        $this->assertEquals(2, $items[2]->position);
+    }
+
+    public function test_job_handles_nonexistent_cycle_menu(): void
+    {
+        Storage::fake();
+
+        ['user' => $user, 'tenant' => $tenant] = $this->setupTenantContext();
+
+        $csvContent = implode("\n", [
+            'day_index,meal_type,title',
+            '1,Breakfast,Oatmeal',
+        ]);
+
+        $storedPath = 'imports/'.$user->id.'/test_items.csv';
+        Storage::put($storedPath, $csvContent);
+
+        $job = new ImportCycleMenuItemsCsv(99999, $user->id, $tenant->id, $storedPath);
+        $job->handle();
+
+        $this->assertDatabaseCount('cycle_menu_items', 0);
+
+        $progress = Cache::get('cycle_menu_items_import_progress:'.$user->id);
+        $this->assertNotNull($progress);
+        $this->assertEquals('failed', $progress['status']);
+    }
+}


### PR DESCRIPTION
## Summary
- Add CSV import feature for cycle menu items, following the expenses CSV import pattern
- Users select a cycle menu from a dropdown, then upload a CSV to bulk-populate meals
- Job finds/creates CycleMenuDay records by day_index, creates CycleMenuItem records
- Duplicate detection skips rows with same day + meal_type + title
- Progress tracking via cache with polling UI

## Changes
- **New**: `ImportCycleMenuItemsCsv` job, `ImportCycleMenuItemsCsvRequest`, Import page, 21 tests
- **Modified**: `CycleMenuItemController` — import methods
- **Modified**: `routes/web.php` — import routes
- **Modified**: CycleMenus Index + Show pages — Import CSV buttons

## CSV Format
```
day_index,meal_type,title,time_of_day,quantity,notes
1,Breakfast,Oatmeal with berries,08:00,1,High fiber
1,Lunch,Grilled chicken salad,12:30,1,
2,Dinner,Pasta primavera,19:00,1,Vegetarian
```

## Test plan
- [x] All 21 import tests pass
- [ ] Upload a CSV via cycle menu import page and verify items appear
- [ ] Verify duplicate rows are skipped on re-import

🤖 Generated with [Claude Code](https://claude.com/claude-code)