### PR TITLE
feat(agents): Phase 2 — Pending Actions queue + Expenses write tools

### DIFF
--- a/app/Ai/Tools/CreateExpense.php
+++ b/app/Ai/Tools/CreateExpense.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 
 namespace App\Ai\Tools;
 
-use App\Models\Expense;
+use App\Models\User;
+use App\Services\Expenses\ExpenseService;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Illuminate\Support\Arr;
 use Laravel\Ai\Tools\Request;
@@ -59,11 +60,8 @@ class CreateExpense extends TenantScopedTool
             return $validated;
         }
 
-        Expense::create([
-            'user_id' => $this->userId,
-            'tenant_id' => $this->tenantId,
-            ...$validated,
-        ]);
+        $user = User::findOrFail($this->userId);
+        app(ExpenseService::class)->create($user, $validated);
 
         $merchantDisplay = $validated['merchant'] ?? 'Unknown';
 

--- a/app/Http/Controllers/ExpenseController.php
+++ b/app/Http/Controllers/ExpenseController.php
@@ -9,6 +9,7 @@ use App\Jobs\ImportExpensesCsv;
 use App\Models\Budget;
 use App\Models\Expense;
 use App\Services\CurrencyService;
+use App\Services\Expenses\ExpenseService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Cache;
@@ -17,12 +18,10 @@ use Inertia\Inertia;
 
 class ExpenseController extends Controller
 {
-    protected CurrencyService $currencyService;
-
-    public function __construct(CurrencyService $currencyService)
-    {
-        $this->currencyService = $currencyService;
-    }
+    public function __construct(
+        protected CurrencyService $currencyService,
+        protected ExpenseService $expenseService,
+    ) {}
 
     /**
      * Display a listing of the resource.
@@ -106,10 +105,7 @@ class ExpenseController extends Controller
      */
     public function store(StoreExpenseRequest $request)
     {
-        $expense = Expense::create([
-            'user_id' => auth()->id(),
-            ...$request->validated(),
-        ]);
+        $expense = $this->expenseService->create(auth()->user(), $request->validated());
 
         return redirect()->route('expenses.show', $expense)
             ->with('success', 'Expense created successfully!');
@@ -157,7 +153,7 @@ class ExpenseController extends Controller
             abort(403, 'Unauthorized access to expense.');
         }
 
-        $expense->update($request->validated());
+        $this->expenseService->update($expense, $request->validated());
 
         return redirect()->route('expenses.show', $expense)
             ->with('success', 'Expense updated successfully!');
@@ -173,7 +169,7 @@ class ExpenseController extends Controller
             abort(403, 'Unauthorized access to expense.');
         }
 
-        $expense->delete();
+        $this->expenseService->delete($expense);
 
         return redirect()->route('expenses.index')
             ->with('success', 'Expense deleted successfully!');
@@ -189,7 +185,7 @@ class ExpenseController extends Controller
             abort(403, 'Unauthorized access to expense.');
         }
 
-        $expense->update(['status' => 'reimbursed']);
+        $this->expenseService->markReimbursed($expense);
 
         return redirect()->route('expenses.show', $expense)
             ->with('success', 'Expense marked as reimbursed!');
@@ -297,10 +293,7 @@ class ExpenseController extends Controller
             abort(403, 'Unauthorized access to expense.');
         }
 
-        $newExpense = $expense->replicate();
-        $newExpense->expense_date = now()->toDateString();
-        $newExpense->status = 'pending';
-        $newExpense->save();
+        $newExpense = $this->expenseService->duplicate($expense);
 
         return redirect()->route('expenses.show', $newExpense)
             ->with('success', 'Expense duplicated successfully!');
@@ -329,28 +322,27 @@ class ExpenseController extends Controller
             abort(403, 'Unauthorized access to one or more expenses.');
         }
 
+        $user = auth()->user();
+        $ids = $request->expense_ids;
+
         switch ($request->action) {
             case 'delete':
-                Expense::where('user_id', auth()->id())
-                    ->whereIn('id', $request->expense_ids)->delete();
+                $this->expenseService->bulkDelete($user, $ids);
                 $message = "{$count} expenses deleted successfully!";
                 break;
 
             case 'mark_reimbursed':
-                Expense::where('user_id', auth()->id())
-                    ->whereIn('id', $request->expense_ids)->update(['status' => 'reimbursed']);
+                $this->expenseService->bulkMarkReimbursed($user, $ids);
                 $message = "{$count} expenses marked as reimbursed!";
                 break;
 
             case 'change_category':
-                Expense::where('user_id', auth()->id())
-                    ->whereIn('id', $request->expense_ids)->update(['category' => $request->category]);
+                $this->expenseService->bulkChangeCategory($user, $ids, $request->category);
                 $message = "{$count} expenses moved to {$request->category} category!";
                 break;
 
             case 'change_status':
-                Expense::where('user_id', auth()->id())
-                    ->whereIn('id', $request->expense_ids)->update(['status' => $request->status]);
+                $this->expenseService->bulkChangeStatus($user, $ids, $request->status);
                 $message = "{$count} expenses status changed to {$request->status}!";
                 break;
         }

--- a/app/Http/Controllers/PendingActionsController.php
+++ b/app/Http/Controllers/PendingActionsController.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\BulkApprovePendingActionsRequest;
+use App\Http\Requests\RejectPendingActionRequest;
+use App\Models\PendingAction;
+use App\Services\Agents\PendingActionApplier;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Gate;
+use Inertia\Inertia;
+use Throwable;
+
+class PendingActionsController extends Controller
+{
+    public function __construct(protected PendingActionApplier $applier) {}
+
+    public function index(Request $request)
+    {
+        Gate::authorize('viewAny', PendingAction::class);
+
+        $query = PendingAction::query()
+            ->with(['user:id,name,email', 'agentToken:id,name,agent_slug', 'reviewer:id,name'])
+            ->orderByDesc('created_at');
+
+        if ($status = $request->input('status')) {
+            $query->where('status', $status);
+        } else {
+            // Default: show pending + recently applied/rejected so users can undo within window.
+            $query->whereIn('status', [
+                PendingAction::STATUS_PENDING,
+                PendingAction::STATUS_APPLIED,
+                PendingAction::STATUS_REJECTED,
+                PendingAction::STATUS_FAILED,
+            ]);
+        }
+
+        if ($agent = $request->input('agent')) {
+            $query->where('agent_slug', $agent);
+        }
+
+        if ($module = $request->input('module')) {
+            $query->where('tool', 'LIKE', $module.'.%');
+        }
+
+        if ($from = $request->input('from')) {
+            $query->where('created_at', '>=', $from);
+        }
+
+        if ($to = $request->input('to')) {
+            $query->where('created_at', '<=', $to);
+        }
+
+        $perPage = (int) min(max((int) $request->input('per_page', 25), 1), 100);
+
+        return Inertia::render('PendingActions/Index', [
+            'pendingActions' => $query->paginate($perPage)->withQueryString(),
+            'filters' => $request->only(['status', 'agent', 'module', 'from', 'to']),
+            'pendingCount' => PendingAction::query()->where('status', PendingAction::STATUS_PENDING)->count(),
+        ]);
+    }
+
+    public function show(PendingAction $pendingAction)
+    {
+        Gate::authorize('view', $pendingAction);
+
+        $pendingAction->load([
+            'user:id,name,email',
+            'agentToken:id,name,agent_slug',
+            'reviewer:id,name',
+            'reverter:id,name',
+        ]);
+
+        return Inertia::render('PendingActions/Show', [
+            'pendingAction' => $pendingAction,
+            'canApprove' => Gate::check('approve', $pendingAction),
+            'canReject' => Gate::check('reject', $pendingAction),
+            'canRevert' => Gate::check('revert', $pendingAction),
+        ]);
+    }
+
+    public function approve(PendingAction $pendingAction)
+    {
+        Gate::authorize('approve', $pendingAction);
+
+        try {
+            $this->applier->apply($pendingAction, request()->user());
+        } catch (Throwable $e) {
+            return back()->with('error', 'Could not apply: '.$e->getMessage());
+        }
+
+        return back()->with('success', 'Pending action applied.');
+    }
+
+    public function reject(RejectPendingActionRequest $request, PendingAction $pendingAction)
+    {
+        Gate::authorize('reject', $pendingAction);
+
+        $this->applier->reject($pendingAction, $request->user(), $request->input('reason'));
+
+        return back()->with('success', 'Pending action rejected.');
+    }
+
+    public function revert(PendingAction $pendingAction)
+    {
+        Gate::authorize('revert', $pendingAction);
+
+        try {
+            $this->applier->revert($pendingAction, request()->user());
+        } catch (Throwable $e) {
+            return back()->with('error', 'Could not revert: '.$e->getMessage());
+        }
+
+        return back()->with('success', 'Action reverted.');
+    }
+
+    public function bulkApprove(BulkApprovePendingActionsRequest $request)
+    {
+        $applied = 0;
+        $failed = [];
+
+        foreach ($request->input('ids', []) as $id) {
+            $action = PendingAction::find($id);
+
+            if ($action === null || ! Gate::check('approve', $action)) {
+                continue;
+            }
+
+            try {
+                $this->applier->apply($action, $request->user());
+                $applied++;
+            } catch (Throwable $e) {
+                $failed[] = ['id' => $action->id, 'reason' => $e->getMessage()];
+            }
+        }
+
+        return back()->with('success', "Applied {$applied} action(s).".(
+            $failed === [] ? '' : ' '.count($failed).' failed.'
+        ))->with('bulkFailures', $failed);
+    }
+}

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Middleware;
 
+use App\Models\PendingAction;
 use Illuminate\Http\Request;
 use Inertia\Middleware;
 
@@ -56,6 +57,23 @@ class HandleInertiaRequests extends Middleware
             'notifications' => [
                 'unread_count' => $request->user()?->unreadNotifications()->count() ?? 0,
             ],
+            'pendingActions' => [
+                'count' => $this->pendingActionsCount($request),
+            ],
         ]);
+    }
+
+    private function pendingActionsCount(Request $request): int
+    {
+        $tenantId = $request->user()?->current_tenant_id;
+
+        if ($tenantId === null) {
+            return 0;
+        }
+
+        return PendingAction::query()
+            ->where('tenant_id', $tenantId)
+            ->where('status', PendingAction::STATUS_PENDING)
+            ->count();
     }
 }

--- a/app/Http/Requests/BulkApprovePendingActionsRequest.php
+++ b/app/Http/Requests/BulkApprovePendingActionsRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class BulkApprovePendingActionsRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'ids' => 'required|array|min:1|max:100',
+            'ids.*' => 'integer|exists:pending_actions,id',
+        ];
+    }
+}

--- a/app/Http/Requests/RejectPendingActionRequest.php
+++ b/app/Http/Requests/RejectPendingActionRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class RejectPendingActionRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'reason' => 'nullable|string|max:1000',
+        ];
+    }
+}

--- a/app/Mcp/LifeOsServer.php
+++ b/app/Mcp/LifeOsServer.php
@@ -8,6 +8,9 @@ use App\Mcp\Tools\Bills\UpcomingBills;
 use App\Mcp\Tools\Contracts\ListContracts;
 use App\Mcp\Tools\CycleMenu\CurrentWeekCycleMenu;
 use App\Mcp\Tools\Dashboard\Summary;
+use App\Mcp\Tools\Expenses\BulkImportExpenses;
+use App\Mcp\Tools\Expenses\CategorizeExpense;
+use App\Mcp\Tools\Expenses\CreateExpense;
 use App\Mcp\Tools\Expenses\ListExpenses;
 use App\Mcp\Tools\Investments\Portfolio;
 use App\Mcp\Tools\Iou\ListIou;
@@ -46,5 +49,8 @@ class LifeOsServer extends Server
         Pipeline::class,
         CurrentWeekCycleMenu::class,
         ListNotifications::class,
+        CreateExpense::class,
+        BulkImportExpenses::class,
+        CategorizeExpense::class,
     ];
 }

--- a/app/Mcp/Tools/Expenses/BulkImportExpenses.php
+++ b/app/Mcp/Tools/Expenses/BulkImportExpenses.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Mcp\Tools\Expenses;
+
+use App\Mcp\Tools\AbstractTool;
+use App\Models\PendingAction;
+use App\Services\Agents\PendingActionApplier;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\ResponseFactory;
+
+class BulkImportExpenses extends AbstractTool
+{
+    protected string $name = 'expenses.bulkImport';
+
+    protected string $description = 'Queue a bulk import of expenses for the authenticated tenant as a single pending action.';
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'items' => $schema->array()->description('Array of expense payloads. Each item uses the same shape as expenses.create.'),
+        ];
+    }
+
+    public function handle(Request $request, PendingActionApplier $applier): Response|ResponseFactory
+    {
+        if ($error = $this->authorize()) {
+            return $error;
+        }
+
+        $token = $this->agentToken();
+        $items = (array) $request->get('items', []);
+
+        if ($items === []) {
+            return Response::error('items must contain at least one expense.');
+        }
+
+        $normalized = array_map(static function ($item): array {
+            $item = (array) $item;
+            $item['currency'] ??= 'MKD';
+            $item['description'] ??= $item['merchant'] ?? null;
+
+            return array_filter($item, static fn ($v) => $v !== null);
+        }, $items);
+
+        try {
+            $action = $applier->record(
+                token: $token,
+                tool: $this->name(),
+                action: PendingAction::ACTION_BULK_CREATE,
+                payload: ['items' => $normalized],
+            );
+        } catch (\Throwable $e) {
+            return Response::error($e->getMessage());
+        }
+
+        return Response::structured([
+            'pending_action_id' => $action->id,
+            'status' => $action->status,
+            'idempotency_key' => $action->idempotency_key,
+            'item_count' => count($normalized),
+            'auto_applied' => $action->status === PendingAction::STATUS_APPLIED,
+        ]);
+    }
+}

--- a/app/Mcp/Tools/Expenses/CategorizeExpense.php
+++ b/app/Mcp/Tools/Expenses/CategorizeExpense.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Mcp\Tools\Expenses;
+
+use App\Mcp\Tools\AbstractTool;
+use App\Models\Expense;
+use App\Models\PendingAction;
+use App\Services\Agents\PendingActionApplier;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\ResponseFactory;
+
+class CategorizeExpense extends AbstractTool
+{
+    protected string $name = 'expenses.categorize';
+
+    protected string $description = 'Re-categorize an existing expense. Queued as a pending action awaiting human approval.';
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'expense_id' => $schema->integer()->description('Expense id (must belong to the authenticated tenant). Required.'),
+            'category' => $schema->string()->description('New category. Required.'),
+            'subcategory' => $schema->string()->description('Optional subcategory.'),
+            'confidence' => $schema->number()->description('Optional 0-1 confidence score the agent attaches to its choice.'),
+        ];
+    }
+
+    public function handle(Request $request, PendingActionApplier $applier): Response|ResponseFactory
+    {
+        if ($error = $this->authorize()) {
+            return $error;
+        }
+
+        $token = $this->agentToken();
+        $expenseId = (int) $request->get('expense_id', 0);
+
+        if ($expenseId <= 0) {
+            return Response::error('expense_id is required.');
+        }
+
+        // Tenant scoping is implicit via the BelongsToTenant global scope —
+        // referencing an expense in a different tenant returns null.
+        $expense = Expense::query()->find($expenseId);
+
+        if ($expense === null) {
+            return Response::error("Expense [{$expenseId}] not found in this tenant.");
+        }
+
+        $payload = array_filter([
+            'expense_id' => $expense->id,
+            'category' => $request->get('category'),
+            'subcategory' => $request->get('subcategory'),
+            'confidence' => $request->get('confidence'),
+        ], static fn ($v) => $v !== null);
+
+        try {
+            $action = $applier->record(
+                token: $token,
+                tool: $this->name(),
+                action: PendingAction::ACTION_UPDATE,
+                payload: $payload,
+            );
+        } catch (\Throwable $e) {
+            return Response::error($e->getMessage());
+        }
+
+        return Response::structured([
+            'pending_action_id' => $action->id,
+            'status' => $action->status,
+            'idempotency_key' => $action->idempotency_key,
+            'auto_applied' => $action->status === PendingAction::STATUS_APPLIED,
+        ]);
+    }
+}

--- a/app/Mcp/Tools/Expenses/CreateExpense.php
+++ b/app/Mcp/Tools/Expenses/CreateExpense.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Mcp\Tools\Expenses;
+
+use App\Mcp\Tools\AbstractTool;
+use App\Models\PendingAction;
+use App\Services\Agents\PendingActionApplier;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\ResponseFactory;
+
+class CreateExpense extends AbstractTool
+{
+    protected string $name = 'expenses.create';
+
+    protected string $description = 'Create an expense for the authenticated tenant. The write is queued as a pending action awaiting human approval.';
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'amount' => $schema->number()->description('Amount in expense currency. Required.'),
+            'currency' => $schema->string()->description('ISO 4217 3-letter code, defaults to MKD.'),
+            'expense_date' => $schema->string()->description('YYYY-MM-DD. Required.'),
+            'merchant' => $schema->string()->description('Vendor or store name.'),
+            'category' => $schema->string()->description('Expense category. Required.'),
+            'subcategory' => $schema->string()->description('Optional subcategory.'),
+            'description' => $schema->string()->description('Free-text description. Required.'),
+            'payment_method' => $schema->string()->description('Card, cash, transfer, etc.'),
+            'expense_type' => $schema->string()->description('"business" or "personal".'),
+            'is_tax_deductible' => $schema->boolean()->description('Whether this expense is tax-deductible.'),
+            'tags' => $schema->array()->description('Tag strings.'),
+            'source_email_id' => $schema->string()->description('Optional Gmail message id used for idempotency disambiguation.'),
+        ];
+    }
+
+    public function handle(Request $request, PendingActionApplier $applier): Response|ResponseFactory
+    {
+        if ($error = $this->authorize()) {
+            return $error;
+        }
+
+        $token = $this->agentToken();
+
+        $payload = array_filter([
+            'amount' => $request->get('amount'),
+            'currency' => $request->get('currency', 'MKD'),
+            'expense_date' => $request->get('expense_date'),
+            'merchant' => $request->get('merchant'),
+            'category' => $request->get('category'),
+            'subcategory' => $request->get('subcategory'),
+            'description' => $request->get('description') ?? $request->get('merchant'),
+            'payment_method' => $request->get('payment_method'),
+            'expense_type' => $request->get('expense_type'),
+            'is_tax_deductible' => $request->get('is_tax_deductible'),
+            'tags' => $request->get('tags'),
+            'source_email_id' => $request->get('source_email_id'),
+        ], static fn ($v) => $v !== null);
+
+        try {
+            $action = $applier->record(
+                token: $token,
+                tool: $this->name(),
+                action: PendingAction::ACTION_CREATE,
+                payload: $payload,
+            );
+        } catch (\Throwable $e) {
+            return Response::error($e->getMessage());
+        }
+
+        return Response::structured([
+            'pending_action_id' => $action->id,
+            'status' => $action->status,
+            'idempotency_key' => $action->idempotency_key,
+            'auto_applied' => $action->status === PendingAction::STATUS_APPLIED,
+        ]);
+    }
+}

--- a/app/Models/Expense.php
+++ b/app/Models/Expense.php
@@ -34,6 +34,8 @@ class Expense extends Model
         'notes',
         'status',
         'unique_key',
+        'source',
+        'created_by_agent_token_id',
     ];
 
     protected function casts(): array

--- a/app/Models/PendingAction.php
+++ b/app/Models/PendingAction.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Traits\BelongsToTenant;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+
+class PendingAction extends Model
+{
+    /** @use HasFactory<\Database\Factories\PendingActionFactory> */
+    use BelongsToTenant, HasFactory;
+
+    public const STATUS_PENDING = 'pending';
+
+    public const STATUS_APPROVED = 'approved';
+
+    public const STATUS_REJECTED = 'rejected';
+
+    public const STATUS_APPLIED = 'applied';
+
+    public const STATUS_FAILED = 'failed';
+
+    public const STATUS_REVERTED = 'reverted';
+
+    public const STATUS_SUPERSEDED = 'superseded';
+
+    public const ACTION_CREATE = 'create';
+
+    public const ACTION_UPDATE = 'update';
+
+    public const ACTION_DELETE = 'delete';
+
+    public const ACTION_BULK_CREATE = 'bulk_create';
+
+    public const ACTION_REVERT = 'revert';
+
+    protected $fillable = [
+        'tenant_id',
+        'user_id',
+        'agent_token_id',
+        'agent_slug',
+        'session_id',
+        'tool',
+        'action',
+        'target_type',
+        'target_id',
+        'payload',
+        'preview',
+        'idempotency_key',
+        'status',
+        'applied_diff',
+        'failure_reason',
+        'reviewed_by',
+        'reviewed_at',
+        'applied_at',
+        'reverted_by',
+        'reverted_at',
+        'reverted_pending_action_id',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'payload' => 'array',
+            'preview' => 'array',
+            'applied_diff' => 'array',
+            'reviewed_at' => 'datetime',
+            'applied_at' => 'datetime',
+            'reverted_at' => 'datetime',
+        ];
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function agentToken(): BelongsTo
+    {
+        return $this->belongsTo(AgentToken::class);
+    }
+
+    public function reviewer(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'reviewed_by');
+    }
+
+    public function reverter(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'reverted_by');
+    }
+
+    public function target(): MorphTo
+    {
+        return $this->morphTo();
+    }
+
+    public function revertedFrom(): BelongsTo
+    {
+        return $this->belongsTo(PendingAction::class, 'reverted_pending_action_id');
+    }
+
+    public function scopePending(Builder $query): Builder
+    {
+        return $query->where('status', self::STATUS_PENDING);
+    }
+
+    public function scopeForTool(Builder $query, string $tool): Builder
+    {
+        return $query->where('tool', $tool);
+    }
+
+    public function isPending(): bool
+    {
+        return $this->status === self::STATUS_PENDING;
+    }
+
+    public function isApplied(): bool
+    {
+        return $this->status === self::STATUS_APPLIED;
+    }
+
+    public function isRevertable(int $windowMinutes = 10): bool
+    {
+        if (! $this->isApplied()) {
+            return false;
+        }
+
+        if ($this->applied_at === null) {
+            return false;
+        }
+
+        return $this->applied_at->diffInMinutes(now()) <= $windowMinutes;
+    }
+
+    public function module(): string
+    {
+        return str_contains($this->tool, '.')
+            ? explode('.', $this->tool, 2)[0]
+            : $this->tool;
+    }
+}

--- a/app/Models/Tenant.php
+++ b/app/Models/Tenant.php
@@ -18,7 +18,31 @@ class Tenant extends Model
         'default_currency',
         'default_country',
         'owner_id',
+        'agents_writes_disabled',
+        'tool_auto_apply',
     ];
+
+    protected function casts(): array
+    {
+        return [
+            'agents_writes_disabled' => 'boolean',
+            'tool_auto_apply' => 'array',
+        ];
+    }
+
+    /**
+     * Whether the named MCP write tool may auto-apply on this tenant.
+     */
+    public function autoAppliesTool(string $tool): bool
+    {
+        if ($this->agents_writes_disabled) {
+            return false;
+        }
+
+        $map = $this->tool_auto_apply ?? [];
+
+        return ($map[$tool] ?? false) === true;
+    }
 
     /**
      * Get the owner of the tenant.

--- a/app/Policies/PendingActionPolicy.php
+++ b/app/Policies/PendingActionPolicy.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Policies;
+
+use App\Models\PendingAction;
+use App\Models\User;
+
+class PendingActionPolicy
+{
+    public function viewAny(User $user): bool
+    {
+        return $user->current_tenant_id !== null;
+    }
+
+    public function view(User $user, PendingAction $action): bool
+    {
+        return $user->current_tenant_id === $action->tenant_id;
+    }
+
+    public function approve(User $user, PendingAction $action): bool
+    {
+        return $this->view($user, $action) && $action->isPending();
+    }
+
+    public function reject(User $user, PendingAction $action): bool
+    {
+        return $this->view($user, $action) && $action->isPending();
+    }
+
+    public function revert(User $user, PendingAction $action): bool
+    {
+        return $this->view($user, $action) && $action->isRevertable();
+    }
+}

--- a/app/Services/Agents/IdempotencyKey.php
+++ b/app/Services/Agents/IdempotencyKey.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Agents;
+
+use InvalidArgumentException;
+
+/**
+ * Per-tool idempotency-key generators. Keys are deterministic SHA-256 of natural
+ * fields, scoped to the tenant. Resubmitting the same logical write yields the
+ * same key, so the unique (tenant_id, tool, idempotency_key) index on
+ * pending_actions blocks duplicates.
+ */
+class IdempotencyKey
+{
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    public function for(string $tool, int $tenantId, array $payload): string
+    {
+        $material = match ($tool) {
+            'expenses.create' => $this->expensesCreate($tenantId, $payload),
+            'expenses.bulkImport' => $this->expensesBulkImport($tenantId, $payload),
+            'expenses.categorize' => $this->expensesCategorize($tenantId, $payload),
+            default => throw new InvalidArgumentException("No idempotency-key generator registered for tool [{$tool}]."),
+        };
+
+        return hash('sha256', $material);
+    }
+
+    /**
+     * @param  array<string, mixed>  $p
+     */
+    private function expensesCreate(int $tenantId, array $p): string
+    {
+        $merchant = $this->normalize((string) ($p['merchant'] ?? ''));
+        $amount = $this->amountCents($p['amount'] ?? 0);
+        $currency = strtoupper((string) ($p['currency'] ?? ''));
+        $date = (string) ($p['expense_date'] ?? '');
+        $sourceEmail = (string) ($p['source_email_id'] ?? '');
+
+        return "expenses.create|{$tenantId}|{$merchant}|{$amount}|{$currency}|{$date}|{$sourceEmail}";
+    }
+
+    /**
+     * Bulk import — key over the canonical hash of the items array. Reorderings
+     * that keep the same items collide; duplicate items collide.
+     *
+     * @param  array<string, mixed>  $p
+     */
+    private function expensesBulkImport(int $tenantId, array $p): string
+    {
+        $items = (array) ($p['items'] ?? []);
+
+        $itemKeys = array_map(
+            fn (array $item): string => $this->expensesCreate($tenantId, $item),
+            $items,
+        );
+
+        sort($itemKeys);
+
+        return "expenses.bulkImport|{$tenantId}|".implode("\n", $itemKeys);
+    }
+
+    /**
+     * @param  array<string, mixed>  $p
+     */
+    private function expensesCategorize(int $tenantId, array $p): string
+    {
+        $expenseId = (int) ($p['expense_id'] ?? 0);
+        $category = $this->normalize((string) ($p['category'] ?? ''));
+        $subcategory = $this->normalize((string) ($p['subcategory'] ?? ''));
+
+        return "expenses.categorize|{$tenantId}|{$expenseId}|{$category}|{$subcategory}";
+    }
+
+    private function normalize(string $value): string
+    {
+        return strtolower(trim(preg_replace('/\s+/', ' ', $value) ?? ''));
+    }
+
+    private function amountCents(mixed $amount): int
+    {
+        return (int) round(((float) $amount) * 100);
+    }
+}

--- a/app/Services/Agents/PendingActionApplier.php
+++ b/app/Services/Agents/PendingActionApplier.php
@@ -1,0 +1,458 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Agents;
+
+use App\Http\Requests\StoreExpenseRequest;
+use App\Models\AgentToken;
+use App\Models\Expense;
+use App\Models\PendingAction;
+use App\Models\User;
+use App\Services\Expenses\ExpenseService;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\ValidationException;
+use RuntimeException;
+use Throwable;
+
+/**
+ * Applies a pending action to live data. Validation runs through the same
+ * FormRequest used by the corresponding controller, so agent writes are
+ * indistinguishable from user writes once approved.
+ */
+class PendingActionApplier
+{
+    public function __construct(
+        protected ExpenseService $expenses,
+        protected IdempotencyKey $keys,
+    ) {}
+
+    /**
+     * Record a write request as a pending_action. If a previously approved row
+     * exists for the same idempotency key the older row is returned.
+     *
+     * If the tool is allowed to auto-apply on this tenant AND the same
+     * idempotency key was previously approved, the new row is applied
+     * immediately.
+     *
+     * @param  array<string, mixed>  $payload
+     */
+    public function record(
+        AgentToken $token,
+        string $tool,
+        string $action,
+        array $payload,
+        ?string $sessionId = null,
+    ): PendingAction {
+        $tenantId = $token->tenant_id;
+        $idempotencyKey = $this->keys->for($tool, $tenantId, $payload);
+
+        return DB::transaction(function () use (
+            $token,
+            $tool,
+            $action,
+            $payload,
+            $sessionId,
+            $tenantId,
+            $idempotencyKey,
+        ): PendingAction {
+            $existing = PendingAction::query()
+                ->where('tenant_id', $tenantId)
+                ->where('tool', $tool)
+                ->where('idempotency_key', $idempotencyKey)
+                ->first();
+
+            if ($existing !== null) {
+                return $existing;
+            }
+
+            $action = PendingAction::create([
+                'tenant_id' => $tenantId,
+                'user_id' => $token->user_id,
+                'agent_token_id' => $token->id,
+                'agent_slug' => $token->agent_slug,
+                'session_id' => $sessionId,
+                'tool' => $tool,
+                'action' => $action,
+                'payload' => $payload,
+                'preview' => $this->buildPreview($tool, $payload),
+                'idempotency_key' => $idempotencyKey,
+                'status' => PendingAction::STATUS_PENDING,
+            ]);
+
+            if ($this->shouldAutoApply($token, $tool, $idempotencyKey, $action->id)) {
+                $this->apply($action, reviewer: null, autoApplied: true);
+            }
+
+            return $action->refresh();
+        });
+    }
+
+    /**
+     * Approve and apply the pending action. Throws ValidationException if the
+     * payload no longer satisfies the controller's FormRequest.
+     */
+    public function apply(
+        PendingAction $action,
+        ?User $reviewer,
+        bool $autoApplied = false,
+    ): PendingAction {
+        if (! in_array($action->status, [PendingAction::STATUS_PENDING, PendingAction::STATUS_APPROVED], true)) {
+            throw new RuntimeException("Cannot apply pending action in status [{$action->status}].");
+        }
+
+        $this->guardTenantWrites($action);
+        $this->validatePayload($action);
+
+        return DB::transaction(function () use ($action, $reviewer, $autoApplied): PendingAction {
+            $token = $action->agentToken;
+            $user = $action->user;
+
+            try {
+                $diff = $this->execute($action, $token, $user);
+            } catch (Throwable $e) {
+                $action->forceFill([
+                    'status' => PendingAction::STATUS_FAILED,
+                    'failure_reason' => $e->getMessage(),
+                ])->save();
+
+                throw $e;
+            }
+
+            $action->forceFill([
+                'status' => PendingAction::STATUS_APPLIED,
+                'applied_diff' => $diff,
+                'applied_at' => now(),
+                'reviewed_by' => $reviewer?->id,
+                'reviewed_at' => $autoApplied ? null : now(),
+                'failure_reason' => null,
+            ])->save();
+
+            return $action->refresh();
+        });
+    }
+
+    /**
+     * Reject the pending action. Optional reason is stored in failure_reason
+     * (the column is reused for both failure messages and rejection rationale).
+     */
+    public function reject(PendingAction $action, User $reviewer, ?string $reason = null): PendingAction
+    {
+        if ($action->status !== PendingAction::STATUS_PENDING) {
+            throw new RuntimeException("Cannot reject pending action in status [{$action->status}].");
+        }
+
+        $action->forceFill([
+            'status' => PendingAction::STATUS_REJECTED,
+            'reviewed_by' => $reviewer->id,
+            'reviewed_at' => now(),
+            'failure_reason' => $reason,
+        ])->save();
+
+        return $action->refresh();
+    }
+
+    /**
+     * Revert a previously applied action. Creates an inverse PendingAction
+     * (action='revert') and immediately marks both the original and the
+     * compensation as reverted.
+     */
+    public function revert(PendingAction $action, User $reverter, int $windowMinutes = 10): PendingAction
+    {
+        if (! $action->isRevertable($windowMinutes)) {
+            throw new RuntimeException('This action is no longer revertable.');
+        }
+
+        return DB::transaction(function () use ($action, $reverter): PendingAction {
+            $compensation = PendingAction::create([
+                'tenant_id' => $action->tenant_id,
+                'user_id' => $reverter->id,
+                'agent_token_id' => null,
+                'agent_slug' => $action->agent_slug,
+                'session_id' => $action->session_id,
+                'tool' => $action->tool,
+                'action' => PendingAction::ACTION_REVERT,
+                'payload' => ['original_pending_action_id' => $action->id],
+                'idempotency_key' => hash('sha256', "revert|{$action->id}"),
+                'status' => PendingAction::STATUS_APPLIED,
+                'applied_at' => now(),
+                'reviewed_by' => $reverter->id,
+                'reviewed_at' => now(),
+                'reverted_pending_action_id' => $action->id,
+            ]);
+
+            $this->executeRevert($action);
+
+            $action->forceFill([
+                'status' => PendingAction::STATUS_REVERTED,
+                'reverted_by' => $reverter->id,
+                'reverted_at' => now(),
+            ])->save();
+
+            return $compensation->refresh();
+        });
+    }
+
+    private function guardTenantWrites(PendingAction $action): void
+    {
+        $tenant = $action->tenant;
+
+        if ($tenant !== null && $tenant->agents_writes_disabled) {
+            throw new RuntimeException('Agent writes are disabled for this tenant.');
+        }
+    }
+
+    private function validatePayload(PendingAction $action): void
+    {
+        match ($action->tool) {
+            'expenses.create' => $this->validateExpenseCreate($action->payload),
+            'expenses.bulkImport' => $this->validateExpenseBulkImport($action->payload),
+            'expenses.categorize' => $this->validateExpenseCategorize($action->payload),
+            default => throw new RuntimeException("No validator registered for tool [{$action->tool}]."),
+        };
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function validateExpenseCreate(array $payload): void
+    {
+        $rules = (new StoreExpenseRequest)->rules();
+        $validator = Validator::make($payload, $rules);
+
+        if ($validator->fails()) {
+            throw new ValidationException($validator);
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function validateExpenseBulkImport(array $payload): void
+    {
+        $items = (array) ($payload['items'] ?? []);
+
+        if ($items === []) {
+            throw ValidationException::withMessages(['items' => 'At least one item is required.']);
+        }
+
+        foreach ($items as $i => $item) {
+            try {
+                $this->validateExpenseCreate((array) $item);
+            } catch (ValidationException $e) {
+                throw ValidationException::withMessages([
+                    "items.{$i}" => $e->errors(),
+                ]);
+            }
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function validateExpenseCategorize(array $payload): void
+    {
+        $validator = Validator::make($payload, [
+            'expense_id' => 'required|integer|exists:expenses,id',
+            'category' => 'required|string|max:255',
+            'subcategory' => 'nullable|string|max:255',
+        ]);
+
+        if ($validator->fails()) {
+            throw new ValidationException($validator);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function execute(PendingAction $action, ?AgentToken $token, User $user): array
+    {
+        $attribution = [
+            'source' => 'agent',
+            'agent_token_id' => $token?->id,
+        ];
+
+        return match ($action->tool) {
+            'expenses.create' => $this->executeExpenseCreate($action, $user, $attribution),
+            'expenses.bulkImport' => $this->executeExpenseBulkImport($action, $user, $attribution),
+            'expenses.categorize' => $this->executeExpenseCategorize($action),
+            default => throw new RuntimeException("No executor registered for tool [{$action->tool}]."),
+        };
+    }
+
+    /**
+     * @param  array<string, mixed>  $attribution
+     * @return array<string, mixed>
+     */
+    private function executeExpenseCreate(PendingAction $action, User $user, array $attribution): array
+    {
+        $expense = $this->expenses->create($user, $action->payload, $attribution);
+
+        $action->forceFill([
+            'target_type' => Expense::class,
+            'target_id' => $expense->id,
+        ])->save();
+
+        return [
+            'before' => null,
+            'after' => $expense->only(['id', 'amount', 'currency', 'merchant', 'category', 'expense_date']),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $attribution
+     * @return array<string, mixed>
+     */
+    private function executeExpenseBulkImport(PendingAction $action, User $user, array $attribution): array
+    {
+        $rows = (array) ($action->payload['items'] ?? []);
+        $created = $this->expenses->bulkCreate($user, $rows, $attribution);
+
+        return [
+            'before' => null,
+            'after' => array_map(fn (Expense $e): array => $e->only(['id', 'amount', 'currency', 'merchant']), $created),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function executeExpenseCategorize(PendingAction $action): array
+    {
+        $expense = Expense::query()->findOrFail((int) $action->payload['expense_id']);
+        $before = $expense->only(['id', 'category', 'subcategory']);
+
+        $this->expenses->categorize(
+            $expense,
+            (string) $action->payload['category'],
+            isset($action->payload['subcategory']) ? (string) $action->payload['subcategory'] : null,
+        );
+
+        $action->forceFill([
+            'target_type' => Expense::class,
+            'target_id' => $expense->id,
+        ])->save();
+
+        return [
+            'before' => $before,
+            'after' => $expense->refresh()->only(['id', 'category', 'subcategory']),
+        ];
+    }
+
+    private function executeRevert(PendingAction $action): void
+    {
+        switch ($action->tool) {
+            case 'expenses.create':
+            case 'expenses.bulkImport':
+                $this->revertExpenseCreate($action);
+
+                return;
+            case 'expenses.categorize':
+                $this->revertExpenseCategorize($action);
+
+                return;
+        }
+
+        throw new RuntimeException("No revert executor for tool [{$action->tool}].");
+    }
+
+    private function revertExpenseCreate(PendingAction $action): void
+    {
+        $diff = $action->applied_diff ?? [];
+        $after = $diff['after'] ?? null;
+
+        $ids = match (true) {
+            is_array($after) && isset($after['id']) => [(int) $after['id']],
+            is_array($after) => array_values(array_filter(array_map(
+                static fn ($row) => is_array($row) && isset($row['id']) ? (int) $row['id'] : null,
+                $after,
+            ))),
+            default => [],
+        };
+
+        if ($ids === []) {
+            return;
+        }
+
+        Expense::query()->whereIn('id', $ids)->delete();
+    }
+
+    private function revertExpenseCategorize(PendingAction $action): void
+    {
+        $diff = $action->applied_diff ?? [];
+        $before = $diff['before'] ?? null;
+
+        if (! is_array($before) || ! isset($before['id'])) {
+            return;
+        }
+
+        $expense = Expense::query()->find((int) $before['id']);
+
+        if ($expense === null) {
+            return;
+        }
+
+        $this->expenses->categorize(
+            $expense,
+            (string) ($before['category'] ?? ''),
+            isset($before['subcategory']) ? (string) $before['subcategory'] : null,
+        );
+    }
+
+    private function shouldAutoApply(
+        AgentToken $token,
+        string $tool,
+        string $idempotencyKey,
+        int $newActionId,
+    ): bool {
+        $tenant = $token->tenant;
+
+        if ($tenant === null || ! $tenant->autoAppliesTool($tool)) {
+            return false;
+        }
+
+        return PendingAction::query()
+            ->where('tenant_id', $token->tenant_id)
+            ->where('tool', $tool)
+            ->where('idempotency_key', $idempotencyKey)
+            ->where('id', '!=', $newActionId)
+            ->where('status', PendingAction::STATUS_APPLIED)
+            ->exists();
+    }
+
+    /**
+     * Render a small preview map for the dashboard. Kept simple: tool-specific
+     * presenters are introduced when the UI needs richer rendering.
+     *
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    private function buildPreview(string $tool, array $payload): array
+    {
+        return match ($tool) {
+            'expenses.create' => [
+                'summary' => sprintf(
+                    '%s %s at %s on %s',
+                    number_format((float) ($payload['amount'] ?? 0), 2),
+                    (string) ($payload['currency'] ?? ''),
+                    (string) ($payload['merchant'] ?? '—'),
+                    (string) ($payload['expense_date'] ?? ''),
+                ),
+                'category' => (string) ($payload['category'] ?? ''),
+            ],
+            'expenses.bulkImport' => [
+                'summary' => sprintf('%d expense rows', count((array) ($payload['items'] ?? []))),
+            ],
+            'expenses.categorize' => [
+                'summary' => sprintf(
+                    'Categorize expense #%d as %s',
+                    (int) ($payload['expense_id'] ?? 0),
+                    (string) ($payload['category'] ?? ''),
+                ),
+            ],
+            default => [],
+        };
+    }
+}

--- a/app/Services/Expenses/ExpenseService.php
+++ b/app/Services/Expenses/ExpenseService.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Expenses;
+
+use App\Models\Expense;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+
+class ExpenseService
+{
+    /**
+     * Create an expense. Validation must happen before this call (e.g. via FormRequest).
+     *
+     * @param  array<string, mixed>  $data       Validated expense fields.
+     * @param  array<string, mixed>  $attribution Optional ['source' => 'agent'|'user'|'import',
+     *                                            'agent_token_id' => int|null].
+     */
+    public function create(User $user, array $data, array $attribution = []): Expense
+    {
+        return Expense::create([
+            'user_id' => $user->id,
+            ...$data,
+            'source' => $attribution['source'] ?? 'user',
+            'created_by_agent_token_id' => $attribution['agent_token_id'] ?? null,
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $data Validated expense fields.
+     */
+    public function update(Expense $expense, array $data): Expense
+    {
+        $expense->update($data);
+
+        return $expense->refresh();
+    }
+
+    public function delete(Expense $expense): bool
+    {
+        return (bool) $expense->delete();
+    }
+
+    public function markReimbursed(Expense $expense): Expense
+    {
+        return $this->update($expense, ['status' => 'reimbursed']);
+    }
+
+    public function duplicate(Expense $expense): Expense
+    {
+        $copy = $expense->replicate();
+        $copy->expense_date = now()->toDateString();
+        $copy->status = 'pending';
+        $copy->save();
+
+        return $copy;
+    }
+
+    public function categorize(
+        Expense $expense,
+        string $category,
+        ?string $subcategory = null,
+    ): Expense {
+        $payload = ['category' => $category];
+
+        if ($subcategory !== null) {
+            $payload['subcategory'] = $subcategory;
+        }
+
+        return $this->update($expense, $payload);
+    }
+
+    /**
+     * Bulk-delete expenses scoped to the given user.
+     *
+     * @param  array<int>  $ids
+     */
+    public function bulkDelete(User $user, array $ids): int
+    {
+        return Expense::where('user_id', $user->id)->whereIn('id', $ids)->delete();
+    }
+
+    /**
+     * @param  array<int>  $ids
+     */
+    public function bulkMarkReimbursed(User $user, array $ids): int
+    {
+        return Expense::where('user_id', $user->id)
+            ->whereIn('id', $ids)
+            ->update(['status' => 'reimbursed']);
+    }
+
+    /**
+     * @param  array<int>  $ids
+     */
+    public function bulkChangeCategory(User $user, array $ids, string $category): int
+    {
+        return Expense::where('user_id', $user->id)
+            ->whereIn('id', $ids)
+            ->update(['category' => $category]);
+    }
+
+    /**
+     * @param  array<int>  $ids
+     */
+    public function bulkChangeStatus(User $user, array $ids, string $status): int
+    {
+        return Expense::where('user_id', $user->id)
+            ->whereIn('id', $ids)
+            ->update(['status' => $status]);
+    }
+
+    /**
+     * Bulk-create expenses inside a single transaction. Returns the created models.
+     *
+     * @param  array<int, array<string, mixed>>  $rows
+     * @param  array<string, mixed>  $attribution
+     * @return array<int, Expense>
+     */
+    public function bulkCreate(User $user, array $rows, array $attribution = []): array
+    {
+        return DB::transaction(function () use ($user, $rows, $attribution): array {
+            $created = [];
+
+            foreach ($rows as $row) {
+                $created[] = $this->create($user, $row, $attribution);
+            }
+
+            return $created;
+        });
+    }
+}

--- a/database/factories/PendingActionFactory.php
+++ b/database/factories/PendingActionFactory.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Models\PendingAction;
+use App\Models\Tenant;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<PendingAction>
+ */
+class PendingActionFactory extends Factory
+{
+    protected $model = PendingAction::class;
+
+    public function definition(): array
+    {
+        return [
+            'tenant_id' => Tenant::factory(),
+            'user_id' => User::factory(),
+            'agent_token_id' => null,
+            'agent_slug' => 'phpunit',
+            'session_id' => Str::uuid()->toString(),
+            'tool' => 'expenses.create',
+            'action' => 'create',
+            'payload' => [
+                'amount' => 12.5,
+                'currency' => 'EUR',
+                'category' => 'groceries',
+                'expense_date' => now()->toDateString(),
+                'description' => 'Test',
+                'merchant' => 'Lidl',
+            ],
+            'idempotency_key' => hash('sha256', Str::random(16)),
+            'status' => PendingAction::STATUS_PENDING,
+        ];
+    }
+}

--- a/database/migrations/2026_05_07_002843_create_pending_actions_table.php
+++ b/database/migrations/2026_05_07_002843_create_pending_actions_table.php
@@ -1,0 +1,52 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('pending_actions', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('tenant_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('agent_token_id')->nullable()->constrained('agent_tokens')->nullOnDelete();
+
+            $table->string('agent_slug')->nullable();
+            $table->string('session_id')->nullable();
+            $table->string('tool');
+            $table->string('action');
+
+            $table->nullableMorphs('target');
+            $table->json('payload');
+            $table->json('preview')->nullable();
+
+            $table->string('idempotency_key', 64);
+
+            $table->string('status')->default('pending');
+            $table->json('applied_diff')->nullable();
+            $table->string('failure_reason')->nullable();
+
+            $table->foreignId('reviewed_by')->nullable()->constrained('users')->nullOnDelete();
+            $table->timestamp('reviewed_at')->nullable();
+            $table->timestamp('applied_at')->nullable();
+            $table->foreignId('reverted_by')->nullable()->constrained('users')->nullOnDelete();
+            $table->timestamp('reverted_at')->nullable();
+            $table->foreignId('reverted_pending_action_id')->nullable()
+                ->constrained('pending_actions')->nullOnDelete();
+
+            $table->timestamps();
+
+            $table->unique(['tenant_id', 'tool', 'idempotency_key']);
+            $table->index(['tenant_id', 'status', 'created_at']);
+            $table->index(['tenant_id', 'agent_slug']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('pending_actions');
+    }
+};

--- a/database/migrations/2026_05_07_002844_add_agent_attribution_to_expenses.php
+++ b/database/migrations/2026_05_07_002844_add_agent_attribution_to_expenses.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('expenses', function (Blueprint $table) {
+            $table->string('source', 16)->default('user')->after('status');
+            $table->foreignId('created_by_agent_token_id')->nullable()
+                ->after('source')
+                ->constrained('agent_tokens')->nullOnDelete();
+
+            $table->index(['tenant_id', 'source']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('expenses', function (Blueprint $table) {
+            $table->dropForeign(['created_by_agent_token_id']);
+            $table->dropIndex(['tenant_id', 'source']);
+            $table->dropColumn(['source', 'created_by_agent_token_id']);
+        });
+    }
+};

--- a/database/migrations/2026_05_07_002845_add_agent_settings_to_tenants.php
+++ b/database/migrations/2026_05_07_002845_add_agent_settings_to_tenants.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('tenants', function (Blueprint $table) {
+            $table->boolean('agents_writes_disabled')->default(false)->after('default_country');
+            $table->json('tool_auto_apply')->nullable()->after('agents_writes_disabled');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('tenants', function (Blueprint $table) {
+            $table->dropColumn(['agents_writes_disabled', 'tool_auto_apply']);
+        });
+    }
+};

--- a/docs/agents/IMPLEMENTATION_PLAN.md
+++ b/docs/agents/IMPLEMENTATION_PLAN.md
@@ -1,6 +1,11 @@
 # LifeOS Managed Agents — Implementation Plan
 
 > **Status:** Approved 2026-05-06. Canonical location for the plan; further phases update this file in place. Branch: `claude/implement-managed-agents-L1MeH` with one child branch + PR per phase.
+>
+> **Progress:**
+> - Phase 0 — plan committed (this file).
+> - Phase 1 — read-only MCP server: PR #148 (`claude/managed-agents-phase-1`).
+> - Phase 2 — Pending Actions queue + Expenses writes: in PR.
 
 ## Context
 

--- a/docs/agents/MCP_TOOLS.md
+++ b/docs/agents/MCP_TOOLS.md
@@ -201,10 +201,58 @@ Items: `id, type, data, read_at, created_at`.
 - The `AuthenticateAgent` middleware sets `current_tenant_id` on the bound user before tools run, so the existing `TenantScope` global scope filters every Eloquent query.
 - The middleware does not modify the database (only the in-memory `User` model state), so concurrent web sessions for the same user are unaffected.
 
-## Phase 2 preview
+## Write tools (Phase 2)
 
-Phase 2 introduces:
+The Phase 2 write tools never mutate live data on call. Each one creates a row in `pending_actions` (idempotent by `idempotency_key`) and returns the row's id and status. The user reviews and approves at `/dashboard/pending-actions`. Auto-apply is allowed only when (a) `tenants.agents_writes_disabled = false` AND (b) `tenants.tool_auto_apply[tool] = true` AND (c) an identical idempotency key was previously approved on this tenant. The default is `false` for every (tenant, tool) pair.
 
-- A `pending_actions` table with idempotency keys.
-- Write tools `expenses.create`, `expenses.bulkImport`, `expenses.categorize` that produce pending actions.
-- A `tool_auto_apply` per-tenant config that defaults to `false` for every (tenant, tool) pair.
+### `expenses.create`
+
+| field | type | description |
+|---|---|---|
+| `amount` | number | Required. |
+| `currency` | string | ISO 4217. Defaults to MKD. |
+| `expense_date` | date | YYYY-MM-DD. Required. |
+| `merchant` | string | Vendor / store. |
+| `category` | string | Required. |
+| `subcategory` | string | Optional. |
+| `description` | string | Required (falls back to `merchant`). |
+| `payment_method` | string | Optional. |
+| `expense_type` | string | "business" or "personal". |
+| `is_tax_deductible` | bool | Optional. |
+| `tags` | string[] | Optional. |
+| `source_email_id` | string | Optional, used as an idempotency disambiguator (e.g. Gmail message id). |
+
+Idempotency key: `sha256("expenses.create|<tenant>|<merchant_normalized>|<amount_cents>|<currency>|<expense_date>|<source_email_id>")`.
+
+Returns: `{ pending_action_id, status, idempotency_key, auto_applied }`.
+
+### `expenses.bulkImport`
+
+| field | type | description |
+|---|---|---|
+| `items` | array | Each item uses the same shape as `expenses.create`. |
+
+A single pending action is created for the whole batch. Idempotency key is derived from the sorted hashes of the per-item `expenses.create` keys, so reorderings collide.
+
+Returns: `{ pending_action_id, status, idempotency_key, item_count, auto_applied }`.
+
+### `expenses.categorize`
+
+| field | type | description |
+|---|---|---|
+| `expense_id` | int | Required. The expense must belong to the authenticated tenant (enforced via the global tenant scope). |
+| `category` | string | Required. |
+| `subcategory` | string | Optional. |
+| `confidence` | number | Optional 0-1 score. |
+
+Returns: `{ pending_action_id, status, idempotency_key, auto_applied }`.
+
+## Approval surface
+
+Reviewers act through `/dashboard/pending-actions`:
+
+- Index (filterable list) with bulk-approve.
+- Detail page with payload, applied diff (when applied), and approve / reject (with reason) / revert (within a 10-minute window) actions.
+- Sidebar shows a count badge fed by a global Inertia share `pendingActions.count`.
+
+`PendingActionPolicy` gates view, approve, reject, revert. Revert is only allowed for `applied` actions inside the configurable window.

--- a/resources/js/components/shared/sidebar.tsx
+++ b/resources/js/components/shared/sidebar.tsx
@@ -23,15 +23,18 @@ import {
     UtensilsCrossed,
     DollarSign,
     Calendar,
+    Inbox,
     type LucideIcon,
 } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
 
 interface NavItem {
     label: string
     href: string
     icon: LucideIcon
+    badgeKey?: 'pendingActionsCount'
 }
 
 interface NavGroup {
@@ -49,6 +52,7 @@ const navigation: NavGroup[] = [
             { label: 'Expenses', href: '/expenses', icon: Receipt },
             { label: 'Subscriptions', href: '/subscriptions', icon: CreditCard },
             { label: 'Utility Bills', href: '/utility-bills', icon: Zap },
+            { label: 'Pending Actions', href: '/dashboard/pending-actions', icon: Inbox, badgeKey: 'pendingActionsCount' },
         ],
     },
     {
@@ -91,8 +95,16 @@ interface SidebarProps {
     onToggle: () => void
 }
 
+interface SharedPageProps {
+    pendingActions?: { count?: number }
+}
+
 export function Sidebar({ collapsed, onToggle }: SidebarProps) {
-    const { url } = usePage()
+    const { url, props } = usePage<SharedPageProps>()
+    const pendingActionsCount = props.pendingActions?.count ?? 0
+    const badgeValues: Record<NonNullable<NavItem['badgeKey']>, number> = {
+        pendingActionsCount,
+    }
     const [openGroups, setOpenGroups] = useState<string[]>(
         navigation.map(g => g.label)
     )
@@ -171,22 +183,34 @@ export function Sidebar({ collapsed, onToggle }: SidebarProps) {
                         )}
                         {(collapsed || openGroups.includes(group.label)) && (
                             <div className="space-y-0.5">
-                                {group.items.map((item) => (
-                                    <Link
-                                        key={item.href}
-                                        href={item.href}
-                                        className={cn(
-                                            'flex items-center gap-3 rounded-md px-3 py-2.5 text-sm transition-colors',
-                                            isActive(item.href)
-                                                ? 'border-l-2 border-foreground bg-sidebar-accent font-medium text-sidebar-accent-foreground'
-                                                : 'text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground'
-                                        )}
-                                        title={collapsed ? item.label : undefined}
-                                    >
-                                        <item.icon className="h-4 w-4 shrink-0" />
-                                        {!collapsed && <span>{item.label}</span>}
-                                    </Link>
-                                ))}
+                                {group.items.map((item) => {
+                                    const badgeCount = item.badgeKey ? badgeValues[item.badgeKey] : 0
+                                    return (
+                                        <Link
+                                            key={item.href}
+                                            href={item.href}
+                                            className={cn(
+                                                'flex items-center gap-3 rounded-md px-3 py-2.5 text-sm transition-colors',
+                                                isActive(item.href)
+                                                    ? 'border-l-2 border-foreground bg-sidebar-accent font-medium text-sidebar-accent-foreground'
+                                                    : 'text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground'
+                                            )}
+                                            title={collapsed ? item.label : undefined}
+                                        >
+                                            <item.icon className="h-4 w-4 shrink-0" />
+                                            {!collapsed && (
+                                                <span className="flex flex-1 items-center justify-between">
+                                                    <span>{item.label}</span>
+                                                    {badgeCount > 0 && (
+                                                        <Badge variant="destructive" className="ml-2 h-5 px-1.5 text-[10px]">
+                                                            {badgeCount}
+                                                        </Badge>
+                                                    )}
+                                                </span>
+                                            )}
+                                        </Link>
+                                    )
+                                })}
                             </div>
                         )}
                     </div>

--- a/resources/js/pages/PendingActions/Index.tsx
+++ b/resources/js/pages/PendingActions/Index.tsx
@@ -1,0 +1,266 @@
+import { Head, Link, router } from '@inertiajs/react'
+import { useMemo, useState } from 'react'
+import AppLayout from '@/components/shared/app-layout'
+import { PageHeader } from '@/components/shared/page-header'
+import { EmptyState } from '@/components/shared/empty-state'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { Card, CardContent } from '@/components/ui/card'
+import { Checkbox } from '@/components/ui/checkbox'
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '@/components/ui/select'
+import {
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow,
+} from '@/components/ui/table'
+import { Inbox, Eye } from 'lucide-react'
+import type { PaginatedData } from '@/types'
+
+interface PendingAction {
+    id: number
+    agent_slug: string | null
+    tool: string
+    action: string
+    status:
+        | 'pending'
+        | 'approved'
+        | 'rejected'
+        | 'applied'
+        | 'failed'
+        | 'reverted'
+        | 'superseded'
+    preview: { summary?: string; category?: string } | null
+    payload: Record<string, unknown>
+    created_at: string
+    applied_at: string | null
+    user?: { id: number; name: string; email: string }
+    agent_token?: { id: number; name: string; agent_slug: string | null }
+}
+
+interface IndexProps {
+    pendingActions: PaginatedData<PendingAction>
+    filters: {
+        status?: string
+        agent?: string
+        module?: string
+        from?: string
+        to?: string
+    }
+    pendingCount: number
+}
+
+const STATUS_VARIANTS: Record<PendingAction['status'], 'default' | 'secondary' | 'destructive' | 'outline'> = {
+    pending: 'default',
+    approved: 'secondary',
+    applied: 'secondary',
+    rejected: 'destructive',
+    failed: 'destructive',
+    reverted: 'outline',
+    superseded: 'outline',
+}
+
+const MODULES = [
+    { value: '', label: 'All modules' },
+    { value: 'expenses', label: 'Expenses' },
+    { value: 'subscriptions', label: 'Subscriptions' },
+    { value: 'contracts', label: 'Contracts' },
+    { value: 'warranties', label: 'Warranties' },
+    { value: 'iou', label: 'IOU' },
+    { value: 'bills', label: 'Bills' },
+]
+
+const STATUSES = [
+    { value: '', label: 'Active (pending + recent)' },
+    { value: 'pending', label: 'Pending' },
+    { value: 'applied', label: 'Applied' },
+    { value: 'rejected', label: 'Rejected' },
+    { value: 'failed', label: 'Failed' },
+    { value: 'reverted', label: 'Reverted' },
+]
+
+export default function PendingActionsIndex({ pendingActions, filters, pendingCount }: IndexProps) {
+    const [selected, setSelected] = useState<number[]>([])
+    const [statusFilter, setStatusFilter] = useState(filters.status ?? '')
+    const [moduleFilter, setModuleFilter] = useState(filters.module ?? '')
+
+    const allSelected = useMemo(
+        () => pendingActions.data.length > 0 && selected.length === pendingActions.data.filter((a) => a.status === 'pending').length,
+        [pendingActions.data, selected.length],
+    )
+
+    const toggleSelected = (id: number, checked: boolean) => {
+        setSelected((prev) => (checked ? [...prev, id] : prev.filter((x) => x !== id)))
+    }
+
+    const toggleAllPending = (checked: boolean) => {
+        setSelected(checked ? pendingActions.data.filter((a) => a.status === 'pending').map((a) => a.id) : [])
+    }
+
+    const submitFilters = (next: Partial<IndexProps['filters']>) => {
+        router.get(
+            '/dashboard/pending-actions',
+            { ...filters, ...next },
+            { preserveState: true, preserveScroll: true, replace: true },
+        )
+    }
+
+    const bulkApprove = () => {
+        if (selected.length === 0) return
+        router.post(
+            '/dashboard/pending-actions/bulk-approve',
+            { ids: selected },
+            {
+                onSuccess: () => setSelected([]),
+            },
+        )
+    }
+
+    return (
+        <AppLayout>
+            <Head title="Pending Agent Actions" />
+            <PageHeader
+                title="Pending Agent Actions"
+                description="Review writes proposed by agents before they touch live data."
+            />
+
+            <div className="mt-6 grid gap-4 md:grid-cols-3">
+                <Card>
+                    <CardContent className="p-4">
+                        <div className="text-xs text-muted-foreground">Currently pending</div>
+                        <div className="mt-1 text-2xl font-semibold">{pendingCount}</div>
+                    </CardContent>
+                </Card>
+                <Card>
+                    <CardContent className="p-4">
+                        <div className="text-xs text-muted-foreground">In this view</div>
+                        <div className="mt-1 text-2xl font-semibold">{pendingActions.total}</div>
+                    </CardContent>
+                </Card>
+                <Card>
+                    <CardContent className="flex items-center justify-between p-4">
+                        <div>
+                            <div className="text-xs text-muted-foreground">Selected</div>
+                            <div className="mt-1 text-2xl font-semibold">{selected.length}</div>
+                        </div>
+                        <Button onClick={bulkApprove} disabled={selected.length === 0}>
+                            Approve selected
+                        </Button>
+                    </CardContent>
+                </Card>
+            </div>
+
+            <Card className="mt-6">
+                <CardContent className="p-4">
+                    <div className="flex flex-wrap gap-3">
+                        <Select
+                            value={statusFilter}
+                            onValueChange={(v) => {
+                                setStatusFilter(v)
+                                submitFilters({ status: v || undefined })
+                            }}
+                        >
+                            <SelectTrigger className="w-[220px]">
+                                <SelectValue placeholder="Status" />
+                            </SelectTrigger>
+                            <SelectContent>
+                                {STATUSES.map((s) => (
+                                    <SelectItem key={s.value || 'all'} value={s.value}>
+                                        {s.label}
+                                    </SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+                        <Select
+                            value={moduleFilter}
+                            onValueChange={(v) => {
+                                setModuleFilter(v)
+                                submitFilters({ module: v || undefined })
+                            }}
+                        >
+                            <SelectTrigger className="w-[200px]">
+                                <SelectValue placeholder="Module" />
+                            </SelectTrigger>
+                            <SelectContent>
+                                {MODULES.map((m) => (
+                                    <SelectItem key={m.value || 'all'} value={m.value}>
+                                        {m.label}
+                                    </SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+                    </div>
+                </CardContent>
+            </Card>
+
+            <Card className="mt-6">
+                <CardContent className="p-0">
+                    {pendingActions.data.length === 0 ? (
+                        <EmptyState
+                            icon={Inbox}
+                            title="No pending actions"
+                            description="When an agent proposes a write, it will appear here for review."
+                        />
+                    ) : (
+                        <Table>
+                            <TableHeader>
+                                <TableRow>
+                                    <TableHead className="w-10">
+                                        <Checkbox checked={allSelected} onCheckedChange={(c) => toggleAllPending(Boolean(c))} />
+                                    </TableHead>
+                                    <TableHead>Tool</TableHead>
+                                    <TableHead>Agent</TableHead>
+                                    <TableHead>Summary</TableHead>
+                                    <TableHead>Status</TableHead>
+                                    <TableHead>Created</TableHead>
+                                    <TableHead className="text-right">Actions</TableHead>
+                                </TableRow>
+                            </TableHeader>
+                            <TableBody>
+                                {pendingActions.data.map((action) => (
+                                    <TableRow key={action.id}>
+                                        <TableCell>
+                                            {action.status === 'pending' && (
+                                                <Checkbox
+                                                    checked={selected.includes(action.id)}
+                                                    onCheckedChange={(c) => toggleSelected(action.id, Boolean(c))}
+                                                />
+                                            )}
+                                        </TableCell>
+                                        <TableCell className="font-mono text-sm">{action.tool}</TableCell>
+                                        <TableCell className="text-sm">{action.agent_slug ?? action.agent_token?.agent_slug ?? '—'}</TableCell>
+                                        <TableCell className="max-w-md truncate text-sm">
+                                            {action.preview?.summary ?? '—'}
+                                        </TableCell>
+                                        <TableCell>
+                                            <Badge variant={STATUS_VARIANTS[action.status]}>{action.status}</Badge>
+                                        </TableCell>
+                                        <TableCell className="text-sm text-muted-foreground">
+                                            {new Date(action.created_at).toLocaleString()}
+                                        </TableCell>
+                                        <TableCell className="text-right">
+                                            <Button asChild variant="ghost" size="sm">
+                                                <Link href={`/dashboard/pending-actions/${action.id}`}>
+                                                    <Eye className="mr-1 h-4 w-4" />
+                                                    View
+                                                </Link>
+                                            </Button>
+                                        </TableCell>
+                                    </TableRow>
+                                ))}
+                            </TableBody>
+                        </Table>
+                    )}
+                </CardContent>
+            </Card>
+        </AppLayout>
+    )
+}

--- a/resources/js/pages/PendingActions/Show.tsx
+++ b/resources/js/pages/PendingActions/Show.tsx
@@ -1,0 +1,213 @@
+import { Head, Link, router } from '@inertiajs/react'
+import { useState } from 'react'
+import AppLayout from '@/components/shared/app-layout'
+import { PageHeader } from '@/components/shared/page-header'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Textarea } from '@/components/ui/textarea'
+import {
+    AlertDialog,
+    AlertDialogAction,
+    AlertDialogCancel,
+    AlertDialogContent,
+    AlertDialogDescription,
+    AlertDialogFooter,
+    AlertDialogHeader,
+    AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
+import { ArrowLeft, Check, Undo2, X } from 'lucide-react'
+
+interface PendingActionShowProps {
+    pendingAction: {
+        id: number
+        tenant_id: number
+        agent_slug: string | null
+        session_id: string | null
+        tool: string
+        action: string
+        status: string
+        idempotency_key: string
+        payload: Record<string, unknown>
+        preview: { summary?: string; category?: string } | null
+        applied_diff: { before?: unknown; after?: unknown } | null
+        failure_reason: string | null
+        created_at: string
+        applied_at: string | null
+        reviewed_at: string | null
+        user?: { id: number; name: string; email: string }
+        agent_token?: { id: number; name: string; agent_slug: string | null }
+        reviewer?: { id: number; name: string }
+        reverter?: { id: number; name: string }
+    }
+    canApprove: boolean
+    canReject: boolean
+    canRevert: boolean
+}
+
+export default function PendingActionShow({ pendingAction, canApprove, canReject, canRevert }: PendingActionShowProps) {
+    const [rejectOpen, setRejectOpen] = useState(false)
+    const [reason, setReason] = useState('')
+
+    const approve = () => {
+        router.patch(`/dashboard/pending-actions/${pendingAction.id}/approve`)
+    }
+
+    const submitReject = () => {
+        router.patch(
+            `/dashboard/pending-actions/${pendingAction.id}/reject`,
+            { reason },
+            {
+                onFinish: () => {
+                    setRejectOpen(false)
+                    setReason('')
+                },
+            },
+        )
+    }
+
+    const revert = () => {
+        router.patch(`/dashboard/pending-actions/${pendingAction.id}/revert`)
+    }
+
+    return (
+        <AppLayout>
+            <Head title={`Pending action #${pendingAction.id}`} />
+            <PageHeader
+                title={`#${pendingAction.id} ${pendingAction.tool}`}
+                description={pendingAction.preview?.summary ?? pendingAction.action}
+                actions={
+                    <Button asChild variant="ghost" size="sm">
+                        <Link href="/dashboard/pending-actions">
+                            <ArrowLeft className="mr-1 h-4 w-4" />
+                            Back to list
+                        </Link>
+                    </Button>
+                }
+            />
+
+            <div className="mt-6 grid gap-6 lg:grid-cols-3">
+                <Card className="lg:col-span-2">
+                    <CardHeader>
+                        <CardTitle className="text-base">Payload</CardTitle>
+                    </CardHeader>
+                    <CardContent>
+                        <pre className="overflow-x-auto rounded-md bg-muted p-4 text-xs">
+                            {JSON.stringify(pendingAction.payload, null, 2)}
+                        </pre>
+                    </CardContent>
+                </Card>
+
+                <Card>
+                    <CardHeader>
+                        <CardTitle className="text-base">Status</CardTitle>
+                    </CardHeader>
+                    <CardContent className="space-y-3 text-sm">
+                        <div className="flex justify-between">
+                            <span className="text-muted-foreground">Status</span>
+                            <Badge variant="default">{pendingAction.status}</Badge>
+                        </div>
+                        <div className="flex justify-between">
+                            <span className="text-muted-foreground">Action</span>
+                            <span className="font-mono text-xs">{pendingAction.action}</span>
+                        </div>
+                        <div className="flex justify-between">
+                            <span className="text-muted-foreground">Agent</span>
+                            <span>{pendingAction.agent_slug ?? '—'}</span>
+                        </div>
+                        <div className="flex justify-between">
+                            <span className="text-muted-foreground">Created</span>
+                            <span>{new Date(pendingAction.created_at).toLocaleString()}</span>
+                        </div>
+                        {pendingAction.reviewed_at && (
+                            <div className="flex justify-between">
+                                <span className="text-muted-foreground">Reviewed</span>
+                                <span>{new Date(pendingAction.reviewed_at).toLocaleString()}</span>
+                            </div>
+                        )}
+                        {pendingAction.applied_at && (
+                            <div className="flex justify-between">
+                                <span className="text-muted-foreground">Applied</span>
+                                <span>{new Date(pendingAction.applied_at).toLocaleString()}</span>
+                            </div>
+                        )}
+                        <div className="break-all text-xs text-muted-foreground">
+                            <span>idempotency: </span>
+                            <span className="font-mono">{pendingAction.idempotency_key}</span>
+                        </div>
+                        {pendingAction.failure_reason && (
+                            <div className="rounded-md border border-destructive/50 bg-destructive/10 p-2 text-xs text-destructive">
+                                {pendingAction.failure_reason}
+                            </div>
+                        )}
+                    </CardContent>
+                </Card>
+
+                {pendingAction.applied_diff && (
+                    <Card className="lg:col-span-3">
+                        <CardHeader>
+                            <CardTitle className="text-base">Applied diff</CardTitle>
+                        </CardHeader>
+                        <CardContent className="grid gap-4 md:grid-cols-2">
+                            <div>
+                                <div className="mb-2 text-xs font-medium text-muted-foreground">Before</div>
+                                <pre className="overflow-x-auto rounded-md bg-muted p-4 text-xs">
+                                    {JSON.stringify(pendingAction.applied_diff.before ?? null, null, 2)}
+                                </pre>
+                            </div>
+                            <div>
+                                <div className="mb-2 text-xs font-medium text-muted-foreground">After</div>
+                                <pre className="overflow-x-auto rounded-md bg-muted p-4 text-xs">
+                                    {JSON.stringify(pendingAction.applied_diff.after ?? null, null, 2)}
+                                </pre>
+                            </div>
+                        </CardContent>
+                    </Card>
+                )}
+
+                <Card className="lg:col-span-3">
+                    <CardHeader>
+                        <CardTitle className="text-base">Actions</CardTitle>
+                    </CardHeader>
+                    <CardContent className="flex flex-wrap gap-3">
+                        <Button onClick={approve} disabled={!canApprove}>
+                            <Check className="mr-1 h-4 w-4" />
+                            Approve & apply
+                        </Button>
+                        <Button variant="outline" onClick={() => setRejectOpen(true)} disabled={!canReject}>
+                            <X className="mr-1 h-4 w-4" />
+                            Reject
+                        </Button>
+                        <Button variant="outline" onClick={revert} disabled={!canRevert}>
+                            <Undo2 className="mr-1 h-4 w-4" />
+                            Revert (within 10 min)
+                        </Button>
+                    </CardContent>
+                </Card>
+            </div>
+
+            <AlertDialog open={rejectOpen} onOpenChange={setRejectOpen}>
+                <AlertDialogContent>
+                    <AlertDialogHeader>
+                        <AlertDialogTitle>Reject pending action</AlertDialogTitle>
+                        <AlertDialogDescription>
+                            Optional: explain why this action is being rejected. The reason is stored on the audit record.
+                        </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <Textarea
+                        value={reason}
+                        onChange={(e) => setReason(e.target.value)}
+                        placeholder="Reason (optional)…"
+                        rows={3}
+                    />
+                    <AlertDialogFooter>
+                        <AlertDialogCancel>Cancel</AlertDialogCancel>
+                        <AlertDialogAction onClick={submitReject} className="bg-destructive text-destructive-foreground hover:bg-destructive/90">
+                            Reject
+                        </AlertDialogAction>
+                    </AlertDialogFooter>
+                </AlertDialogContent>
+            </AlertDialog>
+        </AppLayout>
+    )
+}

--- a/resources/js/types/index.ts
+++ b/resources/js/types/index.ts
@@ -19,6 +19,9 @@ export interface SharedProps {
     notifications: {
         unread_count: number
     }
+    pendingActions: {
+        count: number
+    }
     [key: string]: unknown
 }
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -286,6 +286,16 @@ Route::middleware('auth')->group(function () {
         Route::post('expenses/{expense}/duplicate', [ExpenseController::class, 'duplicate'])->name('expenses.duplicate');
         Route::post('expenses/bulk-action', [ExpenseController::class, 'bulkAction'])->name('expenses.bulk-action');
 
+        // Pending Agent Actions
+        Route::prefix('dashboard')->name('dashboard.')->group(function () {
+            Route::get('pending-actions', [\App\Http\Controllers\PendingActionsController::class, 'index'])->name('pending-actions.index');
+            Route::get('pending-actions/{pendingAction}', [\App\Http\Controllers\PendingActionsController::class, 'show'])->name('pending-actions.show');
+            Route::patch('pending-actions/{pendingAction}/approve', [\App\Http\Controllers\PendingActionsController::class, 'approve'])->name('pending-actions.approve');
+            Route::patch('pending-actions/{pendingAction}/reject', [\App\Http\Controllers\PendingActionsController::class, 'reject'])->name('pending-actions.reject');
+            Route::patch('pending-actions/{pendingAction}/revert', [\App\Http\Controllers\PendingActionsController::class, 'revert'])->name('pending-actions.revert');
+            Route::post('pending-actions/bulk-approve', [\App\Http\Controllers\PendingActionsController::class, 'bulkApprove'])->name('pending-actions.bulk-approve');
+        });
+
         // Budget Analytics routes must come before resource routes to prevent conflicts
         Route::get('budgets/analytics', [BudgetController::class, 'analytics'])->name('budgets.analytics');
 

--- a/tests/Feature/Agents/PendingActionApplierTest.php
+++ b/tests/Feature/Agents/PendingActionApplierTest.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Agents;
+
+use App\Models\AgentToken;
+use App\Models\Expense;
+use App\Models\PendingAction;
+use App\Models\Tenant;
+use App\Models\User;
+use App\Services\Agents\PendingActionApplier;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Validation\ValidationException;
+use Tests\TestCase;
+
+class PendingActionApplierTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+
+    private Tenant $tenant;
+
+    private AgentToken $token;
+
+    private PendingActionApplier $applier;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        ['user' => $this->user, 'tenant' => $this->tenant] = $this->setupTenantContext();
+        [$this->token] = AgentToken::issue($this->user, $this->tenant, 'phpunit', ['*']);
+        $this->applier = app(PendingActionApplier::class);
+    }
+
+    private function expensePayload(array $overrides = []): array
+    {
+        return array_merge([
+            'amount' => 12.5,
+            'currency' => 'EUR',
+            'expense_date' => '2026-05-01',
+            'merchant' => 'Lidl',
+            'category' => 'groceries',
+            'description' => 'Weekly groceries',
+        ], $overrides);
+    }
+
+    public function test_record_creates_pending_action(): void
+    {
+        $action = $this->applier->record($this->token, 'expenses.create', PendingAction::ACTION_CREATE, $this->expensePayload());
+
+        $this->assertEquals(PendingAction::STATUS_PENDING, $action->status);
+        $this->assertSame($this->tenant->id, $action->tenant_id);
+        $this->assertSame($this->user->id, $action->user_id);
+        $this->assertNotEmpty($action->idempotency_key);
+        $this->assertSame(0, Expense::query()->count(), 'No expense should be created until approval.');
+    }
+
+    public function test_record_dedupes_on_idempotency_key(): void
+    {
+        $first = $this->applier->record($this->token, 'expenses.create', PendingAction::ACTION_CREATE, $this->expensePayload());
+        $second = $this->applier->record($this->token, 'expenses.create', PendingAction::ACTION_CREATE, $this->expensePayload());
+
+        $this->assertSame($first->id, $second->id);
+        $this->assertSame(1, PendingAction::query()->count());
+    }
+
+    public function test_apply_creates_expense_with_agent_attribution(): void
+    {
+        $action = $this->applier->record($this->token, 'expenses.create', PendingAction::ACTION_CREATE, $this->expensePayload());
+        $applied = $this->applier->apply($action, $this->user);
+
+        $this->assertSame(PendingAction::STATUS_APPLIED, $applied->status);
+        $this->assertSame(1, Expense::query()->count());
+
+        $expense = Expense::query()->first();
+        $this->assertSame('agent', $expense->source);
+        $this->assertSame($this->token->id, $expense->created_by_agent_token_id);
+        $this->assertSame(Expense::class, $applied->target_type);
+        $this->assertSame($expense->id, $applied->target_id);
+    }
+
+    public function test_apply_validates_payload_against_form_request(): void
+    {
+        $action = $this->applier->record(
+            $this->token,
+            'expenses.create',
+            PendingAction::ACTION_CREATE,
+            $this->expensePayload(['amount' => 0]), // fails StoreExpenseRequest min:1
+        );
+
+        $this->expectException(ValidationException::class);
+        $this->applier->apply($action, $this->user);
+    }
+
+    public function test_reject_marks_pending_action_with_reason(): void
+    {
+        $action = $this->applier->record($this->token, 'expenses.create', PendingAction::ACTION_CREATE, $this->expensePayload());
+        $rejected = $this->applier->reject($action, $this->user, 'looks like a duplicate');
+
+        $this->assertSame(PendingAction::STATUS_REJECTED, $rejected->status);
+        $this->assertSame('looks like a duplicate', $rejected->failure_reason);
+        $this->assertSame(0, Expense::query()->count());
+    }
+
+    public function test_revert_deletes_created_expense_within_window(): void
+    {
+        $action = $this->applier->record($this->token, 'expenses.create', PendingAction::ACTION_CREATE, $this->expensePayload());
+        $applied = $this->applier->apply($action, $this->user);
+        $this->assertSame(1, Expense::query()->count());
+
+        $compensation = $this->applier->revert($applied, $this->user);
+
+        $this->assertSame(PendingAction::ACTION_REVERT, $compensation->action);
+        $this->assertSame(0, Expense::query()->count());
+        $this->assertSame(PendingAction::STATUS_REVERTED, $applied->refresh()->status);
+    }
+
+    public function test_auto_apply_requires_prior_approval_and_tenant_setting(): void
+    {
+        // First submission: pending, no auto-apply (config not set).
+        $first = $this->applier->record($this->token, 'expenses.create', PendingAction::ACTION_CREATE, $this->expensePayload());
+        $this->assertSame(PendingAction::STATUS_PENDING, $first->status);
+
+        // Approve it manually so the idempotency key is recorded as previously approved.
+        $this->applier->apply($first, $this->user);
+
+        // Flip the per-tenant tool_auto_apply for expenses.create.
+        $this->tenant->forceFill([
+            'tool_auto_apply' => ['expenses.create' => true],
+        ])->save();
+
+        // Submit a different expense (different idempotency key) — must still be pending,
+        // because the prior-approval check is keyed on the exact same idempotency key.
+        $different = $this->applier->record(
+            $this->token,
+            'expenses.create',
+            PendingAction::ACTION_CREATE,
+            $this->expensePayload(['merchant' => 'Konzum']),
+        );
+        $this->assertSame(PendingAction::STATUS_PENDING, $different->status);
+
+        // But we should never duplicate the original (idempotency dedup), so
+        // re-submitting the original key returns the already-applied row.
+        $resubmit = $this->applier->record($this->token, 'expenses.create', PendingAction::ACTION_CREATE, $this->expensePayload());
+        $this->assertSame($first->id, $resubmit->id);
+        $this->assertSame(PendingAction::STATUS_APPLIED, $resubmit->status);
+    }
+
+    public function test_writes_disabled_tenant_blocks_apply(): void
+    {
+        $action = $this->applier->record($this->token, 'expenses.create', PendingAction::ACTION_CREATE, $this->expensePayload());
+
+        $this->tenant->forceFill(['agents_writes_disabled' => true])->save();
+
+        $this->expectException(\RuntimeException::class);
+        $this->applier->apply($action->fresh(), $this->user);
+    }
+}

--- a/tests/Feature/Dashboard/PendingActionsControllerTest.php
+++ b/tests/Feature/Dashboard/PendingActionsControllerTest.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Dashboard;
+
+use App\Models\AgentToken;
+use App\Models\Expense;
+use App\Models\PendingAction;
+use App\Models\Tenant;
+use App\Models\User;
+use App\Services\Agents\PendingActionApplier;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PendingActionsControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+
+    private Tenant $tenant;
+
+    private AgentToken $token;
+
+    private PendingActionApplier $applier;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        ['user' => $this->user, 'tenant' => $this->tenant] = $this->setupTenantContext();
+        [$this->token] = AgentToken::issue($this->user, $this->tenant, 'phpunit', ['*']);
+        $this->applier = app(PendingActionApplier::class);
+    }
+
+    private function record(array $overrides = []): PendingAction
+    {
+        return $this->applier->record(
+            $this->token,
+            'expenses.create',
+            PendingAction::ACTION_CREATE,
+            array_merge([
+                'amount' => 12.5,
+                'currency' => 'EUR',
+                'expense_date' => '2026-05-01',
+                'merchant' => 'Lidl',
+                'category' => 'groceries',
+                'description' => 'Weekly groceries',
+            ], $overrides),
+        );
+    }
+
+    public function test_index_shows_pending_actions_for_current_tenant(): void
+    {
+        $this->record();
+
+        $response = $this->get(route('dashboard.pending-actions.index'));
+
+        $response->assertStatus(200);
+        $response->assertInertia(fn ($page) => $page
+            ->component('PendingActions/Index')
+            ->has('pendingActions.data', 1)
+        );
+    }
+
+    public function test_index_does_not_leak_other_tenant_actions(): void
+    {
+        // Foreign tenant + pending action.
+        $other = User::factory()->create();
+        $otherTenant = Tenant::factory()->create(['owner_id' => $other->id]);
+        $other->forceFill(['current_tenant_id' => $otherTenant->id])->save();
+        [$otherToken] = AgentToken::issue($other, $otherTenant, 'foreign', ['*']);
+
+        $this->actingAs($other);
+        $this->applier->record($otherToken, 'expenses.create', PendingAction::ACTION_CREATE, [
+            'amount' => 1, 'currency' => 'EUR', 'expense_date' => '2026-05-01',
+            'merchant' => 'Foreign', 'category' => 'x', 'description' => 'x',
+        ]);
+
+        $this->actingAs($this->user);
+
+        $this->get(route('dashboard.pending-actions.index'))
+            ->assertInertia(fn ($page) => $page->where('pendingActions.total', 0));
+    }
+
+    public function test_approve_applies_action_and_creates_expense(): void
+    {
+        $action = $this->record();
+
+        $this->patch(route('dashboard.pending-actions.approve', $action))
+            ->assertRedirect();
+
+        $action->refresh();
+        $this->assertSame(PendingAction::STATUS_APPLIED, $action->status);
+        $this->assertSame(1, Expense::query()->count());
+    }
+
+    public function test_reject_marks_action_with_reason(): void
+    {
+        $action = $this->record();
+
+        $this->patch(route('dashboard.pending-actions.reject', $action), [
+            'reason' => 'duplicate of existing entry',
+        ])->assertRedirect();
+
+        $action->refresh();
+        $this->assertSame(PendingAction::STATUS_REJECTED, $action->status);
+        $this->assertSame('duplicate of existing entry', $action->failure_reason);
+    }
+
+    public function test_revert_compensates_an_applied_action(): void
+    {
+        $action = $this->applier->apply($this->record(), $this->user);
+        $this->assertSame(1, Expense::query()->count());
+
+        $this->patch(route('dashboard.pending-actions.revert', $action))
+            ->assertRedirect();
+
+        $this->assertSame(0, Expense::query()->count());
+        $this->assertSame(PendingAction::STATUS_REVERTED, $action->refresh()->status);
+    }
+
+    public function test_bulk_approve_applies_selected_pending_actions(): void
+    {
+        $a = $this->record(['merchant' => 'Lidl']);
+        $b = $this->record(['merchant' => 'Konzum']);
+
+        $this->post(route('dashboard.pending-actions.bulk-approve'), [
+            'ids' => [$a->id, $b->id],
+        ])->assertRedirect();
+
+        $this->assertSame(2, Expense::query()->count());
+        $this->assertSame(PendingAction::STATUS_APPLIED, $a->refresh()->status);
+        $this->assertSame(PendingAction::STATUS_APPLIED, $b->refresh()->status);
+    }
+}

--- a/tests/Feature/Mcp/WriteToolsTest.php
+++ b/tests/Feature/Mcp/WriteToolsTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Mcp;
+
+use App\Mcp\LifeOsServer;
+use App\Mcp\Tools\Expenses\BulkImportExpenses;
+use App\Mcp\Tools\Expenses\CategorizeExpense;
+use App\Mcp\Tools\Expenses\CreateExpense;
+use App\Models\AgentToken;
+use App\Models\Expense;
+use App\Models\PendingAction;
+use App\Models\Tenant;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\App;
+use Tests\TestCase;
+
+class WriteToolsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+
+    private Tenant $tenant;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        ['user' => $this->user, 'tenant' => $this->tenant] = $this->setupTenantContext();
+
+        [$token] = AgentToken::issue($this->user, $this->tenant, 'phpunit', ['*']);
+        App::instance('agent.token', $token);
+    }
+
+    private function expenseArgs(array $overrides = []): array
+    {
+        return array_merge([
+            'amount' => 12.50,
+            'currency' => 'EUR',
+            'expense_date' => '2026-05-01',
+            'merchant' => 'Lidl',
+            'category' => 'groceries',
+            'description' => 'Weekly groceries',
+        ], $overrides);
+    }
+
+    public function test_expenses_create_returns_pending_action(): void
+    {
+        LifeOsServer::tool(CreateExpense::class, $this->expenseArgs())
+            ->assertOk()
+            ->assertStructuredContent(function (array $content): bool {
+                $this->assertArrayHasKey('pending_action_id', $content);
+                $this->assertSame(PendingAction::STATUS_PENDING, $content['status']);
+                $this->assertNotEmpty($content['idempotency_key']);
+                $this->assertFalse($content['auto_applied']);
+
+                return true;
+            });
+
+        $this->assertSame(1, PendingAction::query()->count());
+        $this->assertSame(0, Expense::query()->count(), 'No expense before approval.');
+    }
+
+    public function test_expenses_create_is_idempotent(): void
+    {
+        LifeOsServer::tool(CreateExpense::class, $this->expenseArgs());
+        LifeOsServer::tool(CreateExpense::class, $this->expenseArgs());
+
+        $this->assertSame(1, PendingAction::query()->count());
+    }
+
+    public function test_expenses_create_is_unauthorized_without_matching_ability(): void
+    {
+        [$restricted] = AgentToken::issue($this->user, $this->tenant, 'restricted', ['expenses.list']);
+        App::instance('agent.token', $restricted);
+
+        LifeOsServer::tool(CreateExpense::class, $this->expenseArgs())
+            ->assertHasErrors(['Agent token is not authorized to call [expenses.create].']);
+
+        $this->assertSame(0, PendingAction::query()->count());
+    }
+
+    public function test_expenses_bulk_import_creates_one_pending_row(): void
+    {
+        LifeOsServer::tool(BulkImportExpenses::class, [
+            'items' => [
+                $this->expenseArgs(),
+                $this->expenseArgs(['amount' => 5.0, 'merchant' => 'Konzum']),
+            ],
+        ])
+            ->assertOk()
+            ->assertStructuredContent(function (array $content): bool {
+                $this->assertSame(2, $content['item_count']);
+                $this->assertSame(PendingAction::STATUS_PENDING, $content['status']);
+
+                return true;
+            });
+
+        $this->assertSame(1, PendingAction::query()->count());
+        $this->assertSame('expenses.bulkImport', PendingAction::query()->first()->tool);
+    }
+
+    public function test_expenses_categorize_requires_existing_expense_in_tenant(): void
+    {
+        // Foreign expense in another tenant.
+        $other = User::factory()->create();
+        $otherTenant = Tenant::factory()->create(['owner_id' => $other->id]);
+        $other->forceFill(['current_tenant_id' => $otherTenant->id])->save();
+        $this->actingAs($other);
+        $foreign = Expense::factory()->create();
+
+        // Restore primary acting user.
+        $this->actingAs($this->user);
+
+        LifeOsServer::tool(CategorizeExpense::class, [
+            'expense_id' => $foreign->id,
+            'category' => 'travel',
+        ])->assertHasErrors([
+            "Expense [{$foreign->id}] not found in this tenant.",
+        ]);
+    }
+
+    public function test_expenses_categorize_records_pending_action_for_local_expense(): void
+    {
+        $expense = Expense::factory()->create();
+
+        LifeOsServer::tool(CategorizeExpense::class, [
+            'expense_id' => $expense->id,
+            'category' => 'travel',
+        ])->assertOk();
+
+        $this->assertSame(1, PendingAction::query()->count());
+        $action = PendingAction::query()->first();
+        $this->assertSame('expenses.categorize', $action->tool);
+        $this->assertSame($expense->id, (int) $action->payload['expense_id']);
+        $this->assertSame('travel', $action->payload['category']);
+    }
+}

--- a/tests/Unit/Services/Agents/IdempotencyKeyTest.php
+++ b/tests/Unit/Services/Agents/IdempotencyKeyTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Agents;
+
+use App\Services\Agents\IdempotencyKey;
+use InvalidArgumentException;
+use Tests\TestCase;
+
+class IdempotencyKeyTest extends TestCase
+{
+    private IdempotencyKey $keys;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->keys = new IdempotencyKey;
+    }
+
+    public function test_expenses_create_keys_are_deterministic(): void
+    {
+        $payload = [
+            'amount' => 12.5,
+            'currency' => 'EUR',
+            'expense_date' => '2026-05-01',
+            'merchant' => 'Lidl',
+        ];
+
+        $this->assertSame(
+            $this->keys->for('expenses.create', 1, $payload),
+            $this->keys->for('expenses.create', 1, $payload),
+        );
+    }
+
+    public function test_expenses_create_keys_normalize_merchant_whitespace_and_case(): void
+    {
+        $a = $this->keys->for('expenses.create', 1, [
+            'amount' => 5,
+            'currency' => 'EUR',
+            'expense_date' => '2026-05-01',
+            'merchant' => 'LIDL ',
+        ]);
+
+        $b = $this->keys->for('expenses.create', 1, [
+            'amount' => 5,
+            'currency' => 'EUR',
+            'expense_date' => '2026-05-01',
+            'merchant' => '  lidl',
+        ]);
+
+        $this->assertSame($a, $b);
+    }
+
+    public function test_expenses_create_keys_differ_across_tenants(): void
+    {
+        $payload = [
+            'amount' => 10,
+            'currency' => 'EUR',
+            'expense_date' => '2026-05-01',
+            'merchant' => 'Acme',
+        ];
+
+        $this->assertNotSame(
+            $this->keys->for('expenses.create', 1, $payload),
+            $this->keys->for('expenses.create', 2, $payload),
+        );
+    }
+
+    public function test_expenses_create_amount_drives_distinct_keys(): void
+    {
+        $this->assertNotSame(
+            $this->keys->for('expenses.create', 1, [
+                'amount' => 9.99,
+                'currency' => 'EUR',
+                'expense_date' => '2026-05-01',
+                'merchant' => 'Acme',
+            ]),
+            $this->keys->for('expenses.create', 1, [
+                'amount' => 10.00,
+                'currency' => 'EUR',
+                'expense_date' => '2026-05-01',
+                'merchant' => 'Acme',
+            ]),
+        );
+    }
+
+    public function test_bulk_import_is_order_insensitive(): void
+    {
+        $a = $this->keys->for('expenses.bulkImport', 1, [
+            'items' => [
+                ['amount' => 1, 'currency' => 'EUR', 'expense_date' => '2026-05-01', 'merchant' => 'A'],
+                ['amount' => 2, 'currency' => 'EUR', 'expense_date' => '2026-05-02', 'merchant' => 'B'],
+            ],
+        ]);
+
+        $b = $this->keys->for('expenses.bulkImport', 1, [
+            'items' => [
+                ['amount' => 2, 'currency' => 'EUR', 'expense_date' => '2026-05-02', 'merchant' => 'B'],
+                ['amount' => 1, 'currency' => 'EUR', 'expense_date' => '2026-05-01', 'merchant' => 'A'],
+            ],
+        ]);
+
+        $this->assertSame($a, $b);
+    }
+
+    public function test_categorize_keys_depend_on_target_and_category(): void
+    {
+        $a = $this->keys->for('expenses.categorize', 1, ['expense_id' => 7, 'category' => 'groceries']);
+        $b = $this->keys->for('expenses.categorize', 1, ['expense_id' => 7, 'category' => 'travel']);
+        $c = $this->keys->for('expenses.categorize', 1, ['expense_id' => 8, 'category' => 'groceries']);
+
+        $this->assertNotSame($a, $b);
+        $this->assertNotSame($a, $c);
+    }
+
+    public function test_unknown_tool_throws(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->keys->for('unknown.tool', 1, []);
+    }
+}


### PR DESCRIPTION
> Stacked on top of #148 (Phase 1). Once #148 merges to `claude/implement-managed-agents-L1MeH`, GitHub will retarget this PR automatically. Plan: `docs/agents/IMPLEMENTATION_PLAN.md`.

## Summary

Phase 2 adds a tenant-scoped `pending_actions` queue and the supporting service layer so MCP write tools record proposed writes for human review instead of mutating live data on call. Phase 2 covers Expenses only; the queue and approval surface are general and ready to absorb writes from later phases.

- **`pending_actions` table** with idempotency keys, polymorphic target, applied diff, and a revert chain. Unique on `(tenant_id, tool, idempotency_key)` so a duplicate submission returns the existing row rather than creating a second one.
- **Service-layer extraction.** `App\Services\Expenses\ExpenseService` now owns expense writes. `ExpenseController` and the existing `app/Ai/Tools/CreateExpense` both delegate, so user, in-app assistant, and agent writes share one path.
- **`PendingActionApplier`** records, applies, rejects, and reverts pending actions. Apply runs payloads through the same FormRequest the controller uses (`StoreExpenseRequest`), so agent writes are indistinguishable from user writes once approved. Auto-apply requires (a) `agents_writes_disabled = false`, (b) per-tenant `tool_auto_apply[tool] = true`, AND (c) an identical idempotency key already approved on this tenant. Defaults are all `false`, matching the plan's strict-Phase-2 stance.
- **MCP write tools.** `expenses.create`, `expenses.bulkImport`, `expenses.categorize`. Registered on `LifeOsServer`.
- **Dashboard.** `/dashboard/pending-actions` index with filters and bulk-approve; show page with payload, applied diff, approve/reject-with-reason/revert. A new global Inertia share `pendingActions.count` powers a destructive-style sidebar badge under Personal Finance — and the Notification Center can deep-link into the same page once Phase 3 starts emitting per-action notifications.
- **Idempotency key generators.** Per-tool deterministic SHA-256 over natural fields. `expenses.create` keys on (tenant, normalized merchant, amount cents, currency, expense_date, optional source_email_id). `expenses.bulkImport` keys over the sorted hashes of per-item create keys, so reorderings collide. `expenses.categorize` keys on (tenant, expense_id, category, subcategory).

## Test plan

- [ ] `composer install` (CI)
- [ ] `php artisan migrate` — three new migrations apply cleanly.
- [ ] `php artisan test --compact tests/Unit/Services/Agents tests/Feature/Agents tests/Feature/Mcp tests/Feature/Dashboard` — all green.
  - **Unit:** `IdempotencyKeyTest` covers determinism, merchant normalization, cross-tenant scoping, amount sensitivity, bulk-import order insensitivity, unknown-tool error.
  - **Feature:** `PendingActionApplierTest` covers record/dedup/apply/reject/revert, FormRequest enforcement, auto-apply gating, writes-disabled tenant guard.
  - **Feature:** `WriteToolsTest` covers MCP write tools queueing rather than mutating, idempotency, ability-layer rejection, tenant isolation on categorize.
  - **Feature:** `PendingActionsControllerTest` covers index isolation, approve/reject/revert/bulk-approve through the live web routes.
- [ ] `vendor/bin/pint --dirty --format agent`
- [ ] `npm run build` (or `dev`)
- [ ] Manual UI check at `/dashboard/pending-actions`: pending list renders, sidebar badge shows count, approve creates the expense, reject + reason persists, revert within 10 minutes deletes.
- [ ] Manual MCP smoke (Claude Code with the lifeos MCP entry): call `expenses.create` and confirm a pending action row appears with status `pending`. Call it again with the same args and confirm the same row is returned (idempotency).

## Notes / future work

- Auto-apply config is plumbed but **disabled by default**; the existing tests prove the gate works once flipped. UI for toggling lives in a later phase.
- Phase 2 only adds `source` + `created_by_agent_token_id` columns to `expenses` (the only module with writes today). Future phases will extend to the other modules as their write tools land.
- Notification Center integration (i.e. emitting a database notification of type `pending_action`) is intentionally deferred to Phase 3, where agent runs become the trigger source.

## Phase gate

Per the plan, Phase 2 ends with a stop-and-confirm. After this merges, demo end-to-end: from Claude Code call `expenses.create` against the deployed (or local) MCP server, then approve it in the dashboard. Confirm the audit trail (applied diff, reviewer) before Phase 3 starts.

https://claude.ai/code/session_01AxKEBuMxrHVjg7DShsnGi2

---
_Generated by [Claude Code](https://claude.ai/code/session_01AxKEBuMxrHVjg7DShsnGi2)_