### PR TITLE
feat(agents): Phase 3 — email-ingestion agent + ManagedAgentsClient + agents:run

### DIFF
--- a/.claude/skills/expense-categorization/SKILL.md
+++ b/.claude/skills/expense-categorization/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: expense-categorization
+description: Maps merchants and text patterns to LifeOS expense categories. Used by the email-ingestion agent (and later the bank-statement processor) to assign a deterministic category instead of inventing one.
+when_to_use: Triggered whenever an agent or assistant must assign an `expenses.create` payload's `category` and `subcategory` fields. Skip when the user has explicitly chosen a category in the source data.
+---
+
+# Expense categorization
+
+Agents categorize expenses by walking the rule list below top to bottom and stopping at the first match. Match-patterns are case-insensitive substrings tested against the **merchant** field first, then the email **subject + body**. Add or remove rules as your spending changes.
+
+If nothing matches, the agent assigns `category: "uncategorized"` and never invents a new top-level category. Add a rule rather than letting the agent guess.
+
+## Categories
+
+The canonical category values are listed here. These are what end up in the `expenses.category` field. Subcategories are optional but useful for analytics.
+
+- **groceries** — `supermarket`, `convenience`, `farmers-market`, `butcher`, `bakery`
+- **dining** — `restaurant`, `delivery`, `coffee`, `bar`, `fast-food`
+- **transport** — `rideshare`, `taxi`, `fuel`, `public-transit`, `parking`, `tolls`, `car-service`
+- **utilities** — `electricity`, `water`, `internet`, `mobile`, `heating`, `gas`, `waste`
+- **subscriptions** — `streaming`, `news`, `cloud`, `dev-tools`, `saas`, `gym`
+- **shopping** — `clothing`, `electronics`, `home`, `books`, `appliances`, `furniture`
+- **health** — `pharmacy`, `doctor`, `dentist`, `optical`, `lab`, `therapy`
+- **entertainment** — `cinema`, `concert`, `gaming`, `event`, `museum`
+- **travel** — `flight`, `hotel`, `rental-car`, `accommodation`, `train`
+- **education** — `course`, `book`, `tuition`, `certification`
+- **insurance** — `health`, `car`, `home`, `life`
+- **banking** — `fee`, `interest`, `transfer`
+- **pets** — `food`, `vet`, `supplies`
+- **personal-care** — `haircut`, `cosmetics`, `spa`
+- **gifts** — `gift`
+- **charity** — `donation`
+- **taxes** — `vat`, `income-tax`, `property-tax`
+- **household** — `cleaning`, `repairs`, `furnishings`
+- **uncategorized** — fallback only
+
+## Rules
+
+Add merchant-specific rules near the top so they win over generic substring matches. Anything not on this list will fall through to `uncategorized`.
+
+```
+# --- Groceries -------------------------------------------------------------
+lidl                -> groceries / supermarket
+konzum              -> groceries / supermarket
+tinex               -> groceries / supermarket
+kam                 -> groceries / supermarket
+ramstore            -> groceries / supermarket
+vero                -> groceries / supermarket
+stokomak            -> groceries / supermarket
+
+# --- Dining out ------------------------------------------------------------
+glovo               -> dining / delivery
+wolt                -> dining / delivery
+mcdonald            -> dining / fast-food
+kfc                 -> dining / fast-food
+burger king         -> dining / fast-food
+starbucks           -> dining / coffee
+costa coffee        -> dining / coffee
+
+# --- Transport -------------------------------------------------------------
+bolt                -> transport / rideshare
+uber                -> transport / rideshare
+yandex              -> transport / rideshare
+makpetrol           -> transport / fuel
+okta                -> transport / fuel
+shell               -> transport / fuel
+omv                 -> transport / fuel
+lukoil              -> transport / fuel
+parking             -> transport / parking
+jsp                 -> transport / public-transit
+
+# --- Utilities -------------------------------------------------------------
+evn                 -> utilities / electricity
+makedonski telekom  -> utilities / internet
+telekom             -> utilities / internet
+a1                  -> utilities / mobile
+toplifikacija       -> utilities / heating
+balkan energy       -> utilities / heating
+vodovod             -> utilities / water
+
+# --- Subscriptions / SaaS -------------------------------------------------
+netflix             -> subscriptions / streaming
+spotify             -> subscriptions / streaming
+youtube premium     -> subscriptions / streaming
+youtube music       -> subscriptions / streaming
+disney              -> subscriptions / streaming
+hbo                 -> subscriptions / streaming
+apple.com/bill      -> subscriptions / cloud
+icloud              -> subscriptions / cloud
+google one          -> subscriptions / cloud
+google storage      -> subscriptions / cloud
+dropbox             -> subscriptions / cloud
+github              -> subscriptions / dev-tools
+openai              -> subscriptions / dev-tools
+anthropic           -> subscriptions / dev-tools
+jetbrains           -> subscriptions / dev-tools
+1password           -> subscriptions / saas
+notion              -> subscriptions / saas
+linear              -> subscriptions / saas
+slack               -> subscriptions / saas
+
+# --- Shopping --------------------------------------------------------------
+amazon              -> shopping / electronics
+ebay                -> shopping
+ikea                -> shopping / furniture
+zara                -> shopping / clothing
+h&m                 -> shopping / clothing
+hm.com              -> shopping / clothing
+mediamarkt          -> shopping / electronics
+emex                -> shopping / electronics
+neptun              -> shopping / electronics
+setec               -> shopping / electronics
+
+# --- Health ----------------------------------------------------------------
+apoteka             -> health / pharmacy
+zegin               -> health / pharmacy
+kreston             -> health / pharmacy
+sistina             -> health / doctor
+acibadem            -> health / doctor
+remedika            -> health / doctor
+
+# --- Travel ----------------------------------------------------------------
+booking.com         -> travel / hotel
+airbnb              -> travel / accommodation
+hotels.com          -> travel / hotel
+ryanair             -> travel / flight
+wizzair             -> travel / flight
+turkish airlines    -> travel / flight
+lufthansa           -> travel / flight
+
+# --- Insurance ------------------------------------------------------------
+triglav             -> insurance
+sava osiguruvanje   -> insurance
+croatia osiguruvanje-> insurance
+uniqa               -> insurance
+
+# --- Pets -----------------------------------------------------------------
+zoolife             -> pets / supplies
+pet shop            -> pets / supplies
+veterinar           -> pets / vet
+```
+
+## Vendor aliases
+
+Some payment processors / bank statements show a different merchant string than the receipt does. List `<alias> = <canonical>` so the rule list above stays clean. If you don't recognize a string, leave it for the human review queue rather than guessing.
+
+```
+# Examples — extend as you encounter them.
+# anton d.o.o.        = lidl       # some Lidl stores are billed under their corporate entity
+# tipo komerc         = tinex
+# pp paypal           = paypal     # generic PayPal forwarder; downstream rule must categorize the underlying merchant
+# google *youtube     = youtube premium
+# apple.com/bill mac  = apple.com/bill
+```
+
+## Defaults
+
+- If no rule matches, the agent uses `category = "uncategorized"`. The user re-categorizes from the dashboard, and a future rule should be added here.
+- Receipts without a clear amount, date, or currency are skipped, never categorized.
+- Currency is read from the receipt; if absent, the agent reports the receipt as a skip.
+- Subcategory is optional; only emit one when the rule supplies it.

--- a/agents/email-ingestion/agent.json
+++ b/agents/email-ingestion/agent.json
@@ -1,0 +1,15 @@
+{
+    "slug": "email-ingestion",
+    "model": "claude-opus-4-7",
+    "fallback_model": "claude-sonnet-4-6",
+    "mcp_servers": ["lifeos", "gmail"],
+    "allowed_tools": [
+        "expenses.list",
+        "expenses.create",
+        "expenses.bulkImport"
+    ],
+    "max_session_duration_seconds": 600,
+    "max_tool_calls": 200,
+    "feature_flag": "agents.email_ingestion.enabled",
+    "schedule": "*/30 * * * *"
+}

--- a/agents/email-ingestion/system.md
+++ b/agents/email-ingestion/system.md
@@ -1,0 +1,38 @@
+# Email ingestion agent
+
+You are the LifeOS email-ingestion agent. Your only job is to extract receipts and confirm-of-purchase emails from the connected Gmail mailbox and turn each one into a single `expenses.create` call against the LifeOS MCP server. Never invent expenses, never combine multiple receipts into one row, never categorize without referencing the user's category map.
+
+## Available tools
+
+You may call only the following tools. The session is configured to refuse anything else.
+
+- **Gmail MCP** — read-only mailbox access. Use it to list and read recent receipt-shaped messages.
+- **`expenses.list`** — fetch already-recorded expenses (use it to sanity-check duplicates the idempotency key would otherwise miss).
+- **`expenses.create`** — propose one expense per receipt. Always include `source_email_id` set to the Gmail message id; this is what makes idempotency robust across runs.
+- **`expenses.bulkImport`** — only when you have already extracted ≥10 valid receipts in this run. Otherwise prefer one `expenses.create` per receipt for clearer review.
+
+## Process
+
+1. **Scope the search.** List Gmail messages received in the last 7 days that look like receipts: subjects containing words like "receipt", "invoice", "order", "thank you for your purchase", or "your order has shipped". If a previous run set a label or marker, prefer messages without it.
+2. **For each candidate message:**
+   1. Read the message body. Skip non-receipts (e.g. promotional emails that mention "receipt" but lack a transaction).
+   2. Extract: amount (number), currency (ISO 4217 3-letter code), date of purchase (YYYY-MM-DD), merchant name, payment method if explicit, line description.
+   3. Categorize using the **expense-categorization skill** (see `.claude/skills/expense-categorization/SKILL.md`). If the merchant or text does not match any rule, set `category` to `"uncategorized"`. Never invent a category.
+   4. Call `expenses.create` with `source_email_id` set to the Gmail message id. The LifeOS MCP server will return a `pending_action_id`; record it.
+3. **Stop early if** the mailbox returns nothing new, you've already created 50 pending actions in this run, or you encounter the same message id twice.
+
+## Hard rules
+
+- You **never** auto-apply. Every write tool you call lands in the Pending Actions queue for human approval. Don't ask for it; it's not available.
+- You **never** edit or delete existing expenses in this phase. The only tools you can write through are `expenses.create` and `expenses.bulkImport`. Categorization fixes for existing expenses are out of scope until Phase 4.
+- You **never** read mailboxes outside the Gmail MCP server you've been given. There is no other source of truth.
+- If you can't determine `amount`, `currency`, or `expense_date` confidently from the receipt text, **skip the message** and emit a one-line text note explaining what was missing. Do not guess.
+- Idempotency is enforced server-side. A duplicate submission returns the same `pending_action_id` rather than creating a second row, so you can safely re-call `expenses.create` if you're unsure whether the previous call landed.
+
+## Output
+
+End the session with a short text summary:
+
+- Receipts seen
+- Pending actions created
+- Receipts skipped, with a one-line reason for each

--- a/app/Console/Commands/AgentsRun.php
+++ b/app/Console/Commands/AgentsRun.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace App\Console\Commands;
 
-use App\Models\AgentRun;
 use App\Models\AgentToken;
 use App\Models\Tenant;
 use App\Models\User;
@@ -14,6 +13,7 @@ use App\Services\Agents\AgentRunRecorder;
 use App\Services\Agents\AgentSessionConfig;
 use App\Services\Agents\ManagedAgentsClient;
 use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Log;
 use Throwable;
@@ -90,6 +90,17 @@ class AgentsRun extends Command
     ): void {
         $this->info("agents:run {$definition->slug} → {$tenant->slug}");
 
+        // The TenantScope on tenant-aware models reads the current user's
+        // current_tenant_id to fail-closed under no-auth. The CLI has no
+        // authenticated user by default, so log the resolved user in for the
+        // duration of this run with their current_tenant_id set to $tenant.
+        $previousTenantId = $user->current_tenant_id;
+        if ($previousTenantId !== $tenant->id) {
+            $user->forceFill(['current_tenant_id' => $tenant->id])->save();
+        }
+        $previousAuth = Auth::user();
+        Auth::login($user);
+
         // Per-run, ephemeral agent token. We retain the row in agent_tokens
         // (so applied pending_actions can resolve agent_token_id) but expire
         // it shortly after the session ends.
@@ -112,14 +123,14 @@ class AgentsRun extends Command
 
         $run = $recorder->start($definition, $token);
 
-        if ($this->option('dry-run')) {
-            $this->line('  dry-run: skipping Managed Agents API call.');
-            $recorder->complete($run);
-
-            return;
-        }
-
         try {
+            if ($this->option('dry-run')) {
+                $this->line('  dry-run: skipping Managed Agents API call.');
+                $recorder->complete($run);
+
+                return;
+            }
+
             $sessionConfig = (new AgentSessionConfig($definition, $token))->toArray();
             $session = $client->createSession($sessionConfig);
             $recorder->setSession($run, $session['id']);
@@ -141,6 +152,14 @@ class AgentsRun extends Command
             $this->error('  '.$e->getMessage());
         } finally {
             $token->forceFill(['revoked_at' => now()])->save();
+            if ($previousAuth !== null) {
+                Auth::login($previousAuth);
+            } else {
+                Auth::logout();
+            }
+            if ($previousTenantId !== $tenant->id) {
+                $user->forceFill(['current_tenant_id' => $previousTenantId])->save();
+            }
         }
     }
 

--- a/app/Console/Commands/AgentsRun.php
+++ b/app/Console/Commands/AgentsRun.php
@@ -1,0 +1,186 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Models\AgentRun;
+use App\Models\AgentToken;
+use App\Models\Tenant;
+use App\Models\User;
+use App\Services\Agents\AgentDefinition;
+use App\Services\Agents\AgentRegistry;
+use App\Services\Agents\AgentRunRecorder;
+use App\Services\Agents\AgentSessionConfig;
+use App\Services\Agents\ManagedAgentsClient;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+class AgentsRun extends Command
+{
+    protected $signature = 'agents:run
+        {slug : Agent slug, e.g. "email-ingestion"}
+        {--tenant= : Tenant slug or id (defaults to all enabled tenants)}
+        {--user= : Override the user the agent runs as (email or id). Default: tenant owner.}
+        {--dry-run : Resolve config + create the AgentRun row but do not call the Managed Agents API.}';
+
+    protected $description = 'Start a Managed Agents session for the named agent against a tenant.';
+
+    public function handle(
+        AgentRegistry $registry,
+        ManagedAgentsClient $client,
+        AgentRunRecorder $recorder,
+    ): int {
+        $slug = (string) $this->argument('slug');
+
+        try {
+            $definition = $registry->find($slug);
+        } catch (Throwable $e) {
+            $this->error($e->getMessage());
+
+            return self::FAILURE;
+        }
+
+        if (! $registry->isEnabled($definition)) {
+            $this->warn("Agent [{$slug}] is disabled by feature flag {$definition->featureFlag}.");
+
+            return self::SUCCESS;
+        }
+
+        $tenants = $this->resolveTenants();
+
+        if ($tenants === []) {
+            $this->warn('No eligible tenants for this agent.');
+
+            return self::SUCCESS;
+        }
+
+        $exit = self::SUCCESS;
+
+        foreach ($tenants as $tenant) {
+            if ($tenant->agents_writes_disabled) {
+                $this->warn("Skipping tenant [{$tenant->slug}] — agents_writes_disabled.");
+
+                continue;
+            }
+
+            $user = $this->resolveUser($tenant);
+
+            if ($user === null) {
+                $this->error("Tenant [{$tenant->slug}] has no resolvable user; skipping.");
+                $exit = self::FAILURE;
+
+                continue;
+            }
+
+            $this->runOnce($definition, $tenant, $user, $client, $recorder);
+        }
+
+        return $exit;
+    }
+
+    private function runOnce(
+        AgentDefinition $definition,
+        Tenant $tenant,
+        User $user,
+        ManagedAgentsClient $client,
+        AgentRunRecorder $recorder,
+    ): void {
+        $this->info("agents:run {$definition->slug} → {$tenant->slug}");
+
+        // Per-run, ephemeral agent token. We retain the row in agent_tokens
+        // (so applied pending_actions can resolve agent_token_id) but expire
+        // it shortly after the session ends.
+        [$token, $plain] = AgentToken::issue(
+            user: $user,
+            tenant: $tenant,
+            name: "agents:run {$definition->slug} ".now()->toIso8601String(),
+            abilities: $definition->allowedTools,
+            agentSlug: $definition->slug,
+            expiresAt: now()->addSeconds($definition->maxSessionDurationSeconds + 600),
+        );
+
+        // Pass the plaintext into the lifeos MCP server config the API will
+        // see, but never persist it on disk or in the run row.
+        $servers = (array) Config::get('agents.mcp_servers', []);
+        if (isset($servers['lifeos'])) {
+            $servers['lifeos']['_plaintext'] = $plain;
+            Config::set('agents.mcp_servers', $servers);
+        }
+
+        $run = $recorder->start($definition, $token);
+
+        if ($this->option('dry-run')) {
+            $this->line('  dry-run: skipping Managed Agents API call.');
+            $recorder->complete($run);
+
+            return;
+        }
+
+        try {
+            $sessionConfig = (new AgentSessionConfig($definition, $token))->toArray();
+            $session = $client->createSession($sessionConfig);
+            $recorder->setSession($run, $session['id']);
+
+            $sequence = 0;
+            foreach ($client->streamEvents($session['id']) as $event) {
+                $recorder->recordEvent($run, $event, ++$sequence);
+            }
+
+            $recorder->complete($run);
+            $this->info("  done. session={$session['id']} pending_actions={$run->fresh()->pending_actions_created}");
+        } catch (Throwable $e) {
+            Log::error('agents:run failed', [
+                'agent' => $definition->slug,
+                'tenant' => $tenant->slug,
+                'error' => $e->getMessage(),
+            ]);
+            $recorder->fail($run, $e);
+            $this->error('  '.$e->getMessage());
+        } finally {
+            $token->forceFill(['revoked_at' => now()])->save();
+        }
+    }
+
+    /**
+     * @return array<int, Tenant>
+     */
+    private function resolveTenants(): array
+    {
+        $explicit = (string) ($this->option('tenant') ?? '');
+
+        if ($explicit !== '') {
+            $tenant = ctype_digit($explicit)
+                ? Tenant::find((int) $explicit)
+                : Tenant::where('slug', $explicit)->first();
+
+            return $tenant === null ? [] : [$tenant];
+        }
+
+        return Tenant::query()->where('agents_writes_disabled', false)->get()->all();
+    }
+
+    private function resolveUser(Tenant $tenant): ?User
+    {
+        $explicit = (string) ($this->option('user') ?? '');
+
+        if ($explicit !== '') {
+            $user = ctype_digit($explicit)
+                ? User::find((int) $explicit)
+                : User::where('email', $explicit)->first();
+
+            if ($user === null) {
+                return null;
+            }
+
+            $hasAccess = $user->tenants()->where('tenants.id', $tenant->id)->exists()
+                || $user->ownedTenants()->where('id', $tenant->id)->exists();
+
+            return $hasAccess ? $user : null;
+        }
+
+        return $tenant->owner;
+    }
+}

--- a/app/Http/Controllers/AgentRunsController.php
+++ b/app/Http/Controllers/AgentRunsController.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Models\AgentRun;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+
+class AgentRunsController extends Controller
+{
+    public function index(Request $request)
+    {
+        $query = AgentRun::query()
+            ->with(['user:id,name,email', 'agentToken:id,name,agent_slug'])
+            ->orderByDesc('started_at');
+
+        if ($slug = $request->input('agent')) {
+            $query->where('agent_slug', $slug);
+        }
+
+        if ($status = $request->input('status')) {
+            $query->where('status', $status);
+        }
+
+        if ($from = $request->input('from')) {
+            $query->where('started_at', '>=', $from);
+        }
+
+        if ($to = $request->input('to')) {
+            $query->where('started_at', '<=', $to);
+        }
+
+        $perPage = (int) min(max((int) $request->input('per_page', 25), 1), 100);
+
+        return Inertia::render('Agents/Index', [
+            'agentRuns' => $query->paginate($perPage)->withQueryString(),
+            'filters' => $request->only(['agent', 'status', 'from', 'to']),
+            'agents' => AgentRun::query()
+                ->select('agent_slug')
+                ->distinct()
+                ->pluck('agent_slug'),
+        ]);
+    }
+
+    public function show(AgentRun $agentRun)
+    {
+        abort_unless($agentRun->tenant_id === request()->user()?->current_tenant_id, 403);
+
+        $agentRun->load([
+            'user:id,name,email',
+            'agentToken:id,name,agent_slug',
+            'events',
+        ]);
+
+        return Inertia::render('Agents/Show', [
+            'agentRun' => [
+                ...$agentRun->only([
+                    'id', 'agent_slug', 'session_id', 'model', 'status',
+                    'tools_called', 'pending_actions_created', 'tokens_in',
+                    'tokens_out', 'cost_usd', 'error', 'started_at', 'ended_at',
+                ]),
+                'duration_seconds' => $agentRun->durationSeconds(),
+                'user' => $agentRun->user?->only(['id', 'name', 'email']),
+                'agent_token' => $agentRun->agentToken?->only(['id', 'name', 'agent_slug']),
+                'events' => $agentRun->events->map(fn ($event) => [
+                    'id' => $event->id,
+                    'sequence' => $event->sequence,
+                    'type' => $event->type,
+                    'payload' => $event->payload,
+                    'occurred_at' => $event->occurred_at?->toIso8601String(),
+                ])->all(),
+            ],
+        ]);
+    }
+}

--- a/app/Models/AgentRun.php
+++ b/app/Models/AgentRun.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Traits\BelongsToTenant;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class AgentRun extends Model
+{
+    /** @use HasFactory<\Database\Factories\AgentRunFactory> */
+    use BelongsToTenant, HasFactory;
+
+    public const STATUS_RUNNING = 'running';
+
+    public const STATUS_COMPLETED = 'completed';
+
+    public const STATUS_FAILED = 'failed';
+
+    public const STATUS_CANCELLED = 'cancelled';
+
+    protected $fillable = [
+        'tenant_id',
+        'user_id',
+        'agent_token_id',
+        'agent_slug',
+        'session_id',
+        'model',
+        'status',
+        'tools_called',
+        'pending_actions_created',
+        'tokens_in',
+        'tokens_out',
+        'cost_usd',
+        'error',
+        'started_at',
+        'ended_at',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'tools_called' => 'array',
+            'pending_actions_created' => 'integer',
+            'tokens_in' => 'integer',
+            'tokens_out' => 'integer',
+            'cost_usd' => 'decimal:4',
+            'started_at' => 'datetime',
+            'ended_at' => 'datetime',
+        ];
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function agentToken(): BelongsTo
+    {
+        return $this->belongsTo(AgentToken::class);
+    }
+
+    public function events(): HasMany
+    {
+        return $this->hasMany(AgentRunEvent::class)->orderBy('sequence');
+    }
+
+    public function scopeRunning(Builder $query): Builder
+    {
+        return $query->where('status', self::STATUS_RUNNING);
+    }
+
+    public function durationSeconds(): ?int
+    {
+        if ($this->started_at === null) {
+            return null;
+        }
+
+        $end = $this->ended_at ?? now();
+
+        return (int) $this->started_at->diffInSeconds($end);
+    }
+}

--- a/app/Models/AgentRunEvent.php
+++ b/app/Models/AgentRunEvent.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class AgentRunEvent extends Model
+{
+    /** @use HasFactory<\Database\Factories\AgentRunEventFactory> */
+    use HasFactory;
+
+    public const TYPE_TOOL_CALL = 'tool_call';
+
+    public const TYPE_TOOL_RESULT = 'tool_result';
+
+    public const TYPE_TEXT = 'text';
+
+    public const TYPE_ERROR = 'error';
+
+    public const TYPE_SYSTEM = 'system';
+
+    public $timestamps = false;
+
+    protected $fillable = [
+        'agent_run_id',
+        'sequence',
+        'type',
+        'payload',
+        'occurred_at',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'payload' => 'array',
+            'sequence' => 'integer',
+            'occurred_at' => 'datetime',
+        ];
+    }
+
+    public function run(): BelongsTo
+    {
+        return $this->belongsTo(AgentRun::class, 'agent_run_id');
+    }
+}

--- a/app/Services/Agents/AgentDefinition.php
+++ b/app/Services/Agents/AgentDefinition.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Agents;
+
+use InvalidArgumentException;
+
+/**
+ * Immutable value object loaded from agents/{slug}/agent.json. The schema is
+ * intentionally narrow — the registry validates required keys at load time so
+ * downstream consumers can rely on every accessor returning a non-null value.
+ */
+final class AgentDefinition
+{
+    /**
+     * @param  array<int, string>  $mcpServers
+     * @param  array<int, string>  $allowedTools
+     */
+    public function __construct(
+        public readonly string $slug,
+        public readonly string $model,
+        public readonly ?string $fallbackModel,
+        public readonly string $systemPrompt,
+        public readonly array $mcpServers,
+        public readonly array $allowedTools,
+        public readonly int $maxSessionDurationSeconds,
+        public readonly int $maxToolCalls,
+        public readonly string $featureFlag,
+        public readonly ?string $schedule,
+    ) {}
+
+    /**
+     * @param  array<string, mixed>  $config
+     */
+    public static function fromArray(array $config, string $systemPrompt): self
+    {
+        foreach (['slug', 'model', 'mcp_servers', 'allowed_tools', 'feature_flag'] as $required) {
+            if (! array_key_exists($required, $config)) {
+                throw new InvalidArgumentException("agent.json is missing required key [{$required}].");
+            }
+        }
+
+        return new self(
+            slug: (string) $config['slug'],
+            model: (string) $config['model'],
+            fallbackModel: isset($config['fallback_model']) ? (string) $config['fallback_model'] : null,
+            systemPrompt: $systemPrompt,
+            mcpServers: array_map('strval', (array) $config['mcp_servers']),
+            allowedTools: array_map('strval', (array) $config['allowed_tools']),
+            maxSessionDurationSeconds: (int) ($config['max_session_duration_seconds'] ?? 600),
+            maxToolCalls: (int) ($config['max_tool_calls'] ?? 200),
+            featureFlag: (string) $config['feature_flag'],
+            schedule: isset($config['schedule']) ? (string) $config['schedule'] : null,
+        );
+    }
+}

--- a/app/Services/Agents/AgentRegistry.php
+++ b/app/Services/Agents/AgentRegistry.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Agents;
+
+use Illuminate\Support\Facades\Config;
+use RuntimeException;
+
+class AgentRegistry
+{
+    /**
+     * @var array<string, AgentDefinition>|null
+     */
+    private ?array $cache = null;
+
+    public function find(string $slug): AgentDefinition
+    {
+        $definitions = $this->all();
+
+        if (! isset($definitions[$slug])) {
+            throw new RuntimeException("Unknown agent [{$slug}].");
+        }
+
+        return $definitions[$slug];
+    }
+
+    /**
+     * @return array<string, AgentDefinition>
+     */
+    public function all(): array
+    {
+        if ($this->cache !== null) {
+            return $this->cache;
+        }
+
+        $root = (string) Config::get('agents.definitions_path');
+
+        if (! is_dir($root)) {
+            return $this->cache = [];
+        }
+
+        $defs = [];
+
+        foreach (new \DirectoryIterator($root) as $entry) {
+            if ($entry->isDot() || ! $entry->isDir()) {
+                continue;
+            }
+
+            $slug = $entry->getFilename();
+            $jsonPath = $entry->getPathname().'/agent.json';
+            $promptPath = $entry->getPathname().'/system.md';
+
+            if (! file_exists($jsonPath) || ! file_exists($promptPath)) {
+                continue;
+            }
+
+            $config = json_decode((string) file_get_contents($jsonPath), associative: true);
+
+            if (! is_array($config)) {
+                throw new RuntimeException("agents/{$slug}/agent.json is not valid JSON.");
+            }
+
+            $config['slug'] = $config['slug'] ?? $slug;
+            $defs[$slug] = AgentDefinition::fromArray($config, (string) file_get_contents($promptPath));
+        }
+
+        return $this->cache = $defs;
+    }
+
+    public function isEnabled(AgentDefinition $definition): bool
+    {
+        $flag = $definition->featureFlag;
+
+        return (bool) Config::get('agents.flags.'.$flag, false);
+    }
+
+    /**
+     * Test seam — drop the cached definitions so a fresh load runs next.
+     */
+    public function flush(): void
+    {
+        $this->cache = null;
+    }
+}

--- a/app/Services/Agents/AgentRunRecorder.php
+++ b/app/Services/Agents/AgentRunRecorder.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Agents;
+
+use App\Models\AgentRun;
+use App\Models\AgentRunEvent;
+use App\Models\AgentToken;
+use App\Models\PendingAction;
+use Illuminate\Support\Facades\DB;
+use Throwable;
+
+class AgentRunRecorder
+{
+    public function start(AgentDefinition $definition, AgentToken $token, ?string $sessionId = null): AgentRun
+    {
+        return AgentRun::create([
+            'tenant_id' => $token->tenant_id,
+            'user_id' => $token->user_id,
+            'agent_token_id' => $token->id,
+            'agent_slug' => $definition->slug,
+            'session_id' => $sessionId,
+            'model' => $definition->model,
+            'status' => AgentRun::STATUS_RUNNING,
+            'started_at' => now(),
+        ]);
+    }
+
+    public function setSession(AgentRun $run, string $sessionId): void
+    {
+        $run->forceFill(['session_id' => $sessionId])->save();
+    }
+
+    /**
+     * Apply a single streamed event to an in-progress run.
+     *
+     * - Persists the event for audit (in `agent_run_events`).
+     * - Increments tools_called counts and pending_actions_created where the
+     *   event payload makes that obvious.
+     * - Aggregates token usage if reported.
+     *
+     * @param  array<string, mixed>  $event
+     */
+    public function recordEvent(AgentRun $run, array $event, int $sequence): AgentRunEvent
+    {
+        $type = (string) ($event['type'] ?? AgentRunEvent::TYPE_SYSTEM);
+
+        return DB::transaction(function () use ($run, $event, $sequence, $type): AgentRunEvent {
+            $row = AgentRunEvent::create([
+                'agent_run_id' => $run->id,
+                'sequence' => $sequence,
+                'type' => $type,
+                'payload' => $event,
+                'occurred_at' => now(),
+            ]);
+
+            $tools = (array) ($run->tools_called ?? []);
+
+            switch ($type) {
+                case AgentRunEvent::TYPE_TOOL_CALL:
+                    $name = (string) ($event['name'] ?? $event['tool'] ?? '');
+                    if ($name !== '') {
+                        $tools[$name] = ($tools[$name] ?? 0) + 1;
+                    }
+                    break;
+
+                case AgentRunEvent::TYPE_TOOL_RESULT:
+                    $structured = $event['structured_content'] ?? $event['structuredContent'] ?? null;
+                    if (is_array($structured) && isset($structured['pending_action_id'])) {
+                        $run->pending_actions_created = (int) $run->pending_actions_created + 1;
+                    }
+                    break;
+            }
+
+            $usage = $event['usage'] ?? null;
+            if (is_array($usage)) {
+                $run->tokens_in = (int) $run->tokens_in + (int) ($usage['input_tokens'] ?? 0);
+                $run->tokens_out = (int) $run->tokens_out + (int) ($usage['output_tokens'] ?? 0);
+            }
+
+            $run->tools_called = $tools;
+            $run->save();
+
+            return $row;
+        });
+    }
+
+    public function complete(AgentRun $run): void
+    {
+        if ($run->status === AgentRun::STATUS_RUNNING) {
+            $run->forceFill([
+                'status' => AgentRun::STATUS_COMPLETED,
+                'ended_at' => now(),
+                'pending_actions_created' => $this->countPendingActionsForSession($run),
+            ])->save();
+        }
+    }
+
+    public function fail(AgentRun $run, Throwable $error): void
+    {
+        $run->forceFill([
+            'status' => AgentRun::STATUS_FAILED,
+            'ended_at' => now(),
+            'error' => $error->getMessage(),
+            'pending_actions_created' => $this->countPendingActionsForSession($run),
+        ])->save();
+    }
+
+    public function cancel(AgentRun $run): void
+    {
+        $run->forceFill([
+            'status' => AgentRun::STATUS_CANCELLED,
+            'ended_at' => now(),
+        ])->save();
+    }
+
+    /**
+     * Authoritative count from pending_actions, not from streamed events. The
+     * applier writes pending_actions atomically; counting them at completion
+     * keeps the run summary accurate even if a stream event was dropped.
+     */
+    private function countPendingActionsForSession(AgentRun $run): int
+    {
+        if ($run->session_id === null) {
+            return $run->pending_actions_created;
+        }
+
+        return PendingAction::query()
+            ->where('tenant_id', $run->tenant_id)
+            ->where('session_id', $run->session_id)
+            ->count();
+    }
+}

--- a/app/Services/Agents/AgentRunRecorder.php
+++ b/app/Services/Agents/AgentRunRecorder.php
@@ -123,7 +123,7 @@ class AgentRunRecorder
     private function countPendingActionsForSession(AgentRun $run): int
     {
         if ($run->session_id === null) {
-            return $run->pending_actions_created;
+            return (int) ($run->pending_actions_created ?? 0);
         }
 
         return PendingAction::query()

--- a/app/Services/Agents/AgentSessionConfig.php
+++ b/app/Services/Agents/AgentSessionConfig.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Agents;
+
+use App\Models\AgentToken;
+use Illuminate\Support\Facades\Config;
+use RuntimeException;
+
+/**
+ * Builds the JSON body sent to the Managed Agents API when creating a session
+ * for a given (AgentDefinition, AgentToken) pair. Keeping the builder pure (no
+ * HTTP calls) makes Phase 3's tests trivial.
+ */
+final class AgentSessionConfig
+{
+    public function __construct(
+        public readonly AgentDefinition $definition,
+        public readonly AgentToken $token,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'model' => $this->definition->model,
+            'fallback_model' => $this->definition->fallbackModel,
+            'system_prompt' => $this->definition->systemPrompt,
+            'mcp_servers' => $this->resolveMcpServers(),
+            'allowed_tools' => $this->definition->allowedTools,
+            'max_session_duration_seconds' => $this->definition->maxSessionDurationSeconds,
+            'max_tool_calls' => $this->definition->maxToolCalls,
+            'metadata' => [
+                'agent_slug' => $this->definition->slug,
+                'tenant_id' => $this->token->tenant_id,
+                'agent_token_id' => $this->token->id,
+            ],
+        ];
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function resolveMcpServers(): array
+    {
+        $servers = (array) Config::get('agents.mcp_servers', []);
+        $resolved = [];
+
+        foreach ($this->definition->mcpServers as $name) {
+            if (! isset($servers[$name])) {
+                throw new RuntimeException("MCP server [{$name}] referenced by agent.json is not configured in config/agents.php.");
+            }
+
+            $config = $servers[$name];
+
+            if (empty($config['url'])) {
+                throw new RuntimeException("MCP server [{$name}] has no url configured.");
+            }
+
+            $entry = [
+                'name' => $name,
+                'url' => (string) $config['url'],
+            ];
+
+            if (($config['auth'] ?? null) === 'agent_token') {
+                // The plaintext is intentionally not stored anywhere on disk.
+                // It is generated fresh each run by AgentTokenIssuer and passed
+                // here in-memory; in tests we accept the seed via the request
+                // attribute path instead.
+                $entry['headers'] = [
+                    'Authorization' => 'Bearer '.($config['_plaintext'] ?? ''),
+                ];
+            }
+
+            $resolved[] = $entry;
+        }
+
+        return $resolved;
+    }
+}

--- a/app/Services/Agents/ManagedAgentsClient.php
+++ b/app/Services/Agents/ManagedAgentsClient.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Services\Agents;
 
 use Generator;
+use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
@@ -16,7 +17,7 @@ use RuntimeException;
  * The class isolates the wire protocol so callers (the agents:run command,
  * tests) work against a stable PHP interface. Today every method goes through
  * raw HTTP with the `anthropic-beta: managed-agents-2026-04-01` header. As the
- * official anthropic/anthropic-sdk-php gains coverage of Managed Agents
+ * official anthropic-ai/sdk gains coverage of Managed Agents
  * endpoints, individual methods can swap in `Anthropic::beta()->...` calls
  * without callers noticing.
  *
@@ -119,7 +120,7 @@ class ManagedAgentsClient
         return (array) $response->json();
     }
 
-    private function http(): \Illuminate\Http\Client\PendingRequest
+    private function http(): PendingRequest
     {
         $config = (array) Config::get('agents.anthropic', []);
         $apiKey = (string) ($config['api_key'] ?? '');

--- a/app/Services/Agents/ManagedAgentsClient.php
+++ b/app/Services/Agents/ManagedAgentsClient.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Agents;
+
+use Generator;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use RuntimeException;
+
+/**
+ * Thin client for Anthropic's Managed Agents beta API.
+ *
+ * The class isolates the wire protocol so callers (the agents:run command,
+ * tests) work against a stable PHP interface. Today every method goes through
+ * raw HTTP with the `anthropic-beta: managed-agents-2026-04-01` header. As the
+ * official anthropic/anthropic-sdk-php gains coverage of Managed Agents
+ * endpoints, individual methods can swap in `Anthropic::beta()->...` calls
+ * without callers noticing.
+ *
+ * `Http::fake()` in tests stands in for the real API.
+ */
+class ManagedAgentsClient
+{
+    /**
+     * Create a new agent session.
+     *
+     * @param  array<string, mixed>  $payload  Output of AgentSessionConfig::toArray().
+     * @return array{id: string, status: string} session metadata
+     */
+    public function createSession(array $payload): array
+    {
+        $response = $this->http()->post('/v1/agents/sessions', $payload);
+
+        if ($response->failed()) {
+            throw new RuntimeException(
+                'Managed Agents createSession failed: '.$response->body(),
+            );
+        }
+
+        $body = $response->json();
+
+        if (! is_array($body) || empty($body['id'])) {
+            throw new RuntimeException('Managed Agents createSession returned no session id.');
+        }
+
+        return [
+            'id' => (string) $body['id'],
+            'status' => (string) ($body['status'] ?? 'running'),
+        ];
+    }
+
+    /**
+     * Stream events for a session as JSON-decoded arrays. The current API
+     * shape is unstable; the client treats each line of the response body as
+     * a JSON event and yields its decoded payload. Tests use Http::fake() to
+     * supply a canned multi-line body.
+     *
+     * @return Generator<int, array<string, mixed>>
+     */
+    public function streamEvents(string $sessionId): Generator
+    {
+        $response = $this->http()
+            ->withOptions(['stream' => true])
+            ->get('/v1/agents/sessions/'.$sessionId.'/events');
+
+        if ($response->failed()) {
+            throw new RuntimeException(
+                "Managed Agents streamEvents({$sessionId}) failed: ".$response->body(),
+            );
+        }
+
+        $body = $response->body();
+        $lines = preg_split('/\r?\n/', $body) ?: [];
+
+        foreach ($lines as $line) {
+            $line = trim($line);
+
+            if ($line === '' || str_starts_with($line, ':')) {
+                continue;
+            }
+
+            // Tolerate Server-Sent-Events "data: {...}" framing as well as
+            // raw newline-delimited JSON.
+            if (str_starts_with($line, 'data:')) {
+                $line = trim(substr($line, 5));
+            }
+
+            $event = json_decode($line, associative: true);
+
+            if (! is_array($event)) {
+                Log::warning('agents.streamEvents: skipping non-JSON event line', ['line' => $line]);
+
+                continue;
+            }
+
+            yield $event;
+        }
+    }
+
+    public function cancelSession(string $sessionId): void
+    {
+        $this->http()->post('/v1/agents/sessions/'.$sessionId.'/cancel')->throw();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getSession(string $sessionId): array
+    {
+        $response = $this->http()->get('/v1/agents/sessions/'.$sessionId);
+
+        if ($response->failed()) {
+            throw new RuntimeException("Managed Agents getSession({$sessionId}) failed: ".$response->body());
+        }
+
+        return (array) $response->json();
+    }
+
+    private function http(): \Illuminate\Http\Client\PendingRequest
+    {
+        $config = (array) Config::get('agents.anthropic', []);
+        $apiKey = (string) ($config['api_key'] ?? '');
+
+        if ($apiKey === '') {
+            throw new RuntimeException('ANTHROPIC_API_KEY is not set.');
+        }
+
+        return Http::baseUrl((string) $config['base_url'])
+            ->withHeaders([
+                'x-api-key' => $apiKey,
+                'anthropic-version' => (string) ($config['version'] ?? '2023-06-01'),
+                'anthropic-beta' => (string) ($config['beta'] ?? 'managed-agents-2026-04-01'),
+                'content-type' => 'application/json',
+            ])
+            ->connectTimeout((int) ($config['connect_timeout'] ?? 10))
+            ->timeout((int) ($config['request_timeout'] ?? 60))
+            ->acceptJson();
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.5",
-        "anthropic/anthropic-sdk-php": "^0.19",
+        "anthropic-ai/sdk": "^0.19",
         "barryvdh/laravel-dompdf": "^3.1",
         "google/apiclient": "^2.19",
         "inertiajs/inertia-laravel": "^3.0",

--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.5",
+        "anthropic/anthropic-sdk-php": "^0.19",
         "barryvdh/laravel-dompdf": "^3.1",
         "google/apiclient": "^2.19",
         "inertiajs/inertia-laravel": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,69 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c61271d4d27fbb06089e0a63e3f6a84e",
+    "content-hash": "eb613474237f87dea2189cba90d7789c",
     "packages": [
+        {
+            "name": "anthropic-ai/sdk",
+            "version": "v0.19.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/anthropics/anthropic-sdk-php.git",
+                "reference": "0a7fbdaead8fbaf2d41dd4557e2afa1ca1c986e4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/anthropics/anthropic-sdk-php/zipball/0a7fbdaead8fbaf2d41dd4557e2afa1ca1c986e4",
+                "reference": "0a7fbdaead8fbaf2d41dd4557e2afa1ca1c986e4",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.1",
+                "php-http/discovery": "^1",
+                "psr/http-client": "^1",
+                "psr/http-client-implementation": "^1",
+                "psr/http-factory-implementation": "^1",
+                "psr/http-message": "^1|^2"
+            },
+            "require-dev": {
+                "aws/aws-sdk-php": "^3.368",
+                "friendsofphp/php-cs-fixer": "^3",
+                "google/auth": "^1.49",
+                "mcp/sdk": "^0.5",
+                "nyholm/psr7": "^1",
+                "pestphp/pest": "^3",
+                "php-http/mock-client": "^1",
+                "phpstan/extension-installer": "^1",
+                "phpstan/phpstan": "^2",
+                "phpstan/phpstan-phpunit": "^2",
+                "phpunit/phpunit": "^11",
+                "symfony/http-client": "^7"
+            },
+            "suggest": {
+                "aws/aws-sdk-php": "Allows using the AWS Bedrock, AWS gateway, and Bedrock Mantle SDKs",
+                "google/auth": "Allows using the Google Vertex SDK",
+                "mcp/sdk": "Required to use the BetaMcp helpers for integrating MCP servers with the Anthropic SDK"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/Version.php"
+                ],
+                "psr-4": {
+                    "Anthropic\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Anthropic PHP SDK",
+            "support": {
+                "issues": "https://github.com/anthropics/anthropic-sdk-php/issues",
+                "source": "https://github.com/anthropics/anthropic-sdk-php/tree/v0.19.0"
+            },
+            "time": "2026-05-05T16:10:02+00:00"
+        },
         {
             "name": "barryvdh/laravel-dompdf",
             "version": "v3.1.2",
@@ -3444,6 +3505,85 @@
                 }
             ],
             "time": "2026-02-16T23:10:27+00:00"
+        },
+        {
+            "name": "php-http/discovery",
+            "version": "1.20.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-http/discovery.git",
+                "reference": "82fe4c73ef3363caed49ff8dd1539ba06044910d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-http/discovery/zipball/82fe4c73ef3363caed49ff8dd1539ba06044910d",
+                "reference": "82fe4c73ef3363caed49ff8dd1539ba06044910d",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0|^2.0",
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "nyholm/psr7": "<1.0",
+                "zendframework/zend-diactoros": "*"
+            },
+            "provide": {
+                "php-http/async-client-implementation": "*",
+                "php-http/client-implementation": "*",
+                "psr/http-client-implementation": "*",
+                "psr/http-factory-implementation": "*",
+                "psr/http-message-implementation": "*"
+            },
+            "require-dev": {
+                "composer/composer": "^1.0.2|^2.0",
+                "graham-campbell/phpspec-skip-example-extension": "^5.0",
+                "php-http/httplug": "^1.0 || ^2.0",
+                "php-http/message-factory": "^1.0",
+                "phpspec/phpspec": "^5.1 || ^6.1 || ^7.3",
+                "sebastian/comparator": "^3.0.5 || ^4.0.8",
+                "symfony/phpunit-bridge": "^6.4.4 || ^7.0.1"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Http\\Discovery\\Composer\\Plugin",
+                "plugin-optional": true
+            },
+            "autoload": {
+                "psr-4": {
+                    "Http\\Discovery\\": "src/"
+                },
+                "exclude-from-classmap": [
+                    "src/Composer/Plugin.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com"
+                }
+            ],
+            "description": "Finds and installs PSR-7, PSR-17, PSR-18 and HTTPlug implementations",
+            "homepage": "http://php-http.org",
+            "keywords": [
+                "adapter",
+                "client",
+                "discovery",
+                "factory",
+                "http",
+                "message",
+                "psr17",
+                "psr7"
+            ],
+            "support": {
+                "issues": "https://github.com/php-http/discovery/issues",
+                "source": "https://github.com/php-http/discovery/tree/1.20.0"
+            },
+            "time": "2024-10-02T11:20:13+00:00"
         },
         {
             "name": "phpoption/phpoption",

--- a/config/agents.php
+++ b/config/agents.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Definitions root
+    |--------------------------------------------------------------------------
+    |
+    | Filesystem path under which agent definitions live. Each subdirectory is
+    | one agent and contains agent.json + system.md (+ optional skills/).
+    |
+    */
+    'definitions_path' => env('AGENT_DEFINITIONS_PATH', base_path('agents')),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Per-agent feature flags
+    |--------------------------------------------------------------------------
+    |
+    | Agents are gated by feature flags so a malfunctioning agent can be
+    | disabled with a config change. agent.json names the flag; this file
+    | resolves it from the environment.
+    |
+    */
+    'flags' => [
+        'agents.email_ingestion.enabled' => env('AGENT_EMAIL_INGESTION_ENABLED', false),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Managed Agents API
+    |--------------------------------------------------------------------------
+    */
+    'anthropic' => [
+        'api_key' => env('ANTHROPIC_API_KEY'),
+        'base_url' => env('ANTHROPIC_API_BASE_URL', 'https://api.anthropic.com'),
+        'beta' => env('ANTHROPIC_MANAGED_AGENTS_BETA', 'managed-agents-2026-04-01'),
+        'version' => env('ANTHROPIC_API_VERSION', '2023-06-01'),
+        'connect_timeout' => 10,
+        'request_timeout' => 60,
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | MCP servers attached to agent sessions
+    |--------------------------------------------------------------------------
+    |
+    | Each MCP server an agent.json references must be declared here. The
+    | "lifeos" entry points at our own MCP server (Phase 1) and uses an
+    | agent-bound token; "gmail" expects an externally-managed MCP endpoint
+    | that the user connected through the Anthropic Console.
+    |
+    */
+    'mcp_servers' => [
+        'lifeos' => [
+            'url' => env('LIFEOS_MCP_PUBLIC_URL', 'http://localhost/mcp/lifeos'),
+            'auth' => 'agent_token',
+        ],
+        'gmail' => [
+            'url' => env('GMAIL_MCP_URL'),
+            'auth' => 'managed_console',
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Run hygiene
+    |--------------------------------------------------------------------------
+    */
+    'run_event_retention_days' => env('AGENT_RUN_EVENT_RETENTION_DAYS', 90),
+    'revert_window_minutes' => env('AGENT_REVERT_WINDOW_MINUTES', 10),
+];

--- a/database/factories/ContractFactory.php
+++ b/database/factories/ContractFactory.php
@@ -2,10 +2,12 @@
 
 namespace Database\Factories;
 
+use App\Models\Contract;
+use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Contract>
+ * @extends Factory<Contract>
  */
 class ContractFactory extends Factory
 {
@@ -31,7 +33,7 @@ class ContractFactory extends Factory
         $endDate = $this->faker->optional(0.8)->dateTimeBetween($startDate, '+2 years');
 
         return [
-            'user_id' => 1, // Will be overridden when creating with relationships
+            'user_id' => User::factory(),
             'contract_type' => $this->faker->randomElement($contractTypes),
             'title' => $this->faker->randomElement($titles),
             'counterparty' => $this->faker->company(),

--- a/database/factories/InvestmentFactory.php
+++ b/database/factories/InvestmentFactory.php
@@ -3,6 +3,7 @@
 namespace Database\Factories;
 
 use App\Models\Investment;
+use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
@@ -55,7 +56,7 @@ class InvestmentFactory extends Factory
         $currentValue = $purchasePrice * $this->faker->randomFloat(2, 0.5, 3.0); // -50% to +200% change
 
         return [
-            'user_id' => 1, // Will be overridden when creating with relationships
+            'user_id' => User::factory(),
             'investment_type' => $investmentType,
             'symbol_identifier' => $symbol,
             'name' => $name,

--- a/database/migrations/2026_05_07_004448_create_agent_runs_table.php
+++ b/database/migrations/2026_05_07_004448_create_agent_runs_table.php
@@ -1,0 +1,43 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('agent_runs', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('tenant_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('agent_token_id')->nullable()->constrained('agent_tokens')->nullOnDelete();
+
+            $table->string('agent_slug');
+            $table->string('session_id')->nullable();
+            $table->string('model')->nullable();
+            $table->string('status')->default('running'); // running|completed|failed|cancelled
+
+            $table->json('tools_called')->nullable();   // map<tool, count>
+            $table->unsignedInteger('pending_actions_created')->default(0);
+            $table->unsignedBigInteger('tokens_in')->default(0);
+            $table->unsignedBigInteger('tokens_out')->default(0);
+            $table->decimal('cost_usd', 10, 4)->default(0);
+
+            $table->text('error')->nullable();
+
+            $table->timestamp('started_at')->useCurrent();
+            $table->timestamp('ended_at')->nullable();
+            $table->timestamps();
+
+            $table->index(['tenant_id', 'agent_slug', 'status']);
+            $table->index(['tenant_id', 'started_at']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('agent_runs');
+    }
+};

--- a/database/migrations/2026_05_07_004449_create_agent_run_events_table.php
+++ b/database/migrations/2026_05_07_004449_create_agent_run_events_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('agent_run_events', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('agent_run_id')->constrained()->cascadeOnDelete();
+            $table->unsignedInteger('sequence');
+            $table->string('type'); // tool_call | tool_result | text | error | system
+            $table->json('payload')->nullable();
+            $table->timestamp('occurred_at');
+
+            $table->index(['agent_run_id', 'sequence']);
+            $table->index('occurred_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('agent_run_events');
+    }
+};

--- a/docs/agents/AGENTS.md
+++ b/docs/agents/AGENTS.md
@@ -89,7 +89,7 @@ Reads receipt-shaped messages from the connected Gmail mailbox and proposes one 
 - Each run issues a fresh `AgentToken` with abilities limited to the agent's tool allowlist. The token is revoked at the end of the run (success or failure).
 - The plaintext token never lands on disk: it's generated in memory, passed into `AgentSessionConfig` as a config value scoped to the run, and discarded.
 - `agent_run_events` is append-only. A retention sweep (default 90 days, see `agents.run_event_retention_days`) is intentionally not implemented in Phase 3 — add it once we have data on event volume in production.
-- The Managed Agents wire format is still in beta (`managed-agents-2026-04-01`). `ManagedAgentsClient` isolates the protocol so individual methods can swap to `anthropic/anthropic-sdk-php` calls as the SDK gains coverage. No callers will need to change.
+- The Managed Agents wire format is still in beta (`managed-agents-2026-04-01`). `ManagedAgentsClient` isolates the protocol so individual methods can swap to `anthropic-ai/sdk` calls as the SDK gains coverage. No callers will need to change.
 
 ## Failure modes
 

--- a/docs/agents/AGENTS.md
+++ b/docs/agents/AGENTS.md
@@ -1,0 +1,99 @@
+# LifeOS Managed Agents — Agent reference
+
+This file lists the Managed Agents that ship with LifeOS, what they're allowed to touch, how to enable them, and how they connect to the rest of the system. Each agent is a directory under `agents/`; runtime config (URLs, secrets, feature flags) lives in `config/agents.php`.
+
+## Architecture in one paragraph
+
+`php artisan agents:run {slug} [--tenant=...]` resolves an agent's `agent.json`, issues a short-lived agent token bound to (user, tenant) with the allowed-tool list, asks the Anthropic Managed Agents API to create a session pointed at the LifeOS MCP server (and any other MCP servers declared in the agent definition), then streams events into `agent_runs` + `agent_run_events`. Every write tool the session calls produces a row in `pending_actions`; nothing mutates live data without human approval.
+
+Visual:
+
+```
+                         agents:run
+                              │
+                              ▼
+                    ┌──────────────────┐    REST + SSE
+                    │ ManagedAgents    │ ◀───────────────▶  api.anthropic.com (Managed Agents beta)
+                    │ Client           │
+                    └──────────────────┘
+                              │
+                              ▼ (events)
+                    ┌──────────────────┐
+                    │ AgentRunRecorder │  → agent_runs, agent_run_events
+                    └──────────────────┘
+                              │
+                              ▼ (tool_call/tool_result)
+                  ┌─────────────────────────┐
+                  │ Anthropic-hosted agent  │
+                  │ runtime calls our MCP   │
+                  └─────────────────────────┘
+                              │
+                              ▼
+                ┌────────────────────────────┐
+                │ /mcp/lifeos (this app)     │
+                │ auth.agent middleware →    │
+                │ Mcp\Tools\* → services →   │
+                │ pending_actions queue      │
+                └────────────────────────────┘
+```
+
+## Available agents
+
+### `email-ingestion`
+
+Reads receipt-shaped messages from the connected Gmail mailbox and proposes one `expenses.create` per receipt. Never mutates live data — every proposal lands in `/dashboard/pending-actions` for human approval.
+
+| Field | Value |
+|---|---|
+| Definition | `agents/email-ingestion/agent.json` + `system.md` |
+| Skill | `.claude/skills/expense-categorization/SKILL.md` |
+| Model | `claude-opus-4-7` (fallback `claude-sonnet-4-6`) |
+| MCP servers | `lifeos`, `gmail` |
+| Allowed tools | `expenses.list`, `expenses.create`, `expenses.bulkImport` |
+| Limits | 10 min session, 200 tool calls |
+| Feature flag | `AGENT_EMAIL_INGESTION_ENABLED` (env) → `agents.flags.agents.email_ingestion.enabled` (config) |
+| Schedule | Every 30 min when the flag is on (`routes/console.php`) |
+
+**Hard rules** (enforced by the system prompt):
+
+- Never auto-applies. Every proposed write goes through the approval queue.
+- Never edits or deletes existing expenses (categorization fixes for existing rows arrive in Phase 4).
+- Never invents a category. The `expense-categorization` skill is the only source of truth for `category` / `subcategory`. Anything that doesn't match a rule lands as `uncategorized` for human review.
+- Skips messages where amount, currency, or date can't be confidently extracted, with a one-line note explaining the skip.
+
+### Future agents (later phases)
+
+- `email-ingestion` will gain Subscriptions, Utility Bills, IOUs, Contracts, Warranties, and Job-status updates in Phase 4.
+- Phase 5: `investments-sync`.
+- Phase 6: `bank-statements`.
+- Phase 7: `receipts-ocr` (Drive folder).
+- Phase 8: `job-search` (gated, only during active windows).
+- Phase 9: `cycle-menu-planner`.
+- Phase 10: `weekly-digest` (read-only).
+
+## Enabling an agent
+
+1. **Confirm config.** `ANTHROPIC_API_KEY` must be set; the env-driven flag for the agent must be true (e.g. `AGENT_EMAIL_INGESTION_ENABLED=true`).
+2. **Confirm MCP server URLs.** `LIFEOS_MCP_PUBLIC_URL` must point at a publicly reachable URL of `/mcp/lifeos`. Phase 3 deliberately doesn't ship a tunnel playbook — Managed Agents reaches the deployed/staging server, not localhost.
+3. **Confirm the skill.** For `email-ingestion`, `.claude/skills/expense-categorization/SKILL.md` must contain the user's category map and vendor aliases. The agent's system prompt requires it.
+4. **Run once manually.** `php artisan agents:run email-ingestion --tenant=<slug>` (or `--dry-run` first to confirm config without calling the API). Inspect the resulting `AgentRun` at `/dashboard/agents/{id}`.
+5. **Schedule kicks in automatically.** The cron entry in `routes/console.php` runs every 30 minutes for every tenant that hasn't set `agents_writes_disabled = true`.
+
+## Disabling an agent
+
+- **Single tenant:** set `tenants.agents_writes_disabled = true` for that tenant. The command will skip them.
+- **Globally:** flip the env feature flag to false. The schedule is gated on the flag, and so is the explicit command.
+
+## Operational notes
+
+- Each run issues a fresh `AgentToken` with abilities limited to the agent's tool allowlist. The token is revoked at the end of the run (success or failure).
+- The plaintext token never lands on disk: it's generated in memory, passed into `AgentSessionConfig` as a config value scoped to the run, and discarded.
+- `agent_run_events` is append-only. A retention sweep (default 90 days, see `agents.run_event_retention_days`) is intentionally not implemented in Phase 3 — add it once we have data on event volume in production.
+- The Managed Agents wire format is still in beta (`managed-agents-2026-04-01`). `ManagedAgentsClient` isolates the protocol so individual methods can swap to `anthropic/anthropic-sdk-php` calls as the SDK gains coverage. No callers will need to change.
+
+## Failure modes
+
+- **Session creation fails** → run is marked `failed`, the error stored on `agent_runs.error`, and the agent token is revoked. Re-run manually after fixing config.
+- **Tool call fails** → individual `tool_result` events with `is_error=true` show up in the timeline; the run continues.
+- **Agent times out** → the session ends; the run is marked completed with whatever pending actions exist.
+- **Tenant has writes disabled mid-run** → already-proposed pending actions remain visible but cannot be applied (the applier guards `agents_writes_disabled`).

--- a/docs/agents/IMPLEMENTATION_PLAN.md
+++ b/docs/agents/IMPLEMENTATION_PLAN.md
@@ -65,22 +65,22 @@ Every write tool defaults to creating a `pending_action` rather than mutating da
 ### 5. Orchestration: Laravel scheduler dispatches `agents:run` artisan commands
 
 - Reuse the existing scheduler. Each agent has a `Schedule::command('agents:run {slug}')->cron(...)` entry behind a feature flag.
-- The `agents:run` command (Phase 3) creates a Managed Agents session via the official Anthropic PHP SDK (`anthropic/anthropic-sdk-php`), passes the LifeOS MCP server URL and the agent's tool allowlist, streams events into an `agent_runs` table, and exits when the session terminates.
+- The `agents:run` command (Phase 3) creates a Managed Agents session via the official Anthropic PHP SDK (`anthropic-ai/sdk`), passes the LifeOS MCP server URL and the agent's tool allowlist, streams events into an `agent_runs` table, and exits when the session terminates.
 - **Reject** external cron hitting the Managed Agents API directly: duplicates scheduling logic and loses the ability to gate runs behind a tenancy/feature-flag check.
 
-### 6. Anthropic client: official `anthropic/anthropic-sdk-php` + HTTP fallback inside `ManagedAgentsClient`
+### 6. Anthropic client: official `anthropic-ai/sdk` + HTTP fallback inside `ManagedAgentsClient`
 
 **Why this is needed at all.** `laravel/ai` does not cover Managed Agents — verified on both the installed version (`v0.4.2`, per `composer.lock`) and the latest release (`v0.6.6`, published 2026-05-02). `AnthropicProvider` in both versions implements only `TextProvider`, `FileProvider`, `SupportsWebFetch`, `SupportsWebSearch`, and a recursive listing of the v0.6.6 source tree returns zero paths matching `managed`, `session`, or `agent`. The existing `LifeOsAssistant` is therefore an in-process agent against the Messages API, not a Managed Agents client. We need a separate client for the hosted runtime.
 
 **Approach.** A new `App\Services\Agents\ManagedAgentsClient` exposes the minimum surface Phase 3 needs: `createSession`, `streamEvents`, `sendUserMessage`, `cancel`, `getSession`. Internally:
 
-1. **Primary path:** `anthropic/anthropic-sdk-php` (added to composer in Phase 3, when it's first needed). Each `ManagedAgentsClient` method delegates to the SDK where the SDK exposes the corresponding Managed Agents endpoint.
+1. **Primary path:** `anthropic-ai/sdk` (added to composer in Phase 3, when it's first needed). Each `ManagedAgentsClient` method delegates to the SDK where the SDK exposes the corresponding Managed Agents endpoint.
 2. **Fallback path:** for any endpoint the SDK doesn't yet expose, the same method falls back to `Http::withHeaders(['anthropic-beta' => 'managed-agents-2026-04-01', 'x-api-key' => ...])`. The fallback is isolated to the client class so callers (`agents:run`, tests) never see the difference.
 3. **Migration path:** as new SDK versions cover more endpoints, the per-method `if ($this->sdkSupports(...))` checks shrink and the fallback eventually goes away. No caller changes.
 
 This way we benefit from the SDK's idiomatic interfaces, type safety, retries, and streaming where available, while remaining unblocked for any endpoint the SDK still lags on.
 
-**Phase boundary.** No SDK dependency change in Phases 1 or 2. `composer require anthropic/anthropic-sdk-php` happens at the start of Phase 3, alongside the Managed Agents client implementation.
+**Phase boundary.** No SDK dependency change in Phases 1 or 2. `composer require anthropic-ai/sdk` happens at the start of Phase 3, alongside the Managed Agents client implementation.
 
 ### 7. Agent definitions: file-based registry
 
@@ -362,7 +362,7 @@ Each phase ships: (a) any service-extraction needed, (b) module write tools adde
 
 ## Resolved decisions (from plan-mode Q&A)
 
-- **Anthropic client.** `laravel/ai` does not cover Managed Agents (verified against source on both v0.4.2 installed and v0.6.6 latest). Recommended approach selected: official `anthropic/anthropic-sdk-php` is the primary path inside `ManagedAgentsClient`, with raw-HTTP fallback for any endpoint the SDK doesn't yet expose, all behind one interface. SDK is added to composer at the start of Phase 3 (no dependency change in Phases 1–2).
+- **Anthropic client.** `laravel/ai` does not cover Managed Agents (verified against source on both v0.4.2 installed and v0.6.6 latest). Recommended approach selected: official `anthropic-ai/sdk` is the primary path inside `ManagedAgentsClient`, with raw-HTTP fallback for any endpoint the SDK doesn't yet expose, all behind one interface. SDK is added to composer at the start of Phase 3 (no dependency change in Phases 1–2).
 - **Token model.** Dedicated `agent_tokens` table.
 - **Phase 2 auto-apply.** Strict — every write produces a pending action in Phase 2. The auto-apply rule is implemented as plumbing (config + idempotency-key match check) but the config defaults to `false` for every (tenant, tool) pair and only flips after the user approves it explicitly in a later phase.
 - **Branch cadence.** One PR per phase, child branches off `claude/implement-managed-agents-L1MeH`. Final merge to `main` once all phases land.
@@ -396,7 +396,7 @@ Phase 2 and onward have analogous acceptance steps; spelt out in `docs/agents/RU
 
 ## Critical files to be modified or created
 
-- `composer.json` — promote `laravel/mcp` (Phase 1); add `anthropic/anthropic-sdk-php` (Phase 3).
+- `composer.json` — promote `laravel/mcp` (Phase 1); add `anthropic-ai/sdk` (Phase 3).
 - `routes/ai.php` (new), `bootstrap/app.php` — register routes file and `auth.agent` alias.
 - `app/Mcp/**` (new tree).
 - `app/Models/{AgentToken,AgentRun,AgentRunEvent,PendingAction}.php` (new).

--- a/docs/agents/IMPLEMENTATION_PLAN.md
+++ b/docs/agents/IMPLEMENTATION_PLAN.md
@@ -5,7 +5,8 @@
 > **Progress:**
 > - Phase 0 — plan committed (this file).
 > - Phase 1 — read-only MCP server: PR #148 (`claude/managed-agents-phase-1`).
-> - Phase 2 — Pending Actions queue + Expenses writes: in PR.
+> - Phase 2 — Pending Actions queue + Expenses writes: PR #150 (`claude/managed-agents-phase-2`).
+> - Phase 3 — email-ingestion agent + ManagedAgentsClient + `agents:run`: in PR. See `docs/agents/AGENTS.md`.
 
 ## Context
 

--- a/resources/js/components/shared/sidebar.tsx
+++ b/resources/js/components/shared/sidebar.tsx
@@ -24,6 +24,7 @@ import {
     DollarSign,
     Calendar,
     Inbox,
+    Bot,
     type LucideIcon,
 } from 'lucide-react'
 import { cn } from '@/lib/utils'
@@ -53,6 +54,7 @@ const navigation: NavGroup[] = [
             { label: 'Subscriptions', href: '/subscriptions', icon: CreditCard },
             { label: 'Utility Bills', href: '/utility-bills', icon: Zap },
             { label: 'Pending Actions', href: '/dashboard/pending-actions', icon: Inbox, badgeKey: 'pendingActionsCount' },
+            { label: 'Agents', href: '/dashboard/agents', icon: Bot },
         ],
     },
     {

--- a/resources/js/pages/Agents/Index.tsx
+++ b/resources/js/pages/Agents/Index.tsx
@@ -1,0 +1,184 @@
+import { Head, Link, router } from '@inertiajs/react'
+import { useState } from 'react'
+import AppLayout from '@/components/shared/app-layout'
+import { PageHeader } from '@/components/shared/page-header'
+import { EmptyState } from '@/components/shared/empty-state'
+import { Card, CardContent } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '@/components/ui/select'
+import {
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow,
+} from '@/components/ui/table'
+import { Bot, Eye } from 'lucide-react'
+import type { PaginatedData } from '@/types'
+
+interface AgentRun {
+    id: number
+    agent_slug: string
+    session_id: string | null
+    model: string | null
+    status: 'running' | 'completed' | 'failed' | 'cancelled'
+    pending_actions_created: number
+    tokens_in: number
+    tokens_out: number
+    cost_usd: number | string
+    started_at: string
+    ended_at: string | null
+    error: string | null
+    user?: { id: number; name: string; email: string }
+    agent_token?: { id: number; name: string; agent_slug: string | null }
+}
+
+interface IndexProps {
+    agentRuns: PaginatedData<AgentRun>
+    filters: { agent?: string; status?: string; from?: string; to?: string }
+    agents: string[]
+}
+
+const STATUS_VARIANTS: Record<AgentRun['status'], 'default' | 'secondary' | 'destructive' | 'outline'> = {
+    running: 'default',
+    completed: 'secondary',
+    failed: 'destructive',
+    cancelled: 'outline',
+}
+
+const STATUSES = [
+    { value: '', label: 'All statuses' },
+    { value: 'running', label: 'Running' },
+    { value: 'completed', label: 'Completed' },
+    { value: 'failed', label: 'Failed' },
+    { value: 'cancelled', label: 'Cancelled' },
+]
+
+export default function AgentRunsIndex({ agentRuns, filters, agents }: IndexProps) {
+    const [statusFilter, setStatusFilter] = useState(filters.status ?? '')
+    const [agentFilter, setAgentFilter] = useState(filters.agent ?? '')
+
+    const submitFilters = (next: Partial<IndexProps['filters']>) => {
+        router.get(
+            '/dashboard/agents',
+            { ...filters, ...next },
+            { preserveState: true, preserveScroll: true, replace: true },
+        )
+    }
+
+    return (
+        <AppLayout>
+            <Head title="Agent runs" />
+            <PageHeader
+                title="Agents"
+                description="Sessions launched against the Anthropic Managed Agents API. Each row is one run, regardless of how many tools it called."
+            />
+
+            <Card className="mt-6">
+                <CardContent className="p-4">
+                    <div className="flex flex-wrap gap-3">
+                        <Select
+                            value={agentFilter}
+                            onValueChange={(v) => {
+                                setAgentFilter(v)
+                                submitFilters({ agent: v || undefined })
+                            }}
+                        >
+                            <SelectTrigger className="w-[220px]">
+                                <SelectValue placeholder="Agent" />
+                            </SelectTrigger>
+                            <SelectContent>
+                                <SelectItem value="">All agents</SelectItem>
+                                {agents.map((slug) => (
+                                    <SelectItem key={slug} value={slug}>
+                                        {slug}
+                                    </SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+                        <Select
+                            value={statusFilter}
+                            onValueChange={(v) => {
+                                setStatusFilter(v)
+                                submitFilters({ status: v || undefined })
+                            }}
+                        >
+                            <SelectTrigger className="w-[200px]">
+                                <SelectValue placeholder="Status" />
+                            </SelectTrigger>
+                            <SelectContent>
+                                {STATUSES.map((s) => (
+                                    <SelectItem key={s.value || 'all'} value={s.value}>
+                                        {s.label}
+                                    </SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+                    </div>
+                </CardContent>
+            </Card>
+
+            <Card className="mt-6">
+                <CardContent className="p-0">
+                    {agentRuns.data.length === 0 ? (
+                        <EmptyState
+                            icon={Bot}
+                            title="No agent runs yet"
+                            description="When an agent runs, you'll see its session here with tools called and pending actions produced."
+                        />
+                    ) : (
+                        <Table>
+                            <TableHeader>
+                                <TableRow>
+                                    <TableHead>Agent</TableHead>
+                                    <TableHead>Status</TableHead>
+                                    <TableHead className="text-right">Pending</TableHead>
+                                    <TableHead className="text-right">Tokens (in/out)</TableHead>
+                                    <TableHead className="text-right">Cost (USD)</TableHead>
+                                    <TableHead>Started</TableHead>
+                                    <TableHead className="text-right"></TableHead>
+                                </TableRow>
+                            </TableHeader>
+                            <TableBody>
+                                {agentRuns.data.map((run) => (
+                                    <TableRow key={run.id}>
+                                        <TableCell className="font-mono text-sm">{run.agent_slug}</TableCell>
+                                        <TableCell>
+                                            <Badge variant={STATUS_VARIANTS[run.status]}>{run.status}</Badge>
+                                        </TableCell>
+                                        <TableCell className="text-right">{run.pending_actions_created}</TableCell>
+                                        <TableCell className="text-right text-sm tabular-nums">
+                                            {run.tokens_in} / {run.tokens_out}
+                                        </TableCell>
+                                        <TableCell className="text-right text-sm tabular-nums">
+                                            {Number(run.cost_usd).toFixed(4)}
+                                        </TableCell>
+                                        <TableCell className="text-sm text-muted-foreground">
+                                            {new Date(run.started_at).toLocaleString()}
+                                        </TableCell>
+                                        <TableCell className="text-right">
+                                            <Button asChild variant="ghost" size="sm">
+                                                <Link href={`/dashboard/agents/${run.id}`}>
+                                                    <Eye className="mr-1 h-4 w-4" />
+                                                    View
+                                                </Link>
+                                            </Button>
+                                        </TableCell>
+                                    </TableRow>
+                                ))}
+                            </TableBody>
+                        </Table>
+                    )}
+                </CardContent>
+            </Card>
+        </AppLayout>
+    )
+}

--- a/resources/js/pages/Agents/Show.tsx
+++ b/resources/js/pages/Agents/Show.tsx
@@ -1,0 +1,180 @@
+import { Head, Link } from '@inertiajs/react'
+import AppLayout from '@/components/shared/app-layout'
+import { PageHeader } from '@/components/shared/page-header'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { ArrowLeft } from 'lucide-react'
+
+interface AgentRunEvent {
+    id: number
+    sequence: number
+    type: 'tool_call' | 'tool_result' | 'text' | 'error' | 'system'
+    payload: Record<string, unknown>
+    occurred_at: string
+}
+
+interface AgentRunShowProps {
+    agentRun: {
+        id: number
+        agent_slug: string
+        session_id: string | null
+        model: string | null
+        status: string
+        tools_called: Record<string, number> | null
+        pending_actions_created: number
+        tokens_in: number
+        tokens_out: number
+        cost_usd: number | string
+        error: string | null
+        started_at: string
+        ended_at: string | null
+        duration_seconds: number | null
+        user?: { id: number; name: string; email: string }
+        agent_token?: { id: number; name: string; agent_slug: string | null }
+        events: AgentRunEvent[]
+    }
+}
+
+const EVENT_BADGE: Record<AgentRunEvent['type'], 'default' | 'secondary' | 'destructive' | 'outline'> = {
+    tool_call: 'default',
+    tool_result: 'secondary',
+    text: 'outline',
+    error: 'destructive',
+    system: 'outline',
+}
+
+export default function AgentRunShow({ agentRun }: AgentRunShowProps) {
+    const tools = agentRun.tools_called ?? {}
+
+    return (
+        <AppLayout>
+            <Head title={`Agent run #${agentRun.id}`} />
+            <PageHeader
+                title={`#${agentRun.id} ${agentRun.agent_slug}`}
+                description={agentRun.session_id ? `session ${agentRun.session_id}` : 'no session created'}
+                actions={
+                    <Button asChild variant="ghost" size="sm">
+                        <Link href="/dashboard/agents">
+                            <ArrowLeft className="mr-1 h-4 w-4" />
+                            Back
+                        </Link>
+                    </Button>
+                }
+            />
+
+            <div className="mt-6 grid gap-6 lg:grid-cols-3">
+                <Card>
+                    <CardHeader>
+                        <CardTitle className="text-base">Status</CardTitle>
+                    </CardHeader>
+                    <CardContent className="space-y-3 text-sm">
+                        <div className="flex justify-between">
+                            <span className="text-muted-foreground">Status</span>
+                            <Badge>{agentRun.status}</Badge>
+                        </div>
+                        <div className="flex justify-between">
+                            <span className="text-muted-foreground">Model</span>
+                            <span>{agentRun.model ?? '—'}</span>
+                        </div>
+                        <div className="flex justify-between">
+                            <span className="text-muted-foreground">Started</span>
+                            <span>{new Date(agentRun.started_at).toLocaleString()}</span>
+                        </div>
+                        {agentRun.ended_at && (
+                            <div className="flex justify-between">
+                                <span className="text-muted-foreground">Ended</span>
+                                <span>{new Date(agentRun.ended_at).toLocaleString()}</span>
+                            </div>
+                        )}
+                        {agentRun.duration_seconds !== null && (
+                            <div className="flex justify-between">
+                                <span className="text-muted-foreground">Duration</span>
+                                <span>{agentRun.duration_seconds}s</span>
+                            </div>
+                        )}
+                        {agentRun.error && (
+                            <div className="rounded-md border border-destructive/50 bg-destructive/10 p-2 text-xs text-destructive">
+                                {agentRun.error}
+                            </div>
+                        )}
+                    </CardContent>
+                </Card>
+
+                <Card>
+                    <CardHeader>
+                        <CardTitle className="text-base">Usage</CardTitle>
+                    </CardHeader>
+                    <CardContent className="space-y-3 text-sm">
+                        <div className="flex justify-between">
+                            <span className="text-muted-foreground">Pending actions</span>
+                            <span className="font-mono">{agentRun.pending_actions_created}</span>
+                        </div>
+                        <div className="flex justify-between">
+                            <span className="text-muted-foreground">Tokens in</span>
+                            <span className="font-mono tabular-nums">{agentRun.tokens_in}</span>
+                        </div>
+                        <div className="flex justify-between">
+                            <span className="text-muted-foreground">Tokens out</span>
+                            <span className="font-mono tabular-nums">{agentRun.tokens_out}</span>
+                        </div>
+                        <div className="flex justify-between">
+                            <span className="text-muted-foreground">Cost (USD)</span>
+                            <span className="font-mono tabular-nums">{Number(agentRun.cost_usd).toFixed(4)}</span>
+                        </div>
+                    </CardContent>
+                </Card>
+
+                <Card>
+                    <CardHeader>
+                        <CardTitle className="text-base">Tools called</CardTitle>
+                    </CardHeader>
+                    <CardContent className="text-sm">
+                        {Object.keys(tools).length === 0 ? (
+                            <p className="text-muted-foreground">No tool calls recorded.</p>
+                        ) : (
+                            <ul className="space-y-1 font-mono">
+                                {Object.entries(tools).map(([name, count]) => (
+                                    <li key={name} className="flex justify-between">
+                                        <span>{name}</span>
+                                        <span className="tabular-nums">{count}</span>
+                                    </li>
+                                ))}
+                            </ul>
+                        )}
+                    </CardContent>
+                </Card>
+
+                <Card className="lg:col-span-3">
+                    <CardHeader>
+                        <CardTitle className="text-base">Timeline</CardTitle>
+                    </CardHeader>
+                    <CardContent className="p-0">
+                        {agentRun.events.length === 0 ? (
+                            <p className="p-4 text-sm text-muted-foreground">No events recorded for this run.</p>
+                        ) : (
+                            <ol className="divide-y">
+                                {agentRun.events.map((event) => (
+                                    <li key={event.id} className="flex items-start gap-3 px-4 py-3">
+                                        <span className="w-10 shrink-0 text-xs tabular-nums text-muted-foreground">#{event.sequence}</span>
+                                        <Badge variant={EVENT_BADGE[event.type]} className="shrink-0">
+                                            {event.type}
+                                        </Badge>
+                                        <div className="min-w-0 flex-1">
+                                            <pre className="overflow-x-auto whitespace-pre-wrap rounded-md bg-muted p-2 text-xs">
+                                                {JSON.stringify(event.payload, null, 2)}
+                                            </pre>
+                                        </div>
+                                        <span className="shrink-0 text-xs text-muted-foreground">
+                                            {new Date(event.occurred_at).toLocaleTimeString()}
+                                        </span>
+                                    </li>
+                                ))}
+                            </ol>
+                        )}
+                    </CardContent>
+                </Card>
+            </div>
+        </AppLayout>
+    )
+}

--- a/routes/console.php
+++ b/routes/console.php
@@ -62,3 +62,11 @@ Schedule::command('gmail:sync-receipts --all --queue')
     ->name('gmail-sync-receipts')
     ->description('Sync receipts from Gmail for all active connections')
     ->when(config('gmail_receipts.sync.auto_sync_enabled', true)); // Only when auto-sync is enabled
+
+// Email-ingestion agent: every 30 minutes, behind a feature flag.
+Schedule::command('agents:run email-ingestion')
+    ->cron('*/30 * * * *')
+    ->name('agent-email-ingestion')
+    ->description('Run the email-ingestion agent across all eligible tenants')
+    ->withoutOverlapping(15)
+    ->when(fn (): bool => (bool) config('agents.flags.agents.email_ingestion.enabled', false));

--- a/routes/web.php
+++ b/routes/web.php
@@ -286,7 +286,7 @@ Route::middleware('auth')->group(function () {
         Route::post('expenses/{expense}/duplicate', [ExpenseController::class, 'duplicate'])->name('expenses.duplicate');
         Route::post('expenses/bulk-action', [ExpenseController::class, 'bulkAction'])->name('expenses.bulk-action');
 
-        // Pending Agent Actions
+        // Pending Agent Actions + Agent runs
         Route::prefix('dashboard')->name('dashboard.')->group(function () {
             Route::get('pending-actions', [\App\Http\Controllers\PendingActionsController::class, 'index'])->name('pending-actions.index');
             Route::get('pending-actions/{pendingAction}', [\App\Http\Controllers\PendingActionsController::class, 'show'])->name('pending-actions.show');
@@ -294,6 +294,9 @@ Route::middleware('auth')->group(function () {
             Route::patch('pending-actions/{pendingAction}/reject', [\App\Http\Controllers\PendingActionsController::class, 'reject'])->name('pending-actions.reject');
             Route::patch('pending-actions/{pendingAction}/revert', [\App\Http\Controllers\PendingActionsController::class, 'revert'])->name('pending-actions.revert');
             Route::post('pending-actions/bulk-approve', [\App\Http\Controllers\PendingActionsController::class, 'bulkApprove'])->name('pending-actions.bulk-approve');
+
+            Route::get('agents', [\App\Http\Controllers\AgentRunsController::class, 'index'])->name('agents.index');
+            Route::get('agents/{agentRun}', [\App\Http\Controllers\AgentRunsController::class, 'show'])->name('agents.show');
         });
 
         // Budget Analytics routes must come before resource routes to prevent conflicts

--- a/tests/Feature/Agents/AgentRunRecorderTest.php
+++ b/tests/Feature/Agents/AgentRunRecorderTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Agents;
+
+use App\Models\AgentRun;
+use App\Models\AgentRunEvent;
+use App\Models\AgentToken;
+use App\Services\Agents\AgentDefinition;
+use App\Services\Agents\AgentRunRecorder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AgentRunRecorderTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function definition(): AgentDefinition
+    {
+        return AgentDefinition::fromArray([
+            'slug' => 'email-ingestion',
+            'model' => 'claude-opus-4-7',
+            'mcp_servers' => ['lifeos'],
+            'allowed_tools' => ['expenses.create'],
+            'feature_flag' => 'agents.email_ingestion.enabled',
+        ], 'prompt');
+    }
+
+    private function token(): AgentToken
+    {
+        ['user' => $user, 'tenant' => $tenant] = $this->setupTenantContext();
+        [$token] = AgentToken::issue($user, $tenant, 'phpunit', ['*']);
+
+        return $token;
+    }
+
+    public function test_start_creates_running_run_with_started_at(): void
+    {
+        $token = $this->token();
+        $recorder = app(AgentRunRecorder::class);
+
+        $run = $recorder->start($this->definition(), $token);
+
+        $this->assertSame(AgentRun::STATUS_RUNNING, $run->status);
+        $this->assertSame('email-ingestion', $run->agent_slug);
+        $this->assertSame($token->id, $run->agent_token_id);
+        $this->assertNotNull($run->started_at);
+    }
+
+    public function test_record_event_persists_row_and_updates_counters(): void
+    {
+        $token = $this->token();
+        $recorder = app(AgentRunRecorder::class);
+        $run = $recorder->start($this->definition(), $token);
+
+        $recorder->recordEvent($run, [
+            'type' => AgentRunEvent::TYPE_TOOL_CALL,
+            'name' => 'expenses.create',
+        ], 1);
+
+        $recorder->recordEvent($run, [
+            'type' => AgentRunEvent::TYPE_TOOL_RESULT,
+            'structured_content' => ['pending_action_id' => 42, 'status' => 'pending'],
+        ], 2);
+
+        $recorder->recordEvent($run, [
+            'type' => AgentRunEvent::TYPE_TEXT,
+            'usage' => ['input_tokens' => 100, 'output_tokens' => 50],
+        ], 3);
+
+        $run->refresh();
+
+        $this->assertSame(3, $run->events()->count());
+        $this->assertSame(['expenses.create' => 1], $run->tools_called);
+        $this->assertSame(1, $run->pending_actions_created);
+        $this->assertSame(100, (int) $run->tokens_in);
+        $this->assertSame(50, (int) $run->tokens_out);
+    }
+
+    public function test_complete_marks_run_completed(): void
+    {
+        $token = $this->token();
+        $recorder = app(AgentRunRecorder::class);
+        $run = $recorder->start($this->definition(), $token);
+
+        $recorder->complete($run);
+
+        $this->assertSame(AgentRun::STATUS_COMPLETED, $run->refresh()->status);
+        $this->assertNotNull($run->ended_at);
+    }
+
+    public function test_fail_records_error_and_ends_run(): void
+    {
+        $token = $this->token();
+        $recorder = app(AgentRunRecorder::class);
+        $run = $recorder->start($this->definition(), $token);
+
+        $recorder->fail($run, new \RuntimeException('upstream timeout'));
+
+        $run->refresh();
+        $this->assertSame(AgentRun::STATUS_FAILED, $run->status);
+        $this->assertSame('upstream timeout', $run->error);
+        $this->assertNotNull($run->ended_at);
+    }
+}

--- a/tests/Feature/Agents/AgentsRunCommandTest.php
+++ b/tests/Feature/Agents/AgentsRunCommandTest.php
@@ -6,8 +6,6 @@ namespace Tests\Feature\Agents;
 
 use App\Models\AgentRun;
 use App\Models\AgentToken;
-use App\Models\Expense;
-use App\Models\PendingAction;
 use App\Models\Tenant;
 use App\Models\User;
 use App\Services\Agents\AgentRegistry;
@@ -60,6 +58,7 @@ class AgentsRunCommandTest extends TestCase
         $user = User::factory()->create();
         $tenant = Tenant::factory()->create(['owner_id' => $user->id]);
         $user->forceFill(['current_tenant_id' => $tenant->id])->save();
+        $this->actingAs($user);
 
         $this->artisan('agents:run', [
             'slug' => 'email-ingestion',
@@ -84,7 +83,7 @@ class AgentsRunCommandTest extends TestCase
             'slug' => 'email-ingestion',
             '--tenant' => $tenant->slug,
         ])->expectsOutputToContain('disabled')
-          ->assertSuccessful();
+            ->assertSuccessful();
 
         $this->assertSame(0, AgentRun::query()->count());
     }
@@ -110,6 +109,7 @@ class AgentsRunCommandTest extends TestCase
         $user = User::factory()->create();
         $tenant = Tenant::factory()->create(['owner_id' => $user->id]);
         $user->forceFill(['current_tenant_id' => $tenant->id])->save();
+        $this->actingAs($user);
 
         $client = $this->mock(ManagedAgentsClient::class);
         $client->shouldReceive('createSession')

--- a/tests/Feature/Agents/AgentsRunCommandTest.php
+++ b/tests/Feature/Agents/AgentsRunCommandTest.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Agents;
+
+use App\Models\AgentRun;
+use App\Models\AgentToken;
+use App\Models\Expense;
+use App\Models\PendingAction;
+use App\Models\Tenant;
+use App\Models\User;
+use App\Services\Agents\AgentRegistry;
+use App\Services\Agents\ManagedAgentsClient;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+class AgentsRunCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private string $agentsPath;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->agentsPath = storage_path('framework/testing/agents-'.uniqid());
+        File::ensureDirectoryExists($this->agentsPath.'/email-ingestion');
+        File::put($this->agentsPath.'/email-ingestion/agent.json', json_encode([
+            'slug' => 'email-ingestion',
+            'model' => 'claude-opus-4-7',
+            'mcp_servers' => ['lifeos'],
+            'allowed_tools' => ['expenses.create'],
+            'feature_flag' => 'agents.email_ingestion.enabled',
+        ]));
+        File::put($this->agentsPath.'/email-ingestion/system.md', '## test prompt');
+
+        Config::set('agents.definitions_path', $this->agentsPath);
+        Config::set('agents.flags.agents.email_ingestion.enabled', true);
+        Config::set('agents.mcp_servers', [
+            'lifeos' => ['url' => 'http://localhost/mcp/lifeos', 'auth' => 'agent_token'],
+        ]);
+        Config::set('agents.anthropic.api_key', 'test');
+        Config::set('agents.anthropic.base_url', 'https://api.anthropic.test');
+
+        app(AgentRegistry::class)->flush();
+    }
+
+    protected function tearDown(): void
+    {
+        File::deleteDirectory($this->agentsPath);
+        parent::tearDown();
+    }
+
+    public function test_dry_run_creates_run_row_without_calling_api(): void
+    {
+        $user = User::factory()->create();
+        $tenant = Tenant::factory()->create(['owner_id' => $user->id]);
+        $user->forceFill(['current_tenant_id' => $tenant->id])->save();
+
+        $this->artisan('agents:run', [
+            'slug' => 'email-ingestion',
+            '--tenant' => $tenant->slug,
+            '--dry-run' => true,
+        ])->assertSuccessful();
+
+        $this->assertSame(1, AgentRun::query()->count());
+        $run = AgentRun::query()->first();
+        $this->assertSame(AgentRun::STATUS_COMPLETED, $run->status);
+        $this->assertSame('email-ingestion', $run->agent_slug);
+    }
+
+    public function test_disabled_feature_flag_short_circuits(): void
+    {
+        Config::set('agents.flags.agents.email_ingestion.enabled', false);
+
+        $user = User::factory()->create();
+        $tenant = Tenant::factory()->create(['owner_id' => $user->id]);
+
+        $this->artisan('agents:run', [
+            'slug' => 'email-ingestion',
+            '--tenant' => $tenant->slug,
+        ])->expectsOutputToContain('disabled')
+          ->assertSuccessful();
+
+        $this->assertSame(0, AgentRun::query()->count());
+    }
+
+    public function test_writes_disabled_tenant_is_skipped(): void
+    {
+        $user = User::factory()->create();
+        $tenant = Tenant::factory()->create([
+            'owner_id' => $user->id,
+            'agents_writes_disabled' => true,
+        ]);
+
+        $this->artisan('agents:run', [
+            'slug' => 'email-ingestion',
+            '--tenant' => $tenant->slug,
+        ])->assertSuccessful();
+
+        $this->assertSame(0, AgentRun::query()->count());
+    }
+
+    public function test_command_drives_session_via_mocked_client(): void
+    {
+        $user = User::factory()->create();
+        $tenant = Tenant::factory()->create(['owner_id' => $user->id]);
+        $user->forceFill(['current_tenant_id' => $tenant->id])->save();
+
+        $client = $this->mock(ManagedAgentsClient::class);
+        $client->shouldReceive('createSession')
+            ->once()
+            ->andReturn(['id' => 'sess_test', 'status' => 'running']);
+        $client->shouldReceive('streamEvents')
+            ->once()
+            ->with('sess_test')
+            ->andReturn((function (): \Generator {
+                yield ['type' => 'tool_call', 'name' => 'expenses.create'];
+                yield [
+                    'type' => 'tool_result',
+                    'structured_content' => ['pending_action_id' => 1, 'status' => 'pending'],
+                ];
+                yield ['type' => 'text', 'usage' => ['input_tokens' => 50, 'output_tokens' => 25]];
+            })());
+
+        $this->artisan('agents:run', [
+            'slug' => 'email-ingestion',
+            '--tenant' => $tenant->slug,
+        ])->assertSuccessful();
+
+        $run = AgentRun::query()->first();
+        $this->assertNotNull($run);
+        $this->assertSame('sess_test', $run->session_id);
+        $this->assertSame(AgentRun::STATUS_COMPLETED, $run->status);
+        $this->assertSame(50, (int) $run->tokens_in);
+        $this->assertSame(25, (int) $run->tokens_out);
+        $this->assertSame(['expenses.create' => 1], $run->tools_called);
+        $this->assertSame(3, $run->events()->count());
+
+        // The agent token issued for the run is revoked at the end.
+        $this->assertSame(1, AgentToken::query()->whereNotNull('revoked_at')->count());
+    }
+}

--- a/tests/Feature/Agents/ManagedAgentsClientTest.php
+++ b/tests/Feature/Agents/ManagedAgentsClientTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Agents;
+
+use App\Services\Agents\ManagedAgentsClient;
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Http;
+use RuntimeException;
+use Tests\TestCase;
+
+class ManagedAgentsClientTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Config::set('agents.anthropic', [
+            'api_key' => 'test-key',
+            'base_url' => 'https://api.anthropic.test',
+            'beta' => 'managed-agents-2026-04-01',
+            'version' => '2023-06-01',
+            'connect_timeout' => 5,
+            'request_timeout' => 30,
+        ]);
+    }
+
+    public function test_create_session_posts_with_beta_header(): void
+    {
+        Http::fake([
+            'https://api.anthropic.test/v1/agents/sessions' => Http::response([
+                'id' => 'sess_123',
+                'status' => 'running',
+            ], 201),
+        ]);
+
+        $session = (new ManagedAgentsClient)->createSession([
+            'model' => 'claude-opus-4-7',
+            'system_prompt' => 'p',
+            'mcp_servers' => [],
+            'allowed_tools' => [],
+        ]);
+
+        $this->assertSame('sess_123', $session['id']);
+
+        Http::assertSent(function (Request $request): bool {
+            return $request->hasHeader('anthropic-beta', 'managed-agents-2026-04-01')
+                && $request->hasHeader('x-api-key', 'test-key')
+                && $request->method() === 'POST';
+        });
+    }
+
+    public function test_create_session_throws_on_failure(): void
+    {
+        Http::fake([
+            'https://api.anthropic.test/v1/agents/sessions' => Http::response('boom', 500),
+        ]);
+
+        $this->expectException(RuntimeException::class);
+        (new ManagedAgentsClient)->createSession(['model' => 'x']);
+    }
+
+    public function test_stream_events_yields_each_json_line(): void
+    {
+        $body = implode("\n", [
+            '{"type":"tool_call","name":"expenses.create"}',
+            'data: {"type":"tool_result","structured_content":{"pending_action_id":1}}',
+            '',
+            ': comment line — ignored',
+            '{"type":"text","usage":{"input_tokens":10,"output_tokens":5}}',
+        ]);
+
+        Http::fake([
+            'https://api.anthropic.test/v1/agents/sessions/sess_123/events' => Http::response($body, 200),
+        ]);
+
+        $events = iterator_to_array((new ManagedAgentsClient)->streamEvents('sess_123'));
+
+        $this->assertCount(3, $events);
+        $this->assertSame('tool_call', $events[0]['type']);
+        $this->assertSame('tool_result', $events[1]['type']);
+        $this->assertSame(1, $events[1]['structured_content']['pending_action_id']);
+        $this->assertSame(10, $events[2]['usage']['input_tokens']);
+    }
+
+    public function test_no_api_key_raises(): void
+    {
+        Config::set('agents.anthropic.api_key', '');
+
+        $this->expectException(RuntimeException::class);
+        (new ManagedAgentsClient)->createSession([]);
+    }
+}

--- a/tests/Feature/Mcp/ToolsTest.php
+++ b/tests/Feature/Mcp/ToolsTest.php
@@ -32,6 +32,8 @@ use App\Models\UtilityBill;
 use App\Models\Warranty;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\App;
+use Illuminate\Support\Str;
+use Illuminate\Testing\Fluent\AssertableJson;
 use Tests\TestCase;
 
 class ToolsTest extends TestCase
@@ -85,12 +87,11 @@ class ToolsTest extends TestCase
 
         LifeOsServer::tool(ListExpenses::class)
             ->assertOk()
-            ->assertStructuredContent(function (array $content): bool {
-                $this->assertSame(1, $content['count']);
-                $this->assertSame('My Merchant', $content['items'][0]['merchant']);
-
-                return true;
-            });
+            ->assertStructuredContent(fn (AssertableJson $json) => $json
+                ->where('count', 1)
+                ->where('items.0.merchant', 'My Merchant')
+                ->etc()
+            );
     }
 
     public function test_dashboard_summary(): void
@@ -100,15 +101,14 @@ class ToolsTest extends TestCase
 
         LifeOsServer::tool(Summary::class)
             ->assertOk()
-            ->assertStructuredContent(function (array $content): bool {
-                $this->assertArrayHasKey('totals', $content);
-                $this->assertArrayHasKey('upcoming', $content);
-                $this->assertArrayHasKey('alerts', $content);
-                $this->assertSame(1, $content['totals']['subscriptions_active']);
-                $this->assertSame(1, $content['totals']['contracts_active']);
-
-                return true;
-            });
+            ->assertStructuredContent(fn (AssertableJson $json) => $json
+                ->has('totals')
+                ->has('upcoming')
+                ->has('alerts')
+                ->where('totals.subscriptions_active', 1)
+                ->where('totals.contracts_active', 1)
+                ->etc()
+            );
     }
 
     public function test_expenses_list(): void
@@ -123,13 +123,12 @@ class ToolsTest extends TestCase
 
         LifeOsServer::tool(ListExpenses::class, ['merchant' => 'Lidl'])
             ->assertOk()
-            ->assertStructuredContent(function (array $content): bool {
-                $this->assertSame(1, $content['count']);
-                $this->assertSame('Lidl', $content['items'][0]['merchant']);
-                $this->assertSame('EUR', $content['items'][0]['currency']);
-
-                return true;
-            });
+            ->assertStructuredContent(fn (AssertableJson $json) => $json
+                ->where('count', 1)
+                ->where('items.0.merchant', 'Lidl')
+                ->where('items.0.currency', 'EUR')
+                ->etc()
+            );
     }
 
     public function test_subscriptions_list(): void
@@ -145,12 +144,11 @@ class ToolsTest extends TestCase
 
         LifeOsServer::tool(ListSubscriptions::class, ['due_within_days' => 7])
             ->assertOk()
-            ->assertStructuredContent(function (array $content): bool {
-                $this->assertSame(1, $content['count']);
-                $this->assertSame('Netflix', $content['items'][0]['service_name']);
-
-                return true;
-            });
+            ->assertStructuredContent(fn (AssertableJson $json) => $json
+                ->where('count', 1)
+                ->where('items.0.service_name', 'Netflix')
+                ->etc()
+            );
     }
 
     public function test_investments_portfolio(): void
@@ -166,14 +164,13 @@ class ToolsTest extends TestCase
 
         LifeOsServer::tool(Portfolio::class)
             ->assertOk()
-            ->assertStructuredContent(function (array $content): bool {
-                $this->assertSame(1, $content['count']);
-                $this->assertArrayHasKey('EUR', $content['totals_by_currency']);
-                $this->assertSame(1100.0, $content['totals_by_currency']['EUR']['market_value']);
-                $this->assertSame(100.0, $content['totals_by_currency']['EUR']['unrealized_gain_loss']);
-
-                return true;
-            });
+            ->assertStructuredContent(fn (AssertableJson $json) => $json
+                ->where('count', 1)
+                ->has('totals_by_currency.EUR')
+                ->where('totals_by_currency.EUR.market_value', 1100.0)
+                ->where('totals_by_currency.EUR.unrealized_gain_loss', 100.0)
+                ->etc()
+            );
     }
 
     public function test_bills_upcoming(): void
@@ -189,12 +186,11 @@ class ToolsTest extends TestCase
 
         LifeOsServer::tool(UpcomingBills::class, ['within_days' => 7])
             ->assertOk()
-            ->assertStructuredContent(function (array $content): bool {
-                $this->assertGreaterThanOrEqual(1, $content['count']);
-                $this->assertSame('EVN', $content['items'][0]['service_provider']);
-
-                return true;
-            });
+            ->assertStructuredContent(fn (AssertableJson $json) => $json
+                ->where('count', fn ($value) => $value >= 1)
+                ->where('items.0.service_provider', 'EVN')
+                ->etc()
+            );
     }
 
     public function test_contracts_list(): void
@@ -208,12 +204,11 @@ class ToolsTest extends TestCase
 
         LifeOsServer::tool(ListContracts::class, ['expiring_within_days' => 30])
             ->assertOk()
-            ->assertStructuredContent(function (array $content): bool {
-                $this->assertSame(1, $content['count']);
-                $this->assertSame('Office Lease', $content['items'][0]['title']);
-
-                return true;
-            });
+            ->assertStructuredContent(fn (AssertableJson $json) => $json
+                ->where('count', 1)
+                ->where('items.0.title', 'Office Lease')
+                ->etc()
+            );
     }
 
     public function test_warranties_list(): void
@@ -227,12 +222,11 @@ class ToolsTest extends TestCase
 
         LifeOsServer::tool(ListWarranties::class, ['expiring_within_days' => 60])
             ->assertOk()
-            ->assertStructuredContent(function (array $content): bool {
-                $this->assertSame(1, $content['count']);
-                $this->assertSame('Laptop', $content['items'][0]['product_name']);
-
-                return true;
-            });
+            ->assertStructuredContent(fn (AssertableJson $json) => $json
+                ->where('count', 1)
+                ->where('items.0.product_name', 'Laptop')
+                ->etc()
+            );
     }
 
     public function test_iou_list(): void
@@ -248,13 +242,12 @@ class ToolsTest extends TestCase
 
         LifeOsServer::tool(ListIou::class, ['direction' => 'owe'])
             ->assertOk()
-            ->assertStructuredContent(function (array $content): bool {
-                $this->assertSame(1, $content['count']);
-                $this->assertSame('John Doe', $content['items'][0]['person_name']);
-                $this->assertSame(150.0, $content['items'][0]['remaining']);
-
-                return true;
-            });
+            ->assertStructuredContent(fn (AssertableJson $json) => $json
+                ->where('count', 1)
+                ->where('items.0.person_name', 'John Doe')
+                ->where('items.0.remaining', 150.0)
+                ->etc()
+            );
     }
 
     public function test_jobs_pipeline(): void
@@ -268,12 +261,11 @@ class ToolsTest extends TestCase
 
         LifeOsServer::tool(Pipeline::class, ['remote_only' => true])
             ->assertOk()
-            ->assertStructuredContent(function (array $content): bool {
-                $this->assertSame(1, $content['count']);
-                $this->assertSame('Acme', $content['items'][0]['company_name']);
-
-                return true;
-            });
+            ->assertStructuredContent(fn (AssertableJson $json) => $json
+                ->where('count', 1)
+                ->where('items.0.company_name', 'Acme')
+                ->etc()
+            );
     }
 
     public function test_cycle_menu_current_week(): void
@@ -295,29 +287,26 @@ class ToolsTest extends TestCase
 
         LifeOsServer::tool(CurrentWeekCycleMenu::class)
             ->assertOk()
-            ->assertStructuredContent(function (array $content): bool {
-                $this->assertNotNull($content['menu']);
-                $this->assertSame('Standard', $content['menu']['name']);
-                $this->assertCount(7, $content['week']);
-
-                return true;
-            });
+            ->assertStructuredContent(fn (AssertableJson $json) => $json
+                ->where('menu.name', 'Standard')
+                ->has('week', 7)
+                ->etc()
+            );
     }
 
     public function test_notifications_list(): void
     {
         $this->user->notifications()->create([
-            'id' => (string) \Illuminate\Support\Str::uuid(),
+            'id' => (string) Str::uuid(),
             'type' => 'TestNotification',
             'data' => ['title' => 'Hello'],
         ]);
 
         LifeOsServer::tool(ListNotifications::class, ['limit' => 10])
             ->assertOk()
-            ->assertStructuredContent(function (array $content): bool {
-                $this->assertGreaterThanOrEqual(1, $content['count']);
-
-                return true;
-            });
+            ->assertStructuredContent(fn (AssertableJson $json) => $json
+                ->where('count', fn ($value) => $value >= 1)
+                ->etc()
+            );
     }
 }

--- a/tests/Feature/Mcp/WriteToolsTest.php
+++ b/tests/Feature/Mcp/WriteToolsTest.php
@@ -15,6 +15,7 @@ use App\Models\Tenant;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\App;
+use Illuminate\Testing\Fluent\AssertableJson;
 use Tests\TestCase;
 
 class WriteToolsTest extends TestCase
@@ -51,14 +52,13 @@ class WriteToolsTest extends TestCase
     {
         LifeOsServer::tool(CreateExpense::class, $this->expenseArgs())
             ->assertOk()
-            ->assertStructuredContent(function (array $content): bool {
-                $this->assertArrayHasKey('pending_action_id', $content);
-                $this->assertSame(PendingAction::STATUS_PENDING, $content['status']);
-                $this->assertNotEmpty($content['idempotency_key']);
-                $this->assertFalse($content['auto_applied']);
-
-                return true;
-            });
+            ->assertStructuredContent(fn (AssertableJson $json) => $json
+                ->has('pending_action_id')
+                ->where('status', PendingAction::STATUS_PENDING)
+                ->where('auto_applied', false)
+                ->whereNot('idempotency_key', '')
+                ->etc()
+            );
 
         $this->assertSame(1, PendingAction::query()->count());
         $this->assertSame(0, Expense::query()->count(), 'No expense before approval.');
@@ -92,12 +92,11 @@ class WriteToolsTest extends TestCase
             ],
         ])
             ->assertOk()
-            ->assertStructuredContent(function (array $content): bool {
-                $this->assertSame(2, $content['item_count']);
-                $this->assertSame(PendingAction::STATUS_PENDING, $content['status']);
-
-                return true;
-            });
+            ->assertStructuredContent(fn (AssertableJson $json) => $json
+                ->where('item_count', 2)
+                ->where('status', PendingAction::STATUS_PENDING)
+                ->etc()
+            );
 
         $this->assertSame(1, PendingAction::query()->count());
         $this->assertSame('expenses.bulkImport', PendingAction::query()->first()->tool);

--- a/tests/Unit/ExpenseModelTest.php
+++ b/tests/Unit/ExpenseModelTest.php
@@ -28,6 +28,7 @@ class ExpenseModelTest extends TestCase
             'description', 'merchant', 'payment_method', 'receipt_attachments', 'tags',
             'location', 'is_tax_deductible', 'expense_type', 'is_recurring',
             'recurring_schedule', 'budget_allocated', 'notes', 'status', 'unique_key',
+            'source', 'created_by_agent_token_id',
         ];
         $expense = new Expense;
 

--- a/tests/Unit/Services/Agents/AgentRegistryTest.php
+++ b/tests/Unit/Services/Agents/AgentRegistryTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Agents;
+
+use App\Services\Agents\AgentRegistry;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\File;
+use RuntimeException;
+use Tests\TestCase;
+
+class AgentRegistryTest extends TestCase
+{
+    private string $root;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->root = storage_path('framework/testing/agents-'.uniqid());
+        File::ensureDirectoryExists($this->root);
+        Config::set('agents.definitions_path', $this->root);
+    }
+
+    protected function tearDown(): void
+    {
+        File::deleteDirectory($this->root);
+        parent::tearDown();
+    }
+
+    private function writeAgent(string $slug, array $config, string $prompt): void
+    {
+        $dir = $this->root.'/'.$slug;
+        File::ensureDirectoryExists($dir);
+        File::put($dir.'/agent.json', json_encode($config));
+        File::put($dir.'/system.md', $prompt);
+    }
+
+    public function test_loads_agent_from_filesystem(): void
+    {
+        $this->writeAgent('email-ingestion', [
+            'slug' => 'email-ingestion',
+            'model' => 'claude-opus-4-7',
+            'mcp_servers' => ['lifeos', 'gmail'],
+            'allowed_tools' => ['expenses.create'],
+            'feature_flag' => 'agents.email_ingestion.enabled',
+            'max_session_duration_seconds' => 600,
+            'max_tool_calls' => 200,
+        ], '## test prompt');
+
+        $registry = new AgentRegistry;
+        $def = $registry->find('email-ingestion');
+
+        $this->assertSame('email-ingestion', $def->slug);
+        $this->assertSame('claude-opus-4-7', $def->model);
+        $this->assertSame(['lifeos', 'gmail'], $def->mcpServers);
+        $this->assertSame(['expenses.create'], $def->allowedTools);
+        $this->assertSame('## test prompt', $def->systemPrompt);
+    }
+
+    public function test_throws_when_agent_missing(): void
+    {
+        $registry = new AgentRegistry;
+
+        $this->expectException(RuntimeException::class);
+        $registry->find('nonexistent');
+    }
+
+    public function test_skips_directories_without_required_files(): void
+    {
+        File::ensureDirectoryExists($this->root.'/incomplete');
+        // Only agent.json, no system.md.
+        File::put($this->root.'/incomplete/agent.json', json_encode([
+            'slug' => 'incomplete',
+            'model' => 'x',
+            'mcp_servers' => [],
+            'allowed_tools' => [],
+            'feature_flag' => 'x',
+        ]));
+
+        $registry = new AgentRegistry;
+
+        $this->assertSame([], $registry->all());
+    }
+
+    public function test_feature_flag_resolves_via_config(): void
+    {
+        $this->writeAgent('flagged', [
+            'slug' => 'flagged',
+            'model' => 'm',
+            'mcp_servers' => [],
+            'allowed_tools' => [],
+            'feature_flag' => 'agents.flagged.enabled',
+        ], 'p');
+
+        Config::set('agents.flags.agents.flagged.enabled', true);
+
+        $registry = new AgentRegistry;
+        $this->assertTrue($registry->isEnabled($registry->find('flagged')));
+
+        Config::set('agents.flags.agents.flagged.enabled', false);
+        $registry->flush();
+        $this->assertFalse($registry->isEnabled($registry->find('flagged')));
+    }
+}


### PR DESCRIPTION
> Phase 3 of the Managed Agents initiative. Phases 1 (#148) and 2 (#150) are already merged to `main`; this PR rebases on top of them. Plan: `docs/agents/IMPLEMENTATION_PLAN.md`. Architecture + runbook: `docs/agents/AGENTS.md`.

## Summary

Stands up the orchestration layer that drives Anthropic Managed Agents sessions against LifeOS data, plus the first agent: **email-ingestion**, which proposes one `expenses.create` per receipt-shaped Gmail message. Every proposed write lands in the Phase 2 pending-actions queue; the agent never auto-applies and never invents categories.

### Backend

- **`config/agents.php`** — Anthropic API config (base URL, `anthropic-beta: managed-agents-2026-04-01`), per-agent feature flags, MCP server registry, retention/window knobs.
- **Migrations** — `agent_runs`, `agent_run_events`.
- **Models** — `AgentRun` + `AgentRunEvent` with status scopes and a duration helper.
- **`App\Services\Agents`:**
  - `AgentDefinition` — immutable VO loaded from `agents/{slug}/agent.json`.
  - `AgentRegistry` — filesystem loader with feature-flag check.
  - `AgentSessionConfig` — pure builder for the Managed Agents session body.
  - `ManagedAgentsClient` — raw HTTP today, designed to swap to `anthropic/anthropic-sdk-php` per method as the SDK adds coverage. The public surface is the migration boundary, not callers.
  - `AgentRunRecorder` — lifecycle: start, recordEvent, complete, fail, cancel. Updates `tools_called` counts, `pending_actions_created`, and token usage live; final pending count is reconciled from `pending_actions` so a dropped stream event doesn't undercount.
- **`composer.json`** — `anthropic/anthropic-sdk-php ^0.19` pinned, ready for per-method SDK swaps.

### Agent definition & skill

- **`agents/email-ingestion/agent.json` + `system.md`.** Gmail + LifeOS MCP, `expenses.{list,create,bulkImport}` only, 10-min / 200-call limits, no auto-apply, skip-on-uncertainty, idempotency anchored on `source_email_id`.
- **`.claude/skills/expense-categorization/SKILL.md`.** Sensible default categories with a Macedonian-leaning merchant rule list (Lidl/Konzum/Tinex, EVN/Telekom/A1, Makpetrol/OKTA, Netflix/Spotify/GitHub, etc.). Easy to extend; unmatched merchants land as `uncategorized` rather than being guessed at.

### Command + schedule

- **`php artisan agents:run {slug} [--tenant=...] [--user=...] [--dry-run]`.** Dry-run mode resolves config and creates the `AgentRun` row without calling the API — useful for sanity checking before flipping the flag.
- **`routes/console.php`** — every-30-min schedule entry for `email-ingestion`, gated by `AGENT_EMAIL_INGESTION_ENABLED` env flag *and* `tenants.agents_writes_disabled`.
- Per-run, ephemeral `AgentToken` bound to the tenant + the agent's tool allowlist. The plaintext is generated in memory, passed into the session config, and the row is revoked when the run ends.

### Dashboard

- **`AgentRunsController`** + `/dashboard/agents` and `/dashboard/agents/{run}`.
- **Sidebar** gains an "Agents" entry under Personal Finance.
- **React** — `Agents/Index.tsx` (list + filter by agent and status) and `Agents/Show.tsx` (status, usage, tools-called map, and a full event timeline).

## Test plan

- [ ] `composer install` (CI) — verify the SDK pin resolves.
- [ ] `php artisan migrate` — `agent_runs` + `agent_run_events` apply.
- [ ] `php artisan test --compact tests/Unit/Services/Agents tests/Feature/Agents` — green:
  - `AgentRegistryTest`: load, skip incomplete dirs, unknown slug, flag resolution.
  - `AgentRunRecorderTest`: start/record/complete/fail + counter aggregation.
  - `ManagedAgentsClientTest`: `Http::fake` covers beta-header send, error path, multi-line streaming with SSE/raw JSON + comment-line tolerance.
  - `AgentsRunCommandTest`: dry-run, disabled-flag short-circuit, writes-disabled-tenant skip, full mocked-client run with 3-event stream, ephemeral token revocation.
- [ ] `vendor/bin/pint --dirty --format agent`
- [ ] `npm run build`
- [ ] **Manual dry-run** (recommended once env is set):
  ```
  ANTHROPIC_API_KEY=... \
  AGENT_EMAIL_INGESTION_ENABLED=true \
  LIFEOS_MCP_PUBLIC_URL=https://your-deploy/mcp/lifeos \
  GMAIL_MCP_URL=... \
  php artisan agents:run email-ingestion --tenant=<slug> --dry-run
  ```
  Inspect `AgentRun` row at `/dashboard/agents/{id}`.
- [ ] **Manual real run** once happy with config. Pending actions appear at `/dashboard/pending-actions`.

## Notes

- **`anthropic/anthropic-sdk-php` is added but not yet wired in.** The intent is to swap individual `ManagedAgentsClient` methods over as the SDK ships Managed Agents coverage. No caller signatures change.
- **MCP wire format is still beta.** If endpoint shapes change before GA, only `ManagedAgentsClient` needs updating — `agents:run`, the recorder, and the dashboard are independent of the wire protocol.
- **Skill content is editable.** The default rules ship enough categories to be useful immediately; extend the merchant list as you encounter new ones, and add `vendor aliases` whenever a bank-statement string differs from the receipt's merchant name.
- **No tunnel playbook.** Per the resolved decision in the plan, Managed Agents reaches the deployed (or staging) MCP server via `LIFEOS_MCP_PUBLIC_URL`. Local-only testing uses `--dry-run`.

## Phase gate

Per the plan, Phase 3 ends with a one-week soak against the user's real Gmail mailbox. After this merges and the schedule entry runs at least one real session: review the `AgentRun` timeline, approve a few proposed expenses, and look for false-positives (non-receipts that became pending actions) or false-negatives (receipts the agent skipped). Tune `expense-categorization` based on what shows up.

https://claude.ai/code/session_01AxKEBuMxrHVjg7DShsnGi2

---
_Generated by [Claude Code](https://claude.ai/code/session_01AxKEBuMxrHVjg7DShsnGi2)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Agents dashboard to view automated agent execution history and details
  * Introduced email-ingestion agent that automatically extracts expense receipts from Gmail and creates pending expenses
  * Added deterministic expense categorization rules for automated receipt processing

* **Documentation**
  * Added comprehensive agents documentation describing architecture, configuration, and operational workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->