### PR TITLE
feat(agents): Phase 4 — email ingestion expansion (5 modules + jobs)

### DIFF
--- a/agents/email-ingestion/agent.json
+++ b/agents/email-ingestion/agent.json
@@ -1,0 +1,28 @@
+{
+    "slug": "email-ingestion",
+    "model": "claude-opus-4-7",
+    "fallback_model": "claude-sonnet-4-6",
+    "mcp_servers": ["lifeos", "gmail"],
+    "allowed_tools": [
+        "expenses.list",
+        "expenses.create",
+        "expenses.bulkImport",
+        "subscriptions.list",
+        "subscriptions.create",
+        "contracts.list",
+        "contracts.create",
+        "warranties.list",
+        "warranties.create",
+        "iou.list",
+        "iou.create",
+        "bills.upcoming",
+        "utilityBills.create",
+        "jobs.pipeline",
+        "jobs.updateStatus",
+        "jobs.addInterview"
+    ],
+    "max_session_duration_seconds": 900,
+    "max_tool_calls": 300,
+    "feature_flag": "agents.email_ingestion.enabled",
+    "schedule": "*/30 * * * *"
+}

--- a/agents/email-ingestion/system.md
+++ b/agents/email-ingestion/system.md
@@ -1,0 +1,80 @@
+# Email ingestion agent
+
+You are the LifeOS email-ingestion agent. Your job is to extract structured records from receipt-shaped, contract-shaped, bill-shaped, IOU-shaped, and recruiter-shaped emails in the connected Gmail mailbox and turn each one into an MCP write call against the LifeOS server. **You never auto-apply.** Every write tool you call lands in the Pending Actions queue for human approval.
+
+## Available tools
+
+You may only call the tools listed in your session config. They fall into two groups:
+
+### Read-only
+
+- **Gmail MCP** — list and read recent messages.
+- **`expenses.list`, `subscriptions.list`, `contracts.list`, `warranties.list`, `iou.list`, `bills.upcoming`, `jobs.pipeline`** — query existing LifeOS data so you can avoid double-creating records the user already entered manually.
+
+### Write (queued)
+
+- **Expenses:** `expenses.create`, `expenses.bulkImport`
+- **Subscriptions:** `subscriptions.create`
+- **Contracts:** `contracts.create`
+- **Warranties:** `warranties.create`
+- **IOU:** `iou.create`
+- **Utility Bills:** `utilityBills.create`
+- **Job Applications:** `jobs.updateStatus`, `jobs.addInterview`
+
+Every write tool returns `{ pending_action_id, status, idempotency_key }`. If you re-submit the same logical write the server returns the existing pending action rather than creating a second one. You can rely on this — re-call without fear of duplicates.
+
+## Process
+
+### 1. Triage the inbox
+
+List unread (or recently received) Gmail messages. Skim subjects and senders. Place each candidate into one of these buckets:
+
+- **Receipt / order confirmation** → `expenses.create` (and possibly `warranties.create` if the product comes with one).
+- **Subscription welcome / renewal notice** → `subscriptions.create`.
+- **Utility bill** → `utilityBills.create`.
+- **Contract / lease / SaaS agreement** → `contracts.create`.
+- **Personal IOU email (e.g. someone confirms they owe me, or I owe them)** → `iou.create`.
+- **Recruiter / interview invite / rejection / offer email** → `jobs.updateStatus` (always) and possibly `jobs.addInterview`.
+- **Anything else** → skip.
+
+If you can't classify confidently, skip and emit a one-line note explaining why. Don't guess.
+
+### 2. Extract per bucket
+
+For every candidate, before calling the write tool:
+
+- **Idempotency anchor.** Set `source_email_id` to the Gmail message id on every write. The server uses it to disambiguate near-duplicates.
+- **Categorize via the skill.** For expenses, the `expense-categorization` skill is the only acceptable source for `category` / `subcategory`. For other modules, use plain English category strings consistent with what the user already has (check the relevant `*.list` first if you're unsure).
+- **Skip on uncertainty.** If you can't pin down required fields with confidence, skip the message and emit a one-line note. Required fields per tool are listed in each tool's schema.
+
+### 3. Specifics
+
+- **Expenses.** One `expenses.create` per receipt. Use `expenses.bulkImport` only when you have ≥10 valid receipts in this run; otherwise prefer one-by-one for clearer review.
+- **Subscriptions.** Only create on a *welcome* email. Do not create a subscription from a renewal receipt for one that already exists in `subscriptions.list` — that's an `expenses.create` (the renewal payment) instead.
+- **Warranties.** Created off purchase receipts that explicitly mention warranty coverage. If the receipt is silent on warranty terms, treat the email as an expense only — don't infer warranty length.
+- **Utility Bills.** Created from inbound bill notifications. The `utilityBills.create` tool records the bill itself, not the payment.
+- **Contracts.** Created off contract documents and leases that arrive as email. Skip auto-renewal extension notices that reference an existing contract — those become an explicit user task.
+- **IOU.** Only formal "you owe me" or "I owe you" emails (e.g. someone replies with "ok, I'll pay you 200 EUR for the dinner"). Don't infer IOUs from invoices or generic mentions of money.
+- **Jobs — updateStatus.** Map common email cues to your application's status enum: "thanks for applying" → `applied`, "we'd like to schedule a call" → `interviewing`, "we're moving forward with another candidate" → `rejected`, "we'd like to make you an offer" → `offered`. Always call `jobs.pipeline` first to find the right `job_application_id` before invoking `updateStatus`.
+- **Jobs — addInterview.** Call this whenever the email schedules a specific interview slot. Set `scheduled_at` to the ISO 8601 datetime in the user's local timezone, and copy the meeting link or address into `location`. Status update happens separately if the email also moves the application forward in the pipeline.
+
+## Hard rules
+
+- Never auto-apply. Every write you call lands in the queue.
+- Never edit existing records (no update tools available in this phase except `jobs.updateStatus` and the dedicated revert flow handled server-side).
+- Never invent a category for expenses. Use the skill or set `"uncategorized"`.
+- Never read mailboxes outside the Gmail MCP server you've been given.
+- Stop once you've created 50 pending actions across all tools, or you've gone 30 messages without a successful classification, or you've already processed the message id in this run.
+
+## Output
+
+End the session with a short text summary, grouped by tool:
+
+```
+Receipts seen: <n>
+- expenses.create: <n>
+- subscriptions.create: <n>
+- ...
+Skipped: <n>, with reasons:
+- <message id> — <reason>
+```

--- a/app/Http/Controllers/ContractController.php
+++ b/app/Http/Controllers/ContractController.php
@@ -82,10 +82,8 @@ class ContractController extends Controller
      */
     public function store(StoreContractRequest $request)
     {
-        $contract = Contract::create([
-            'user_id' => auth()->id(),
-            ...$request->validated(),
-        ]);
+        $contract = app(\App\Services\Contracts\ContractService::class)
+            ->create(auth()->user(), $request->validated());
 
         return redirect()->route('contracts.show', $contract)
             ->with('success', 'Contract created successfully!');
@@ -129,7 +127,7 @@ class ContractController extends Controller
             abort(403, 'Unauthorized access to contract.');
         }
 
-        $contract->update($request->validated());
+        app(\App\Services\Contracts\ContractService::class)->update($contract, $request->validated());
 
         return redirect()->route('contracts.show', $contract)
             ->with('success', 'Contract updated successfully!');
@@ -145,7 +143,7 @@ class ContractController extends Controller
             abort(403, 'Unauthorized access to contract.');
         }
 
-        $contract->delete();
+        app(\App\Services\Contracts\ContractService::class)->delete($contract);
 
         return redirect()->route('contracts.index')
             ->with('success', 'Contract deleted successfully!');
@@ -161,10 +159,7 @@ class ContractController extends Controller
             abort(403, 'Unauthorized access to contract.');
         }
 
-        $contract->update([
-            'status' => 'terminated',
-            'end_date' => now(),
-        ]);
+        app(\App\Services\Contracts\ContractService::class)->terminate($contract);
 
         return redirect()->route('contracts.show', $contract)
             ->with('success', 'Contract terminated successfully!');

--- a/app/Http/Controllers/SubscriptionController.php
+++ b/app/Http/Controllers/SubscriptionController.php
@@ -76,10 +76,8 @@ class SubscriptionController extends Controller
      */
     public function store(StoreSubscriptionRequest $request)
     {
-        $subscription = Subscription::create([
-            'user_id' => auth()->id(),
-            ...$request->validated(),
-        ]);
+        $subscription = app(\App\Services\Subscriptions\SubscriptionService::class)
+            ->create(auth()->user(), $request->validated());
 
         return redirect()->route('subscriptions.show', $subscription)
             ->with('success', 'Subscription created successfully!');
@@ -127,7 +125,8 @@ class SubscriptionController extends Controller
             abort(403, 'Unauthorized access to subscription.');
         }
 
-        $subscription->update($request->validated());
+        app(\App\Services\Subscriptions\SubscriptionService::class)
+            ->update($subscription, $request->validated());
 
         return redirect()->route('subscriptions.show', $subscription)
             ->with('success', 'Subscription updated successfully!');
@@ -143,7 +142,7 @@ class SubscriptionController extends Controller
             abort(403, 'Unauthorized access to subscription.');
         }
 
-        $subscription->delete();
+        app(\App\Services\Subscriptions\SubscriptionService::class)->delete($subscription);
 
         return redirect()->route('subscriptions.index')
             ->with('success', 'Subscription deleted successfully!');
@@ -159,10 +158,7 @@ class SubscriptionController extends Controller
             abort(403, 'Unauthorized access to subscription.');
         }
 
-        $subscription->update([
-            'status' => 'cancelled',
-            'cancellation_date' => now(),
-        ]);
+        app(\App\Services\Subscriptions\SubscriptionService::class)->cancel($subscription);
 
         return redirect()->route('subscriptions.show', $subscription)
             ->with('success', 'Subscription cancelled successfully!');
@@ -178,7 +174,7 @@ class SubscriptionController extends Controller
             abort(403, 'Unauthorized access to subscription.');
         }
 
-        $subscription->update(['status' => 'paused']);
+        app(\App\Services\Subscriptions\SubscriptionService::class)->pause($subscription);
 
         return redirect()->route('subscriptions.show', $subscription)
             ->with('success', 'Subscription paused successfully!');
@@ -194,7 +190,7 @@ class SubscriptionController extends Controller
             abort(403, 'Unauthorized access to subscription.');
         }
 
-        $subscription->update(['status' => 'active']);
+        app(\App\Services\Subscriptions\SubscriptionService::class)->resume($subscription);
 
         return redirect()->route('subscriptions.show', $subscription)
             ->with('success', 'Subscription resumed successfully!');

--- a/app/Mcp/LifeOsServer.php
+++ b/app/Mcp/LifeOsServer.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace App\Mcp;
 
+use App\Mcp\Tools\Bills\CreateUtilityBill;
 use App\Mcp\Tools\Bills\UpcomingBills;
+use App\Mcp\Tools\Contracts\CreateContract;
 use App\Mcp\Tools\Contracts\ListContracts;
 use App\Mcp\Tools\CycleMenu\CurrentWeekCycleMenu;
 use App\Mcp\Tools\Dashboard\Summary;
@@ -13,10 +15,15 @@ use App\Mcp\Tools\Expenses\CategorizeExpense;
 use App\Mcp\Tools\Expenses\CreateExpense;
 use App\Mcp\Tools\Expenses\ListExpenses;
 use App\Mcp\Tools\Investments\Portfolio;
+use App\Mcp\Tools\Iou\CreateIou;
 use App\Mcp\Tools\Iou\ListIou;
+use App\Mcp\Tools\Jobs\AddInterview;
 use App\Mcp\Tools\Jobs\Pipeline;
+use App\Mcp\Tools\Jobs\UpdateJobStatus;
 use App\Mcp\Tools\Notifications\ListNotifications;
+use App\Mcp\Tools\Subscriptions\CreateSubscription;
 use App\Mcp\Tools\Subscriptions\ListSubscriptions;
+use App\Mcp\Tools\Warranties\CreateWarranty;
 use App\Mcp\Tools\Warranties\ListWarranties;
 use Laravel\Mcp\Server;
 
@@ -52,5 +59,12 @@ class LifeOsServer extends Server
         CreateExpense::class,
         BulkImportExpenses::class,
         CategorizeExpense::class,
+        CreateSubscription::class,
+        CreateContract::class,
+        CreateWarranty::class,
+        CreateIou::class,
+        CreateUtilityBill::class,
+        UpdateJobStatus::class,
+        AddInterview::class,
     ];
 }

--- a/app/Mcp/Tools/Bills/CreateUtilityBill.php
+++ b/app/Mcp/Tools/Bills/CreateUtilityBill.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Mcp\Tools\Bills;
+
+use App\Mcp\Tools\AbstractTool;
+use App\Models\PendingAction;
+use App\Services\Agents\PendingActionApplier;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\ResponseFactory;
+
+class CreateUtilityBill extends AbstractTool
+{
+    protected string $name = 'utilityBills.create';
+
+    protected string $description = 'Record an incoming utility bill for the authenticated tenant. Queued as a pending action awaiting human approval.';
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'utility_type' => $schema->string()->description('e.g. "electricity", "water", "internet". Required.'),
+            'service_provider' => $schema->string()->description('Provider name. Required.'),
+            'account_number' => $schema->string()->description('Account number on the bill.'),
+            'service_address' => $schema->string()->description('Service address.'),
+            'bill_amount' => $schema->number()->description('Bill amount. Required.'),
+            'currency' => $schema->string()->description('ISO 4217, defaults to MKD.'),
+            'usage_amount' => $schema->number()->description('Usage quantity (e.g. kWh).'),
+            'usage_unit' => $schema->string()->description('Unit of usage_amount.'),
+            'bill_period_start' => $schema->string()->description('YYYY-MM-DD.'),
+            'bill_period_end' => $schema->string()->description('YYYY-MM-DD.'),
+            'due_date' => $schema->string()->description('YYYY-MM-DD. Required.'),
+            'source_email_id' => $schema->string()->description('Optional Gmail message id for idempotency.'),
+        ];
+    }
+
+    public function handle(Request $request, PendingActionApplier $applier): Response|ResponseFactory
+    {
+        if ($error = $this->authorize()) {
+            return $error;
+        }
+
+        $payload = array_filter([
+            'utility_type' => $request->get('utility_type'),
+            'service_provider' => $request->get('service_provider'),
+            'account_number' => $request->get('account_number'),
+            'service_address' => $request->get('service_address'),
+            'bill_amount' => $request->get('bill_amount'),
+            'currency' => $request->get('currency', 'MKD'),
+            'usage_amount' => $request->get('usage_amount'),
+            'usage_unit' => $request->get('usage_unit'),
+            'bill_period_start' => $request->get('bill_period_start'),
+            'bill_period_end' => $request->get('bill_period_end'),
+            'due_date' => $request->get('due_date'),
+            'payment_status' => 'pending',
+            'source_email_id' => $request->get('source_email_id'),
+        ], static fn ($v) => $v !== null);
+
+        try {
+            $action = $applier->record(
+                token: $this->agentToken(),
+                tool: $this->name(),
+                action: PendingAction::ACTION_CREATE,
+                payload: $payload,
+            );
+        } catch (\Throwable $e) {
+            return Response::error($e->getMessage());
+        }
+
+        return Response::structured([
+            'pending_action_id' => $action->id,
+            'status' => $action->status,
+            'idempotency_key' => $action->idempotency_key,
+            'auto_applied' => $action->status === PendingAction::STATUS_APPLIED,
+        ]);
+    }
+}

--- a/app/Mcp/Tools/Contracts/CreateContract.php
+++ b/app/Mcp/Tools/Contracts/CreateContract.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Mcp\Tools\Contracts;
+
+use App\Mcp\Tools\AbstractTool;
+use App\Models\PendingAction;
+use App\Services\Agents\PendingActionApplier;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\ResponseFactory;
+
+class CreateContract extends AbstractTool
+{
+    protected string $name = 'contracts.create';
+
+    protected string $description = 'Create a contract record for the authenticated tenant. Queued as a pending action awaiting human approval.';
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'title' => $schema->string()->description('Contract title. Required.'),
+            'counterparty' => $schema->string()->description('Counterparty name. Required.'),
+            'contract_type' => $schema->string()->description('Type (lease, employment, service, etc.).'),
+            'start_date' => $schema->string()->description('YYYY-MM-DD. Required.'),
+            'end_date' => $schema->string()->description('YYYY-MM-DD.'),
+            'notice_period_days' => $schema->integer()->description('Notice required before non-renewal.'),
+            'auto_renewal' => $schema->boolean()->description('Whether contract auto-renews.'),
+            'contract_value' => $schema->number()->description('Total contract value (numeric).'),
+            'payment_terms' => $schema->string()->description('Free-text payment terms.'),
+            'notes' => $schema->string()->description('Free-text notes.'),
+            'source_email_id' => $schema->string()->description('Optional Gmail message id for idempotency.'),
+        ];
+    }
+
+    public function handle(Request $request, PendingActionApplier $applier): Response|ResponseFactory
+    {
+        if ($error = $this->authorize()) {
+            return $error;
+        }
+
+        $payload = array_filter([
+            'title' => $request->get('title'),
+            'counterparty' => $request->get('counterparty'),
+            'contract_type' => $request->get('contract_type'),
+            'start_date' => $request->get('start_date'),
+            'end_date' => $request->get('end_date'),
+            'notice_period_days' => $request->get('notice_period_days'),
+            'auto_renewal' => $request->get('auto_renewal'),
+            'contract_value' => $request->get('contract_value'),
+            'payment_terms' => $request->get('payment_terms'),
+            'notes' => $request->get('notes'),
+            'status' => 'active',
+            'source_email_id' => $request->get('source_email_id'),
+        ], static fn ($v) => $v !== null);
+
+        try {
+            $action = $applier->record(
+                token: $this->agentToken(),
+                tool: $this->name(),
+                action: PendingAction::ACTION_CREATE,
+                payload: $payload,
+            );
+        } catch (\Throwable $e) {
+            return Response::error($e->getMessage());
+        }
+
+        return Response::structured([
+            'pending_action_id' => $action->id,
+            'status' => $action->status,
+            'idempotency_key' => $action->idempotency_key,
+            'auto_applied' => $action->status === PendingAction::STATUS_APPLIED,
+        ]);
+    }
+}

--- a/app/Mcp/Tools/Iou/CreateIou.php
+++ b/app/Mcp/Tools/Iou/CreateIou.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Mcp\Tools\Iou;
+
+use App\Mcp\Tools\AbstractTool;
+use App\Models\PendingAction;
+use App\Services\Agents\PendingActionApplier;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\ResponseFactory;
+
+class CreateIou extends AbstractTool
+{
+    protected string $name = 'iou.create';
+
+    protected string $description = 'Record a money-owed entry, in either direction, for the authenticated tenant. Queued as a pending action.';
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'type' => $schema->string()->description('"owe" (you owe) or "owed" (someone owes you). Required.'),
+            'person_name' => $schema->string()->description('Counterparty name. Required.'),
+            'amount' => $schema->number()->description('Total amount. Required.'),
+            'currency' => $schema->string()->description('ISO 4217 3-letter code, defaults to MKD.'),
+            'transaction_date' => $schema->string()->description('YYYY-MM-DD. Required.'),
+            'due_date' => $schema->string()->description('YYYY-MM-DD.'),
+            'description' => $schema->string()->description('Free-text description. Required.'),
+            'category' => $schema->string()->description('Category tag.'),
+            'source_email_id' => $schema->string()->description('Optional Gmail message id for idempotency.'),
+        ];
+    }
+
+    public function handle(Request $request, PendingActionApplier $applier): Response|ResponseFactory
+    {
+        if ($error = $this->authorize()) {
+            return $error;
+        }
+
+        $payload = array_filter([
+            'type' => $request->get('type'),
+            'person_name' => $request->get('person_name'),
+            'amount' => $request->get('amount'),
+            'currency' => $request->get('currency', 'MKD'),
+            'transaction_date' => $request->get('transaction_date'),
+            'due_date' => $request->get('due_date'),
+            'description' => $request->get('description'),
+            'category' => $request->get('category'),
+            'status' => 'pending',
+            'source_email_id' => $request->get('source_email_id'),
+        ], static fn ($v) => $v !== null);
+
+        try {
+            $action = $applier->record(
+                token: $this->agentToken(),
+                tool: $this->name(),
+                action: PendingAction::ACTION_CREATE,
+                payload: $payload,
+            );
+        } catch (\Throwable $e) {
+            return Response::error($e->getMessage());
+        }
+
+        return Response::structured([
+            'pending_action_id' => $action->id,
+            'status' => $action->status,
+            'idempotency_key' => $action->idempotency_key,
+            'auto_applied' => $action->status === PendingAction::STATUS_APPLIED,
+        ]);
+    }
+}

--- a/app/Mcp/Tools/Jobs/AddInterview.php
+++ b/app/Mcp/Tools/Jobs/AddInterview.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Mcp\Tools\Jobs;
+
+use App\Mcp\Tools\AbstractTool;
+use App\Models\JobApplication;
+use App\Models\PendingAction;
+use App\Services\Agents\PendingActionApplier;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\ResponseFactory;
+
+class AddInterview extends AbstractTool
+{
+    protected string $name = 'jobs.addInterview';
+
+    protected string $description = 'Schedule an interview against an existing job application. Queued as a pending action.';
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'job_application_id' => $schema->integer()->description('Job application id (must belong to the authenticated tenant). Required.'),
+            'scheduled_at' => $schema->string()->description('ISO 8601 datetime. Required.'),
+            'interview_type' => $schema->string()->description('"phone", "onsite", "video", "technical", etc.'),
+            'interviewer_name' => $schema->string()->description('Name of the interviewer (or recruiter contact).'),
+            'location' => $schema->string()->description('Address or video link.'),
+            'notes' => $schema->string()->description('Free-text notes from the email.'),
+            'source_email_id' => $schema->string()->description('Optional Gmail message id for idempotency.'),
+        ];
+    }
+
+    public function handle(Request $request, PendingActionApplier $applier): Response|ResponseFactory
+    {
+        if ($error = $this->authorize()) {
+            return $error;
+        }
+
+        $jobId = (int) $request->get('job_application_id', 0);
+
+        if ($jobId <= 0) {
+            return Response::error('job_application_id is required.');
+        }
+
+        $application = JobApplication::query()->find($jobId);
+
+        if ($application === null) {
+            return Response::error("Job application [{$jobId}] not found in this tenant.");
+        }
+
+        $payload = array_filter([
+            'job_application_id' => $application->id,
+            'scheduled_at' => $request->get('scheduled_at'),
+            'interview_type' => $request->get('interview_type'),
+            'interviewer_name' => $request->get('interviewer_name'),
+            'location' => $request->get('location'),
+            'notes' => $request->get('notes'),
+            'source_email_id' => $request->get('source_email_id'),
+        ], static fn ($v) => $v !== null);
+
+        try {
+            $action = $applier->record(
+                token: $this->agentToken(),
+                tool: $this->name(),
+                action: PendingAction::ACTION_CREATE,
+                payload: $payload,
+            );
+        } catch (\Throwable $e) {
+            return Response::error($e->getMessage());
+        }
+
+        return Response::structured([
+            'pending_action_id' => $action->id,
+            'status' => $action->status,
+            'idempotency_key' => $action->idempotency_key,
+            'auto_applied' => $action->status === PendingAction::STATUS_APPLIED,
+        ]);
+    }
+}

--- a/app/Mcp/Tools/Jobs/UpdateJobStatus.php
+++ b/app/Mcp/Tools/Jobs/UpdateJobStatus.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Mcp\Tools\Jobs;
+
+use App\Mcp\Tools\AbstractTool;
+use App\Models\JobApplication;
+use App\Models\PendingAction;
+use App\Services\Agents\PendingActionApplier;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\ResponseFactory;
+
+class UpdateJobStatus extends AbstractTool
+{
+    protected string $name = 'jobs.updateStatus';
+
+    protected string $description = 'Move a job application to a new pipeline status (and optionally schedule the next action). Queued as a pending action.';
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'job_application_id' => $schema->integer()->description('Job application id (must belong to the authenticated tenant). Required.'),
+            'status' => $schema->string()->description('New status (one of the pipeline statuses LifeOS uses). Required.'),
+            'next_action_at' => $schema->string()->description('ISO 8601 datetime to follow up.'),
+            'source_email_id' => $schema->string()->description('Optional Gmail message id for idempotency.'),
+        ];
+    }
+
+    public function handle(Request $request, PendingActionApplier $applier): Response|ResponseFactory
+    {
+        if ($error = $this->authorize()) {
+            return $error;
+        }
+
+        $jobId = (int) $request->get('job_application_id', 0);
+
+        if ($jobId <= 0) {
+            return Response::error('job_application_id is required.');
+        }
+
+        $application = JobApplication::query()->find($jobId);
+
+        if ($application === null) {
+            return Response::error("Job application [{$jobId}] not found in this tenant.");
+        }
+
+        $payload = array_filter([
+            'job_application_id' => $application->id,
+            'status' => $request->get('status'),
+            'next_action_at' => $request->get('next_action_at'),
+            'source_email_id' => $request->get('source_email_id'),
+        ], static fn ($v) => $v !== null);
+
+        try {
+            $action = $applier->record(
+                token: $this->agentToken(),
+                tool: $this->name(),
+                action: PendingAction::ACTION_UPDATE,
+                payload: $payload,
+            );
+        } catch (\Throwable $e) {
+            return Response::error($e->getMessage());
+        }
+
+        return Response::structured([
+            'pending_action_id' => $action->id,
+            'status' => $action->status,
+            'idempotency_key' => $action->idempotency_key,
+            'auto_applied' => $action->status === PendingAction::STATUS_APPLIED,
+        ]);
+    }
+}

--- a/app/Mcp/Tools/Subscriptions/CreateSubscription.php
+++ b/app/Mcp/Tools/Subscriptions/CreateSubscription.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Mcp\Tools\Subscriptions;
+
+use App\Mcp\Tools\AbstractTool;
+use App\Models\PendingAction;
+use App\Services\Agents\PendingActionApplier;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\ResponseFactory;
+
+class CreateSubscription extends AbstractTool
+{
+    protected string $name = 'subscriptions.create';
+
+    protected string $description = 'Create a subscription for the authenticated tenant. Queued as a pending action awaiting human approval.';
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'service_name' => $schema->string()->description('Service or app name (e.g. "Netflix"). Required.'),
+            'description' => $schema->string()->description('Human-readable description.'),
+            'category' => $schema->string()->description('Category (streaming, saas, cloud, etc.).'),
+            'cost' => $schema->number()->description('Cost per billing cycle. Required.'),
+            'currency' => $schema->string()->description('ISO 4217 3-letter code, defaults to MKD.'),
+            'billing_cycle' => $schema->string()->description('"monthly", "yearly", "weekly", "custom". Required.'),
+            'billing_cycle_days' => $schema->integer()->description('When billing_cycle = "custom".'),
+            'start_date' => $schema->string()->description('YYYY-MM-DD. Required.'),
+            'next_billing_date' => $schema->string()->description('YYYY-MM-DD.'),
+            'payment_method' => $schema->string()->description('Card last-4, transfer, etc.'),
+            'auto_renewal' => $schema->boolean()->description('Default true.'),
+            'source_email_id' => $schema->string()->description('Optional Gmail message id used for idempotency.'),
+        ];
+    }
+
+    public function handle(Request $request, PendingActionApplier $applier): Response|ResponseFactory
+    {
+        if ($error = $this->authorize()) {
+            return $error;
+        }
+
+        $payload = array_filter([
+            'service_name' => $request->get('service_name'),
+            'description' => $request->get('description') ?? $request->get('service_name'),
+            'category' => $request->get('category'),
+            'cost' => $request->get('cost'),
+            'currency' => $request->get('currency', 'MKD'),
+            'billing_cycle' => $request->get('billing_cycle'),
+            'billing_cycle_days' => $request->get('billing_cycle_days'),
+            'start_date' => $request->get('start_date'),
+            'next_billing_date' => $request->get('next_billing_date'),
+            'payment_method' => $request->get('payment_method'),
+            'auto_renewal' => $request->get('auto_renewal'),
+            'status' => 'active',
+            'source_email_id' => $request->get('source_email_id'),
+        ], static fn ($v) => $v !== null);
+
+        try {
+            $action = $applier->record(
+                token: $this->agentToken(),
+                tool: $this->name(),
+                action: PendingAction::ACTION_CREATE,
+                payload: $payload,
+            );
+        } catch (\Throwable $e) {
+            return Response::error($e->getMessage());
+        }
+
+        return Response::structured([
+            'pending_action_id' => $action->id,
+            'status' => $action->status,
+            'idempotency_key' => $action->idempotency_key,
+            'auto_applied' => $action->status === PendingAction::STATUS_APPLIED,
+        ]);
+    }
+}

--- a/app/Mcp/Tools/Warranties/CreateWarranty.php
+++ b/app/Mcp/Tools/Warranties/CreateWarranty.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Mcp\Tools\Warranties;
+
+use App\Mcp\Tools\AbstractTool;
+use App\Models\PendingAction;
+use App\Services\Agents\PendingActionApplier;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\ResponseFactory;
+
+class CreateWarranty extends AbstractTool
+{
+    protected string $name = 'warranties.create';
+
+    protected string $description = 'Register a warranty for a purchased product. Queued as a pending action awaiting human approval.';
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'product_name' => $schema->string()->description('Product name. Required.'),
+            'brand' => $schema->string()->description('Brand or manufacturer.'),
+            'model' => $schema->string()->description('Model name or number.'),
+            'serial_number' => $schema->string()->description('Serial number (helpful for idempotency).'),
+            'purchase_date' => $schema->string()->description('YYYY-MM-DD. Required.'),
+            'purchase_price' => $schema->number()->description('Purchase price (numeric).'),
+            'retailer' => $schema->string()->description('Retailer name.'),
+            'warranty_duration_months' => $schema->integer()->description('Length of coverage in months.'),
+            'warranty_expiration_date' => $schema->string()->description('YYYY-MM-DD. Required.'),
+            'warranty_type' => $schema->string()->description('"manufacturer", "extended", etc.'),
+            'warranty_terms' => $schema->string()->description('Coverage details.'),
+            'source_email_id' => $schema->string()->description('Optional Gmail message id for idempotency.'),
+        ];
+    }
+
+    public function handle(Request $request, PendingActionApplier $applier): Response|ResponseFactory
+    {
+        if ($error = $this->authorize()) {
+            return $error;
+        }
+
+        $payload = array_filter([
+            'product_name' => $request->get('product_name'),
+            'brand' => $request->get('brand'),
+            'model' => $request->get('model'),
+            'serial_number' => $request->get('serial_number'),
+            'purchase_date' => $request->get('purchase_date'),
+            'purchase_price' => $request->get('purchase_price'),
+            'retailer' => $request->get('retailer'),
+            'warranty_duration_months' => $request->get('warranty_duration_months'),
+            'warranty_expiration_date' => $request->get('warranty_expiration_date'),
+            'warranty_type' => $request->get('warranty_type'),
+            'warranty_terms' => $request->get('warranty_terms'),
+            'current_status' => 'active',
+            'source_email_id' => $request->get('source_email_id'),
+        ], static fn ($v) => $v !== null);
+
+        try {
+            $action = $applier->record(
+                token: $this->agentToken(),
+                tool: $this->name(),
+                action: PendingAction::ACTION_CREATE,
+                payload: $payload,
+            );
+        } catch (\Throwable $e) {
+            return Response::error($e->getMessage());
+        }
+
+        return Response::structured([
+            'pending_action_id' => $action->id,
+            'status' => $action->status,
+            'idempotency_key' => $action->idempotency_key,
+            'auto_applied' => $action->status === PendingAction::STATUS_APPLIED,
+        ]);
+    }
+}

--- a/app/Models/Contract.php
+++ b/app/Models/Contract.php
@@ -34,6 +34,8 @@ class Contract extends Model
         'amendments',
         'notes',
         'status',
+        'source',
+        'created_by_agent_token_id',
     ];
 
     protected function casts(): array

--- a/app/Models/Iou.php
+++ b/app/Models/Iou.php
@@ -30,6 +30,8 @@ class Iou extends Model
         'attachments',
         'is_recurring',
         'recurring_schedule',
+        'source',
+        'created_by_agent_token_id',
     ];
 
     protected function casts(): array

--- a/app/Models/Subscription.php
+++ b/app/Models/Subscription.php
@@ -35,6 +35,8 @@ class Subscription extends Model
         'tags',
         'status',
         'unique_key',
+        'source',
+        'created_by_agent_token_id',
     ];
 
     protected function casts(): array

--- a/app/Models/UtilityBill.php
+++ b/app/Models/UtilityBill.php
@@ -37,6 +37,8 @@ class UtilityBill extends Model
         'usage_history',
         'budget_alert_threshold',
         'notes',
+        'source',
+        'created_by_agent_token_id',
     ];
 
     protected function casts(): array

--- a/app/Models/Warranty.php
+++ b/app/Models/Warranty.php
@@ -33,6 +33,8 @@ class Warranty extends Model
         'transfer_history',
         'maintenance_reminders',
         'notes',
+        'source',
+        'created_by_agent_token_id',
     ];
 
     protected function casts(): array

--- a/app/Services/Agents/IdempotencyKey.php
+++ b/app/Services/Agents/IdempotencyKey.php
@@ -23,6 +23,13 @@ class IdempotencyKey
             'expenses.create' => $this->expensesCreate($tenantId, $payload),
             'expenses.bulkImport' => $this->expensesBulkImport($tenantId, $payload),
             'expenses.categorize' => $this->expensesCategorize($tenantId, $payload),
+            'subscriptions.create' => $this->subscriptionsCreate($tenantId, $payload),
+            'contracts.create' => $this->contractsCreate($tenantId, $payload),
+            'warranties.create' => $this->warrantiesCreate($tenantId, $payload),
+            'iou.create' => $this->iouCreate($tenantId, $payload),
+            'utilityBills.create' => $this->utilityBillsCreate($tenantId, $payload),
+            'jobs.updateStatus' => $this->jobsUpdateStatus($tenantId, $payload),
+            'jobs.addInterview' => $this->jobsAddInterview($tenantId, $payload),
             default => throw new InvalidArgumentException("No idempotency-key generator registered for tool [{$tool}]."),
         };
 
@@ -73,6 +80,101 @@ class IdempotencyKey
         $subcategory = $this->normalize((string) ($p['subcategory'] ?? ''));
 
         return "expenses.categorize|{$tenantId}|{$expenseId}|{$category}|{$subcategory}";
+    }
+
+    /**
+     * @param  array<string, mixed>  $p
+     */
+    private function subscriptionsCreate(int $tenantId, array $p): string
+    {
+        $service = $this->normalize((string) ($p['service_name'] ?? ''));
+        $currency = strtoupper((string) ($p['currency'] ?? ''));
+        $cycle = $this->normalize((string) ($p['billing_cycle'] ?? ''));
+        $sourceEmail = (string) ($p['source_email_id'] ?? '');
+
+        return "subscriptions.create|{$tenantId}|{$service}|{$currency}|{$cycle}|{$sourceEmail}";
+    }
+
+    /**
+     * @param  array<string, mixed>  $p
+     */
+    private function contractsCreate(int $tenantId, array $p): string
+    {
+        $title = $this->normalize((string) ($p['title'] ?? ''));
+        $counterparty = $this->normalize((string) ($p['counterparty'] ?? ''));
+        $start = (string) ($p['start_date'] ?? '');
+        $sourceEmail = (string) ($p['source_email_id'] ?? '');
+
+        return "contracts.create|{$tenantId}|{$title}|{$counterparty}|{$start}|{$sourceEmail}";
+    }
+
+    /**
+     * @param  array<string, mixed>  $p
+     */
+    private function warrantiesCreate(int $tenantId, array $p): string
+    {
+        $product = $this->normalize((string) ($p['product_name'] ?? ''));
+        $serial = $this->normalize((string) ($p['serial_number'] ?? ''));
+        $purchase = (string) ($p['purchase_date'] ?? '');
+        $sourceEmail = (string) ($p['source_email_id'] ?? '');
+
+        return "warranties.create|{$tenantId}|{$product}|{$serial}|{$purchase}|{$sourceEmail}";
+    }
+
+    /**
+     * @param  array<string, mixed>  $p
+     */
+    private function iouCreate(int $tenantId, array $p): string
+    {
+        $direction = $this->normalize((string) ($p['type'] ?? ''));
+        $person = $this->normalize((string) ($p['person_name'] ?? ''));
+        $amount = $this->amountCents($p['amount'] ?? 0);
+        $currency = strtoupper((string) ($p['currency'] ?? ''));
+        $date = (string) ($p['transaction_date'] ?? '');
+        $sourceEmail = (string) ($p['source_email_id'] ?? '');
+
+        return "iou.create|{$tenantId}|{$direction}|{$person}|{$amount}|{$currency}|{$date}|{$sourceEmail}";
+    }
+
+    /**
+     * @param  array<string, mixed>  $p
+     */
+    private function utilityBillsCreate(int $tenantId, array $p): string
+    {
+        $type = $this->normalize((string) ($p['utility_type'] ?? ''));
+        $provider = $this->normalize((string) ($p['service_provider'] ?? ''));
+        $amount = $this->amountCents($p['bill_amount'] ?? 0);
+        $currency = strtoupper((string) ($p['currency'] ?? ''));
+        $due = (string) ($p['due_date'] ?? '');
+        $period = (string) ($p['bill_period_end'] ?? '');
+        $sourceEmail = (string) ($p['source_email_id'] ?? '');
+
+        return "utilityBills.create|{$tenantId}|{$type}|{$provider}|{$amount}|{$currency}|{$due}|{$period}|{$sourceEmail}";
+    }
+
+    /**
+     * @param  array<string, mixed>  $p
+     */
+    private function jobsUpdateStatus(int $tenantId, array $p): string
+    {
+        $jobId = (int) ($p['job_application_id'] ?? 0);
+        $status = $this->normalize((string) ($p['status'] ?? ''));
+        $sourceEmail = (string) ($p['source_email_id'] ?? '');
+
+        return "jobs.updateStatus|{$tenantId}|{$jobId}|{$status}|{$sourceEmail}";
+    }
+
+    /**
+     * @param  array<string, mixed>  $p
+     */
+    private function jobsAddInterview(int $tenantId, array $p): string
+    {
+        $jobId = (int) ($p['job_application_id'] ?? 0);
+        $scheduledAt = (string) ($p['scheduled_at'] ?? '');
+        $type = $this->normalize((string) ($p['interview_type'] ?? ''));
+        $sourceEmail = (string) ($p['source_email_id'] ?? '');
+
+        return "jobs.addInterview|{$tenantId}|{$jobId}|{$scheduledAt}|{$type}|{$sourceEmail}";
     }
 
     private function normalize(string $value): string

--- a/app/Services/Agents/PendingActionApplier.php
+++ b/app/Services/Agents/PendingActionApplier.php
@@ -4,12 +4,30 @@ declare(strict_types=1);
 
 namespace App\Services\Agents;
 
+use App\Http\Requests\StoreContractRequest;
 use App\Http\Requests\StoreExpenseRequest;
+use App\Http\Requests\StoreIouRequest;
+use App\Http\Requests\StoreJobApplicationRequest;
+use App\Http\Requests\StoreSubscriptionRequest;
+use App\Http\Requests\StoreUtilityBillRequest;
+use App\Http\Requests\StoreWarrantyRequest;
 use App\Models\AgentToken;
+use App\Models\Contract;
 use App\Models\Expense;
+use App\Models\Iou;
+use App\Models\JobApplication;
 use App\Models\PendingAction;
+use App\Models\Subscription;
 use App\Models\User;
+use App\Models\UtilityBill;
+use App\Models\Warranty;
+use App\Services\Contracts\ContractService;
 use App\Services\Expenses\ExpenseService;
+use App\Services\Iou\IouService;
+use App\Services\Jobs\JobApplicationService;
+use App\Services\Subscriptions\SubscriptionService;
+use App\Services\UtilityBills\UtilityBillService;
+use App\Services\Warranties\WarrantyService;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\ValidationException;
@@ -25,6 +43,12 @@ class PendingActionApplier
 {
     public function __construct(
         protected ExpenseService $expenses,
+        protected SubscriptionService $subscriptions,
+        protected ContractService $contracts,
+        protected WarrantyService $warranties,
+        protected IouService $ious,
+        protected UtilityBillService $bills,
+        protected JobApplicationService $jobs,
         protected IdempotencyKey $keys,
     ) {}
 
@@ -209,8 +233,64 @@ class PendingActionApplier
             'expenses.create' => $this->validateExpenseCreate($action->payload),
             'expenses.bulkImport' => $this->validateExpenseBulkImport($action->payload),
             'expenses.categorize' => $this->validateExpenseCategorize($action->payload),
+            'subscriptions.create' => $this->validateWithFormRequest(StoreSubscriptionRequest::class, $action->payload),
+            'contracts.create' => $this->validateWithFormRequest(StoreContractRequest::class, $action->payload),
+            'warranties.create' => $this->validateWithFormRequest(StoreWarrantyRequest::class, $action->payload),
+            'iou.create' => $this->validateWithFormRequest(StoreIouRequest::class, $action->payload),
+            'utilityBills.create' => $this->validateWithFormRequest(StoreUtilityBillRequest::class, $action->payload),
+            'jobs.updateStatus' => $this->validateJobsUpdateStatus($action->payload),
+            'jobs.addInterview' => $this->validateJobsAddInterview($action->payload),
             default => throw new RuntimeException("No validator registered for tool [{$action->tool}]."),
         };
+    }
+
+    /**
+     * @param  class-string<\Illuminate\Foundation\Http\FormRequest>  $formRequestClass
+     * @param  array<string, mixed>  $payload
+     */
+    private function validateWithFormRequest(string $formRequestClass, array $payload): void
+    {
+        $rules = (new $formRequestClass)->rules();
+        $validator = Validator::make($payload, $rules);
+
+        if ($validator->fails()) {
+            throw new ValidationException($validator);
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function validateJobsUpdateStatus(array $payload): void
+    {
+        $validator = Validator::make($payload, [
+            'job_application_id' => 'required|integer|exists:job_applications,id',
+            'status' => 'required|string|max:64',
+            'next_action_at' => 'nullable|date',
+        ]);
+
+        if ($validator->fails()) {
+            throw new ValidationException($validator);
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function validateJobsAddInterview(array $payload): void
+    {
+        $validator = Validator::make($payload, [
+            'job_application_id' => 'required|integer|exists:job_applications,id',
+            'scheduled_at' => 'required|date',
+            'interview_type' => 'nullable|string|max:64',
+            'interviewer_name' => 'nullable|string|max:255',
+            'location' => 'nullable|string|max:255',
+            'notes' => 'nullable|string',
+        ]);
+
+        if ($validator->fails()) {
+            throw new ValidationException($validator);
+        }
     }
 
     /**
@@ -278,8 +358,165 @@ class PendingActionApplier
             'expenses.create' => $this->executeExpenseCreate($action, $user, $attribution),
             'expenses.bulkImport' => $this->executeExpenseBulkImport($action, $user, $attribution),
             'expenses.categorize' => $this->executeExpenseCategorize($action),
+            'subscriptions.create' => $this->executeSubscriptionCreate($action, $user, $attribution),
+            'contracts.create' => $this->executeContractCreate($action, $user, $attribution),
+            'warranties.create' => $this->executeWarrantyCreate($action, $user, $attribution),
+            'iou.create' => $this->executeIouCreate($action, $user, $attribution),
+            'utilityBills.create' => $this->executeUtilityBillCreate($action, $user, $attribution),
+            'jobs.updateStatus' => $this->executeJobsUpdateStatus($action),
+            'jobs.addInterview' => $this->executeJobsAddInterview($action),
             default => throw new RuntimeException("No executor registered for tool [{$action->tool}]."),
         };
+    }
+
+    /**
+     * @param  array<string, mixed>  $attribution
+     * @return array<string, mixed>
+     */
+    private function executeSubscriptionCreate(PendingAction $action, User $user, array $attribution): array
+    {
+        $sub = $this->subscriptions->create($user, $action->payload, $attribution);
+
+        $action->forceFill([
+            'target_type' => Subscription::class,
+            'target_id' => $sub->id,
+        ])->save();
+
+        return [
+            'before' => null,
+            'after' => $sub->only(['id', 'service_name', 'cost', 'currency', 'billing_cycle', 'next_billing_date', 'status']),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $attribution
+     * @return array<string, mixed>
+     */
+    private function executeContractCreate(PendingAction $action, User $user, array $attribution): array
+    {
+        $contract = $this->contracts->create($user, $action->payload, $attribution);
+
+        $action->forceFill([
+            'target_type' => Contract::class,
+            'target_id' => $contract->id,
+        ])->save();
+
+        return [
+            'before' => null,
+            'after' => $contract->only(['id', 'title', 'counterparty', 'contract_type', 'start_date', 'end_date', 'status']),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $attribution
+     * @return array<string, mixed>
+     */
+    private function executeWarrantyCreate(PendingAction $action, User $user, array $attribution): array
+    {
+        $warranty = $this->warranties->create($user, $action->payload, $attribution);
+
+        $action->forceFill([
+            'target_type' => Warranty::class,
+            'target_id' => $warranty->id,
+        ])->save();
+
+        return [
+            'before' => null,
+            'after' => $warranty->only(['id', 'product_name', 'brand', 'purchase_date', 'warranty_expiration_date', 'current_status']),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $attribution
+     * @return array<string, mixed>
+     */
+    private function executeIouCreate(PendingAction $action, User $user, array $attribution): array
+    {
+        $iou = $this->ious->create($user, $action->payload, $attribution);
+
+        $action->forceFill([
+            'target_type' => Iou::class,
+            'target_id' => $iou->id,
+        ])->save();
+
+        return [
+            'before' => null,
+            'after' => $iou->only(['id', 'type', 'person_name', 'amount', 'currency', 'transaction_date', 'due_date', 'status']),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $attribution
+     * @return array<string, mixed>
+     */
+    private function executeUtilityBillCreate(PendingAction $action, User $user, array $attribution): array
+    {
+        $bill = $this->bills->create($user, $action->payload, $attribution);
+
+        $action->forceFill([
+            'target_type' => UtilityBill::class,
+            'target_id' => $bill->id,
+        ])->save();
+
+        return [
+            'before' => null,
+            'after' => $bill->only(['id', 'utility_type', 'service_provider', 'bill_amount', 'currency', 'due_date', 'payment_status']),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function executeJobsUpdateStatus(PendingAction $action): array
+    {
+        $application = JobApplication::query()->findOrFail((int) $action->payload['job_application_id']);
+        $before = $application->only(['id', 'status', 'next_action_at']);
+
+        $nextAt = isset($action->payload['next_action_at'])
+            ? new \DateTimeImmutable((string) $action->payload['next_action_at'])
+            : null;
+
+        $this->jobs->updateStatus($application, (string) $action->payload['status'], $nextAt);
+
+        $action->forceFill([
+            'target_type' => JobApplication::class,
+            'target_id' => $application->id,
+        ])->save();
+
+        return [
+            'before' => $before,
+            'after' => $application->refresh()->only(['id', 'status', 'next_action_at']),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function executeJobsAddInterview(PendingAction $action): array
+    {
+        $application = JobApplication::query()->findOrFail((int) $action->payload['job_application_id']);
+
+        $interview = $this->jobs->addInterview($application, [
+            'scheduled_at' => $action->payload['scheduled_at'],
+            'interview_type' => $action->payload['interview_type'] ?? null,
+            'interviewer_name' => $action->payload['interviewer_name'] ?? null,
+            'location' => $action->payload['location'] ?? null,
+            'notes' => $action->payload['notes'] ?? null,
+        ]);
+
+        $action->forceFill([
+            'target_type' => JobApplication::class,
+            'target_id' => $application->id,
+        ])->save();
+
+        return [
+            'before' => null,
+            'after' => [
+                'job_application_id' => $application->id,
+                'interview_id' => $interview->id,
+                'scheduled_at' => $interview->scheduled_at?->toIso8601String(),
+            ],
+        ];
     }
 
     /**
@@ -353,9 +590,88 @@ class PendingActionApplier
                 $this->revertExpenseCategorize($action);
 
                 return;
+            case 'subscriptions.create':
+                $this->revertCreateById($action, Subscription::class);
+
+                return;
+            case 'contracts.create':
+                $this->revertCreateById($action, Contract::class);
+
+                return;
+            case 'warranties.create':
+                $this->revertCreateById($action, Warranty::class);
+
+                return;
+            case 'iou.create':
+                $this->revertCreateById($action, Iou::class);
+
+                return;
+            case 'utilityBills.create':
+                $this->revertCreateById($action, UtilityBill::class);
+
+                return;
+            case 'jobs.updateStatus':
+                $this->revertJobsUpdateStatus($action);
+
+                return;
+            case 'jobs.addInterview':
+                $this->revertJobsAddInterview($action);
+
+                return;
         }
 
         throw new RuntimeException("No revert executor for tool [{$action->tool}].");
+    }
+
+    /**
+     * @param  class-string<\Illuminate\Database\Eloquent\Model>  $modelClass
+     */
+    private function revertCreateById(PendingAction $action, string $modelClass): void
+    {
+        $diff = $action->applied_diff ?? [];
+        $after = $diff['after'] ?? null;
+
+        if (! is_array($after) || ! isset($after['id'])) {
+            return;
+        }
+
+        $modelClass::query()->whereKey((int) $after['id'])->delete();
+    }
+
+    private function revertJobsUpdateStatus(PendingAction $action): void
+    {
+        $diff = $action->applied_diff ?? [];
+        $before = $diff['before'] ?? null;
+
+        if (! is_array($before) || ! isset($before['id'])) {
+            return;
+        }
+
+        $application = JobApplication::query()->find((int) $before['id']);
+
+        if ($application === null) {
+            return;
+        }
+
+        $payload = ['status' => $before['status']];
+
+        if (array_key_exists('next_action_at', $before)) {
+            $payload['next_action_at'] = $before['next_action_at'];
+        }
+
+        $this->jobs->update($application, $payload);
+    }
+
+    private function revertJobsAddInterview(PendingAction $action): void
+    {
+        $diff = $action->applied_diff ?? [];
+        $after = $diff['after'] ?? null;
+
+        if (! is_array($after) || ! isset($after['interview_id'])) {
+            return;
+        }
+
+        \App\Models\JobApplicationInterview::query()->whereKey((int) $after['interview_id'])->delete();
     }
 
     private function revertExpenseCreate(PendingAction $action): void
@@ -450,6 +766,66 @@ class PendingActionApplier
                     'Categorize expense #%d as %s',
                     (int) ($payload['expense_id'] ?? 0),
                     (string) ($payload['category'] ?? ''),
+                ),
+            ],
+            'subscriptions.create' => [
+                'summary' => sprintf(
+                    'Subscribe to %s — %s %s / %s',
+                    (string) ($payload['service_name'] ?? '—'),
+                    number_format((float) ($payload['cost'] ?? 0), 2),
+                    (string) ($payload['currency'] ?? ''),
+                    (string) ($payload['billing_cycle'] ?? ''),
+                ),
+            ],
+            'contracts.create' => [
+                'summary' => sprintf(
+                    '%s with %s (%s → %s)',
+                    (string) ($payload['title'] ?? '—'),
+                    (string) ($payload['counterparty'] ?? '—'),
+                    (string) ($payload['start_date'] ?? '?'),
+                    (string) ($payload['end_date'] ?? '?'),
+                ),
+            ],
+            'warranties.create' => [
+                'summary' => sprintf(
+                    '%s %s (purchased %s, warranty until %s)',
+                    (string) ($payload['brand'] ?? ''),
+                    (string) ($payload['product_name'] ?? '—'),
+                    (string) ($payload['purchase_date'] ?? '?'),
+                    (string) ($payload['warranty_expiration_date'] ?? '?'),
+                ),
+            ],
+            'iou.create' => [
+                'summary' => sprintf(
+                    '%s %s %s %s',
+                    ($payload['type'] ?? '') === 'owe' ? 'I owe' : 'Owed by',
+                    (string) ($payload['person_name'] ?? '—'),
+                    number_format((float) ($payload['amount'] ?? 0), 2),
+                    (string) ($payload['currency'] ?? ''),
+                ),
+            ],
+            'utilityBills.create' => [
+                'summary' => sprintf(
+                    '%s %s — %s %s due %s',
+                    (string) ($payload['service_provider'] ?? '—'),
+                    (string) ($payload['utility_type'] ?? ''),
+                    number_format((float) ($payload['bill_amount'] ?? 0), 2),
+                    (string) ($payload['currency'] ?? ''),
+                    (string) ($payload['due_date'] ?? ''),
+                ),
+            ],
+            'jobs.updateStatus' => [
+                'summary' => sprintf(
+                    'Set application #%d → %s',
+                    (int) ($payload['job_application_id'] ?? 0),
+                    (string) ($payload['status'] ?? ''),
+                ),
+            ],
+            'jobs.addInterview' => [
+                'summary' => sprintf(
+                    'Schedule interview for #%d at %s',
+                    (int) ($payload['job_application_id'] ?? 0),
+                    (string) ($payload['scheduled_at'] ?? ''),
                 ),
             ],
             default => [],

--- a/app/Services/Contracts/ContractService.php
+++ b/app/Services/Contracts/ContractService.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Contracts;
+
+use App\Models\Contract;
+use App\Models\User;
+
+class ContractService
+{
+    /**
+     * @param  array<string, mixed>  $data
+     * @param  array<string, mixed>  $attribution
+     */
+    public function create(User $user, array $data, array $attribution = []): Contract
+    {
+        return Contract::create([
+            'user_id' => $user->id,
+            ...$data,
+            'source' => $attribution['source'] ?? 'user',
+            'created_by_agent_token_id' => $attribution['agent_token_id'] ?? null,
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public function update(Contract $contract, array $data): Contract
+    {
+        $contract->update($data);
+
+        return $contract->refresh();
+    }
+
+    public function delete(Contract $contract): bool
+    {
+        return (bool) $contract->delete();
+    }
+
+    public function terminate(Contract $contract): Contract
+    {
+        return $this->update($contract, [
+            'status' => 'terminated',
+            'end_date' => now(),
+        ]);
+    }
+
+    /**
+     * Renew a contract: stamps a new end_date and appends to renewal_history.
+     */
+    public function renew(Contract $contract, \DateTimeInterface $newEndDate): Contract
+    {
+        $history = $contract->renewal_history ?? [];
+        $history[] = [
+            'previous_end_date' => $contract->end_date?->toDateString(),
+            'new_end_date' => $newEndDate->format('Y-m-d'),
+            'renewed_at' => now()->toDateTimeString(),
+        ];
+
+        return $this->update($contract, [
+            'renewal_history' => $history,
+            'end_date' => $newEndDate->format('Y-m-d'),
+            'status' => 'active',
+        ]);
+    }
+}

--- a/app/Services/Iou/IouService.php
+++ b/app/Services/Iou/IouService.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Iou;
+
+use App\Models\Iou;
+use App\Models\User;
+
+class IouService
+{
+    /**
+     * @param  array<string, mixed>  $data
+     * @param  array<string, mixed>  $attribution
+     */
+    public function create(User $user, array $data, array $attribution = []): Iou
+    {
+        return Iou::create([
+            'user_id' => $user->id,
+            ...$data,
+            'source' => $attribution['source'] ?? 'user',
+            'created_by_agent_token_id' => $attribution['agent_token_id'] ?? null,
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public function update(Iou $iou, array $data): Iou
+    {
+        $iou->update($data);
+
+        return $iou->refresh();
+    }
+
+    public function delete(Iou $iou): bool
+    {
+        return (bool) $iou->delete();
+    }
+
+    /**
+     * Record a partial or full payment toward this IOU. Caller passes the
+     * absolute new amount_paid (i.e. cumulative) so the same call is
+     * idempotent under retries.
+     */
+    public function recordPayment(Iou $iou, float $amountPaid, ?string $paymentMethod = null): Iou
+    {
+        $payload = ['amount_paid' => $amountPaid];
+
+        if ($paymentMethod !== null) {
+            $payload['payment_method'] = $paymentMethod;
+        }
+
+        if ($amountPaid >= (float) $iou->amount) {
+            $payload['status'] = 'paid';
+        } else {
+            $payload['status'] = 'partially_paid';
+        }
+
+        return $this->update($iou, $payload);
+    }
+
+    public function markPaid(Iou $iou): Iou
+    {
+        return $this->update($iou, [
+            'status' => 'paid',
+            'amount_paid' => $iou->amount,
+        ]);
+    }
+
+    public function cancel(Iou $iou): Iou
+    {
+        return $this->update($iou, ['status' => 'cancelled']);
+    }
+}

--- a/app/Services/Jobs/JobApplicationService.php
+++ b/app/Services/Jobs/JobApplicationService.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Jobs;
+
+use App\Models\JobApplication;
+use App\Models\JobApplicationInterview;
+use App\Models\User;
+
+class JobApplicationService
+{
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public function create(User $user, array $data): JobApplication
+    {
+        return JobApplication::create([
+            'user_id' => $user->id,
+            ...$data,
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public function update(JobApplication $application, array $data): JobApplication
+    {
+        $application->update($data);
+
+        return $application->refresh();
+    }
+
+    public function delete(JobApplication $application): bool
+    {
+        return (bool) $application->delete();
+    }
+
+    public function archive(JobApplication $application): JobApplication
+    {
+        return $this->update($application, ['archived_at' => now()]);
+    }
+
+    public function unarchive(JobApplication $application): JobApplication
+    {
+        return $this->update($application, ['archived_at' => null]);
+    }
+
+    /**
+     * Update the application's pipeline status (and optionally a follow-up date).
+     * Status values are validated upstream by the FormRequest / MCP tool.
+     */
+    public function updateStatus(JobApplication $application, string $status, ?\DateTimeInterface $nextActionAt = null): JobApplication
+    {
+        $payload = ['status' => $status];
+
+        if ($nextActionAt !== null) {
+            $payload['next_action_at'] = $nextActionAt;
+        }
+
+        return $this->update($application, $payload);
+    }
+
+    /**
+     * Add a scheduled interview to an application.
+     *
+     * @param  array<string, mixed>  $data
+     */
+    public function addInterview(JobApplication $application, array $data): JobApplicationInterview
+    {
+        return $application->interviews()->create($data);
+    }
+}

--- a/app/Services/Subscriptions/SubscriptionService.php
+++ b/app/Services/Subscriptions/SubscriptionService.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Subscriptions;
+
+use App\Models\Subscription;
+use App\Models\User;
+
+class SubscriptionService
+{
+    /**
+     * @param  array<string, mixed>  $data
+     * @param  array<string, mixed>  $attribution ['source' => 'agent'|'user', 'agent_token_id' => ?int]
+     */
+    public function create(User $user, array $data, array $attribution = []): Subscription
+    {
+        return Subscription::create([
+            'user_id' => $user->id,
+            ...$data,
+            'source' => $attribution['source'] ?? 'user',
+            'created_by_agent_token_id' => $attribution['agent_token_id'] ?? null,
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public function update(Subscription $subscription, array $data): Subscription
+    {
+        $subscription->update($data);
+
+        return $subscription->refresh();
+    }
+
+    public function delete(Subscription $subscription): bool
+    {
+        return (bool) $subscription->delete();
+    }
+
+    public function cancel(Subscription $subscription): Subscription
+    {
+        return $this->update($subscription, [
+            'status' => 'cancelled',
+            'cancellation_date' => now(),
+        ]);
+    }
+
+    public function pause(Subscription $subscription): Subscription
+    {
+        return $this->update($subscription, ['status' => 'paused']);
+    }
+
+    public function resume(Subscription $subscription): Subscription
+    {
+        return $this->update($subscription, ['status' => 'active']);
+    }
+}

--- a/app/Services/UtilityBills/UtilityBillService.php
+++ b/app/Services/UtilityBills/UtilityBillService.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\UtilityBills;
+
+use App\Models\User;
+use App\Models\UtilityBill;
+
+class UtilityBillService
+{
+    /**
+     * @param  array<string, mixed>  $data
+     * @param  array<string, mixed>  $attribution
+     */
+    public function create(User $user, array $data, array $attribution = []): UtilityBill
+    {
+        return UtilityBill::create([
+            'user_id' => $user->id,
+            ...$data,
+            'source' => $attribution['source'] ?? 'user',
+            'created_by_agent_token_id' => $attribution['agent_token_id'] ?? null,
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public function update(UtilityBill $bill, array $data): UtilityBill
+    {
+        $bill->update($data);
+
+        return $bill->refresh();
+    }
+
+    public function delete(UtilityBill $bill): bool
+    {
+        return (bool) $bill->delete();
+    }
+
+    public function markPaid(UtilityBill $bill, ?\DateTimeInterface $paymentDate = null): UtilityBill
+    {
+        return $this->update($bill, [
+            'payment_status' => 'paid',
+            'payment_date' => ($paymentDate ?? now())->format('Y-m-d'),
+        ]);
+    }
+}

--- a/app/Services/Warranties/WarrantyService.php
+++ b/app/Services/Warranties/WarrantyService.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Warranties;
+
+use App\Models\User;
+use App\Models\Warranty;
+
+class WarrantyService
+{
+    /**
+     * @param  array<string, mixed>  $data
+     * @param  array<string, mixed>  $attribution
+     */
+    public function create(User $user, array $data, array $attribution = []): Warranty
+    {
+        return Warranty::create([
+            'user_id' => $user->id,
+            ...$data,
+            'source' => $attribution['source'] ?? 'user',
+            'created_by_agent_token_id' => $attribution['agent_token_id'] ?? null,
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public function update(Warranty $warranty, array $data): Warranty
+    {
+        $warranty->update($data);
+
+        return $warranty->refresh();
+    }
+
+    public function delete(Warranty $warranty): bool
+    {
+        return (bool) $warranty->delete();
+    }
+
+    /**
+     * @param  array<string, mixed>  $claim
+     */
+    public function recordClaim(Warranty $warranty, array $claim): Warranty
+    {
+        $history = $warranty->claim_history ?? [];
+        $history[] = array_merge(['filed_at' => now()->toDateTimeString()], $claim);
+
+        return $this->update($warranty, [
+            'claim_history' => $history,
+            'current_status' => 'claim_pending',
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $transfer
+     */
+    public function transfer(Warranty $warranty, array $transfer): Warranty
+    {
+        $history = $warranty->transfer_history ?? [];
+        $history[] = array_merge(['transferred_at' => now()->toDateTimeString()], $transfer);
+
+        return $this->update($warranty, [
+            'transfer_history' => $history,
+            'current_status' => 'transferred',
+        ]);
+    }
+}

--- a/database/migrations/2026_05_07_010052_add_agent_attribution_to_phase4_modules.php
+++ b/database/migrations/2026_05_07_010052_add_agent_attribution_to_phase4_modules.php
@@ -1,0 +1,67 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Phase 4 extends agent attribution to the modules the email-ingestion agent
+     * proposes writes against. Same shape as the columns already on `expenses`
+     * (Phase 2 migration).
+     */
+    /**
+     * Note: job_applications already has a `source` column (job-board source —
+     * LinkedIn, Indeed, etc.) that means something different. We trace agent
+     * attribution for status updates / interview adds via the PendingAction
+     * row itself rather than a column on the JobApplication.
+     */
+    private array $tables = [
+        'subscriptions',
+        'contracts',
+        'warranties',
+        'ious',
+        'utility_bills',
+    ];
+
+    public function up(): void
+    {
+        foreach ($this->tables as $name) {
+            if (! Schema::hasTable($name)) {
+                continue;
+            }
+
+            Schema::table($name, function (Blueprint $table) use ($name): void {
+                if (! Schema::hasColumn($name, 'source')) {
+                    $table->string('source', 16)->default('user');
+                }
+
+                if (! Schema::hasColumn($name, 'created_by_agent_token_id')) {
+                    $table->foreignId('created_by_agent_token_id')->nullable()
+                        ->constrained('agent_tokens')->nullOnDelete();
+                }
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        foreach ($this->tables as $name) {
+            if (! Schema::hasTable($name)) {
+                continue;
+            }
+
+            Schema::table($name, function (Blueprint $table) use ($name): void {
+                if (Schema::hasColumn($name, 'created_by_agent_token_id')) {
+                    $table->dropForeign(['created_by_agent_token_id']);
+                    $table->dropColumn('created_by_agent_token_id');
+                }
+
+                if (Schema::hasColumn($name, 'source')) {
+                    $table->dropColumn('source');
+                }
+            });
+        }
+    }
+};

--- a/docs/agents/IMPLEMENTATION_PLAN.md
+++ b/docs/agents/IMPLEMENTATION_PLAN.md
@@ -4,8 +4,10 @@
 >
 > **Progress:**
 > - Phase 0 — plan committed (this file).
-> - Phase 1 — read-only MCP server: PR #148 (`claude/managed-agents-phase-1`).
-> - Phase 2 — Pending Actions queue + Expenses writes: in PR.
+> - Phase 1 — read-only MCP server: PR #148, **merged**.
+> - Phase 2 — Pending Actions queue + Expenses writes: PR #150, **merged**.
+> - Phase 3 — email-ingestion agent + ManagedAgentsClient + `agents:run`: PR #154 (in review). See `docs/agents/AGENTS.md`.
+> - Phase 4 — email-ingestion expansion (Subscriptions, Contracts, Warranties, IOU, Utility Bills, Job status updates + interviews): in PR.
 
 ## Context
 

--- a/docs/agents/MCP_TOOLS.md
+++ b/docs/agents/MCP_TOOLS.md
@@ -247,6 +247,113 @@ Returns: `{ pending_action_id, status, idempotency_key, item_count, auto_applied
 
 Returns: `{ pending_action_id, status, idempotency_key, auto_applied }`.
 
+## Write tools (Phase 4)
+
+Phase 4 widens the email-ingestion agent's reach. Each tool follows the same shape as the Phase 2 tools: validate via the controller's FormRequest, call the module's service, record agent attribution on the new row, and queue the result for human approval. Idempotency keys are deterministic per natural fields and include `source_email_id` where available.
+
+### `subscriptions.create`
+
+| field | type | description |
+|---|---|---|
+| `service_name` | string | Required. |
+| `cost` | number | Required. |
+| `currency` | string | Defaults to MKD. |
+| `billing_cycle` | string | Required (`"monthly"`, `"yearly"`, `"weekly"`, `"custom"`). |
+| `billing_cycle_days` | int | When `billing_cycle = "custom"`. |
+| `start_date` | date | Required. |
+| `next_billing_date` | date | Optional. |
+| `category` | string | Optional. |
+| `payment_method` | string | Optional. |
+| `auto_renewal` | bool | Optional. |
+| `source_email_id` | string | Optional, used for idempotency disambiguation. |
+
+Idempotency key: `sha256("subscriptions.create|<tenant>|<service_normalized>|<currency>|<cycle>|<source_email_id>")`.
+
+### `contracts.create`
+
+| field | type | description |
+|---|---|---|
+| `title` | string | Required. |
+| `counterparty` | string | Required. |
+| `contract_type` | string | Optional. |
+| `start_date` | date | Required. |
+| `end_date` | date | Optional. |
+| `notice_period_days` | int | Optional. |
+| `auto_renewal` | bool | Optional. |
+| `contract_value` | number | Optional. |
+| `payment_terms` | string | Optional. |
+| `notes` | string | Optional. |
+| `source_email_id` | string | Optional, used for idempotency. |
+
+### `warranties.create`
+
+| field | type | description |
+|---|---|---|
+| `product_name` | string | Required. |
+| `brand` | string | Optional. |
+| `model` | string | Optional. |
+| `serial_number` | string | Optional, included in idempotency key when present. |
+| `purchase_date` | date | Required. |
+| `purchase_price` | number | Optional. |
+| `retailer` | string | Optional. |
+| `warranty_duration_months` | int | Optional. |
+| `warranty_expiration_date` | date | Required. |
+| `warranty_type` | string | Optional. |
+| `warranty_terms` | string | Optional. |
+| `source_email_id` | string | Optional. |
+
+### `iou.create`
+
+| field | type | description |
+|---|---|---|
+| `type` | string | `"owe"` or `"owed"`. Required. |
+| `person_name` | string | Required. |
+| `amount` | number | Required. |
+| `currency` | string | Defaults to MKD. |
+| `transaction_date` | date | Required. |
+| `due_date` | date | Optional. |
+| `description` | string | Required. |
+| `category` | string | Optional. |
+| `source_email_id` | string | Optional. |
+
+### `utilityBills.create`
+
+| field | type | description |
+|---|---|---|
+| `utility_type` | string | Required. |
+| `service_provider` | string | Required. |
+| `account_number` | string | Optional. |
+| `service_address` | string | Optional. |
+| `bill_amount` | number | Required. |
+| `currency` | string | Defaults to MKD. |
+| `usage_amount` | number | Optional. |
+| `usage_unit` | string | Optional. |
+| `bill_period_start` | date | Optional. |
+| `bill_period_end` | date | Optional, included in idempotency. |
+| `due_date` | date | Required. |
+| `source_email_id` | string | Optional. |
+
+### `jobs.updateStatus`
+
+| field | type | description |
+|---|---|---|
+| `job_application_id` | int | Required. Application must belong to the authenticated tenant. |
+| `status` | string | Required. New pipeline status. |
+| `next_action_at` | datetime | Optional. ISO 8601. |
+| `source_email_id` | string | Optional. |
+
+### `jobs.addInterview`
+
+| field | type | description |
+|---|---|---|
+| `job_application_id` | int | Required. |
+| `scheduled_at` | datetime | Required. ISO 8601. |
+| `interview_type` | string | Optional. |
+| `interviewer_name` | string | Optional. |
+| `location` | string | Optional. |
+| `notes` | string | Optional. |
+| `source_email_id` | string | Optional. |
+
 ## Approval surface
 
 Reviewers act through `/dashboard/pending-actions`:

--- a/tests/Feature/Mcp/Phase4WriteToolsTest.php
+++ b/tests/Feature/Mcp/Phase4WriteToolsTest.php
@@ -1,0 +1,201 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Mcp;
+
+use App\Mcp\LifeOsServer;
+use App\Mcp\Tools\Bills\CreateUtilityBill;
+use App\Mcp\Tools\Contracts\CreateContract;
+use App\Mcp\Tools\Iou\CreateIou;
+use App\Mcp\Tools\Jobs\AddInterview;
+use App\Mcp\Tools\Jobs\UpdateJobStatus;
+use App\Mcp\Tools\Subscriptions\CreateSubscription;
+use App\Mcp\Tools\Warranties\CreateWarranty;
+use App\Models\AgentToken;
+use App\Models\Contract;
+use App\Models\Iou;
+use App\Models\JobApplication;
+use App\Models\PendingAction;
+use App\Models\Subscription;
+use App\Models\Tenant;
+use App\Models\User;
+use App\Models\UtilityBill;
+use App\Models\Warranty;
+use App\Services\Agents\PendingActionApplier;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\App;
+use Tests\TestCase;
+
+class Phase4WriteToolsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+
+    private Tenant $tenant;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        ['user' => $this->user, 'tenant' => $this->tenant] = $this->setupTenantContext();
+        [$token] = AgentToken::issue($this->user, $this->tenant, 'phpunit', ['*']);
+        App::instance('agent.token', $token);
+    }
+
+    public function test_subscriptions_create_records_pending_action(): void
+    {
+        LifeOsServer::tool(CreateSubscription::class, [
+            'service_name' => 'Netflix',
+            'cost' => 9.99,
+            'currency' => 'EUR',
+            'billing_cycle' => 'monthly',
+            'start_date' => '2026-05-01',
+        ])->assertOk()->assertStructuredContent(function (array $content): bool {
+            $this->assertSame(PendingAction::STATUS_PENDING, $content['status']);
+
+            return true;
+        });
+
+        $this->assertSame(1, PendingAction::query()->where('tool', 'subscriptions.create')->count());
+        $this->assertSame(0, Subscription::query()->count());
+    }
+
+    public function test_apply_subscriptions_create_writes_with_agent_attribution(): void
+    {
+        LifeOsServer::tool(CreateSubscription::class, [
+            'service_name' => 'Netflix',
+            'cost' => 9.99,
+            'currency' => 'EUR',
+            'billing_cycle' => 'monthly',
+            'start_date' => '2026-05-01',
+        ]);
+
+        $action = PendingAction::query()->firstOrFail();
+        app(PendingActionApplier::class)->apply($action, $this->user);
+
+        $this->assertSame(1, Subscription::query()->count());
+        $sub = Subscription::query()->first();
+        $this->assertSame('agent', $sub->source);
+        $this->assertNotNull($sub->created_by_agent_token_id);
+    }
+
+    public function test_contracts_create_records_pending_action(): void
+    {
+        LifeOsServer::tool(CreateContract::class, [
+            'title' => 'Office Lease',
+            'counterparty' => 'Landlord Co',
+            'contract_type' => 'lease',
+            'start_date' => '2026-05-01',
+            'end_date' => '2027-05-01',
+        ])->assertOk();
+
+        $this->assertSame(1, PendingAction::query()->where('tool', 'contracts.create')->count());
+        $this->assertSame(0, Contract::query()->count());
+    }
+
+    public function test_warranties_create_idempotent_by_serial(): void
+    {
+        $args = [
+            'product_name' => 'Laptop',
+            'brand' => 'Apple',
+            'serial_number' => 'ABC123',
+            'purchase_date' => '2026-05-01',
+            'warranty_expiration_date' => '2027-05-01',
+        ];
+
+        LifeOsServer::tool(CreateWarranty::class, $args);
+        LifeOsServer::tool(CreateWarranty::class, $args);
+
+        $this->assertSame(1, PendingAction::query()->where('tool', 'warranties.create')->count());
+    }
+
+    public function test_iou_create_records_pending_action(): void
+    {
+        LifeOsServer::tool(CreateIou::class, [
+            'type' => 'owed',
+            'person_name' => 'Alex',
+            'amount' => 50,
+            'currency' => 'EUR',
+            'transaction_date' => '2026-05-01',
+            'description' => 'Dinner reimbursement',
+        ])->assertOk();
+
+        $this->assertSame(1, PendingAction::query()->where('tool', 'iou.create')->count());
+        $this->assertSame(0, Iou::query()->count());
+    }
+
+    public function test_utility_bills_create_records_pending_action(): void
+    {
+        LifeOsServer::tool(CreateUtilityBill::class, [
+            'utility_type' => 'electricity',
+            'service_provider' => 'EVN',
+            'bill_amount' => 100,
+            'currency' => 'EUR',
+            'due_date' => '2026-05-15',
+            'bill_period_end' => '2026-04-30',
+        ])->assertOk();
+
+        $this->assertSame(1, PendingAction::query()->where('tool', 'utilityBills.create')->count());
+        $this->assertSame(0, UtilityBill::query()->count());
+    }
+
+    public function test_jobs_update_status_requires_existing_application(): void
+    {
+        LifeOsServer::tool(UpdateJobStatus::class, [
+            'job_application_id' => 9999,
+            'status' => 'interviewing',
+        ])->assertHasErrors(['Job application [9999] not found in this tenant.']);
+    }
+
+    public function test_jobs_update_status_records_pending_action_for_local_application(): void
+    {
+        $app = JobApplication::factory()->create([
+            'company_name' => 'Acme',
+            'job_title' => 'Engineer',
+        ]);
+
+        LifeOsServer::tool(UpdateJobStatus::class, [
+            'job_application_id' => $app->id,
+            'status' => 'interviewing',
+        ])->assertOk();
+
+        $this->assertSame(1, PendingAction::query()->where('tool', 'jobs.updateStatus')->count());
+    }
+
+    public function test_jobs_add_interview_records_pending_action(): void
+    {
+        $app = JobApplication::factory()->create();
+
+        LifeOsServer::tool(AddInterview::class, [
+            'job_application_id' => $app->id,
+            'scheduled_at' => '2026-05-10T14:00:00Z',
+            'interview_type' => 'video',
+            'interviewer_name' => 'Jane Doe',
+        ])->assertOk();
+
+        $action = PendingAction::query()->firstOrFail();
+        $this->assertSame('jobs.addInterview', $action->tool);
+        $this->assertSame($app->id, (int) $action->payload['job_application_id']);
+    }
+
+    public function test_cross_tenant_categorize_target_invisible(): void
+    {
+        $other = User::factory()->create();
+        $otherTenant = Tenant::factory()->create(['owner_id' => $other->id]);
+        $other->forceFill(['current_tenant_id' => $otherTenant->id])->save();
+
+        $this->actingAs($other);
+        $foreignApp = JobApplication::factory()->create();
+
+        $this->actingAs($this->user);
+
+        LifeOsServer::tool(UpdateJobStatus::class, [
+            'job_application_id' => $foreignApp->id,
+            'status' => 'rejected',
+        ])->assertHasErrors([
+            "Job application [{$foreignApp->id}] not found in this tenant.",
+        ]);
+    }
+}

--- a/tests/Unit/Services/Agents/IdempotencyKeyPhase4Test.php
+++ b/tests/Unit/Services/Agents/IdempotencyKeyPhase4Test.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Agents;
+
+use App\Services\Agents\IdempotencyKey;
+use Tests\TestCase;
+
+class IdempotencyKeyPhase4Test extends TestCase
+{
+    private IdempotencyKey $keys;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->keys = new IdempotencyKey;
+    }
+
+    public function test_subscriptions_create_keys_collide_on_same_natural_fields(): void
+    {
+        $a = $this->keys->for('subscriptions.create', 1, [
+            'service_name' => 'Netflix',
+            'currency' => 'EUR',
+            'billing_cycle' => 'monthly',
+        ]);
+
+        $b = $this->keys->for('subscriptions.create', 1, [
+            'service_name' => ' netflix ',
+            'currency' => 'eur',
+            'billing_cycle' => 'MONTHLY',
+        ]);
+
+        $this->assertSame($a, $b);
+    }
+
+    public function test_contracts_create_keys_separate_by_counterparty_and_start(): void
+    {
+        $a = $this->keys->for('contracts.create', 1, [
+            'title' => 'Office Lease',
+            'counterparty' => 'Landlord A',
+            'start_date' => '2026-01-01',
+        ]);
+
+        $b = $this->keys->for('contracts.create', 1, [
+            'title' => 'Office Lease',
+            'counterparty' => 'Landlord B',
+            'start_date' => '2026-01-01',
+        ]);
+
+        $this->assertNotSame($a, $b);
+    }
+
+    public function test_warranties_create_keys_use_serial_when_present(): void
+    {
+        $a = $this->keys->for('warranties.create', 1, [
+            'product_name' => 'Laptop',
+            'serial_number' => 'ABC123',
+            'purchase_date' => '2026-05-01',
+        ]);
+
+        $b = $this->keys->for('warranties.create', 1, [
+            'product_name' => 'Laptop',
+            'serial_number' => 'XYZ987',
+            'purchase_date' => '2026-05-01',
+        ]);
+
+        $this->assertNotSame($a, $b, 'Different serials must produce different keys.');
+    }
+
+    public function test_iou_create_distinguishes_direction(): void
+    {
+        $owe = $this->keys->for('iou.create', 1, [
+            'type' => 'owe',
+            'person_name' => 'Alex',
+            'amount' => 50,
+            'currency' => 'EUR',
+            'transaction_date' => '2026-05-01',
+        ]);
+
+        $owed = $this->keys->for('iou.create', 1, [
+            'type' => 'owed',
+            'person_name' => 'Alex',
+            'amount' => 50,
+            'currency' => 'EUR',
+            'transaction_date' => '2026-05-01',
+        ]);
+
+        $this->assertNotSame($owe, $owed);
+    }
+
+    public function test_utility_bills_create_uses_period_and_amount(): void
+    {
+        $a = $this->keys->for('utilityBills.create', 1, [
+            'utility_type' => 'electricity',
+            'service_provider' => 'EVN',
+            'bill_amount' => 100,
+            'currency' => 'EUR',
+            'due_date' => '2026-05-15',
+            'bill_period_end' => '2026-04-30',
+        ]);
+
+        $b = $this->keys->for('utilityBills.create', 1, [
+            'utility_type' => 'electricity',
+            'service_provider' => 'EVN',
+            'bill_amount' => 100,
+            'currency' => 'EUR',
+            'due_date' => '2026-06-15',
+            'bill_period_end' => '2026-05-31',
+        ]);
+
+        $this->assertNotSame($a, $b, 'Different billing periods are different bills.');
+    }
+
+    public function test_jobs_update_status_keys_collide_per_message_per_status(): void
+    {
+        $a = $this->keys->for('jobs.updateStatus', 1, [
+            'job_application_id' => 7,
+            'status' => 'interviewing',
+            'source_email_id' => 'gmail-123',
+        ]);
+
+        $b = $this->keys->for('jobs.updateStatus', 1, [
+            'job_application_id' => 7,
+            'status' => 'interviewing',
+            'source_email_id' => 'gmail-123',
+        ]);
+
+        $this->assertSame($a, $b);
+    }
+
+    public function test_jobs_add_interview_keys_use_scheduled_slot(): void
+    {
+        $first = $this->keys->for('jobs.addInterview', 1, [
+            'job_application_id' => 7,
+            'scheduled_at' => '2026-05-10T14:00:00Z',
+            'interview_type' => 'video',
+        ]);
+
+        $second = $this->keys->for('jobs.addInterview', 1, [
+            'job_application_id' => 7,
+            'scheduled_at' => '2026-05-10T15:00:00Z',
+            'interview_type' => 'video',
+        ]);
+
+        $this->assertNotSame($first, $second);
+    }
+}


### PR DESCRIPTION
> Stacked on PR #154 (Phase 3). Will retarget `main` automatically when #154 merges. Plan: `docs/agents/IMPLEMENTATION_PLAN.md`. Phase 3's `docs/agents/AGENTS.md` will be refreshed in a follow-up once #154 lands.

## Summary

Widens the email-ingestion agent's reach beyond Expenses to cover the modules a typical mailbox surfaces: Subscriptions, Contracts, Warranties, IOU/Debt, Utility Bills, plus job-application status updates and interview scheduling. The shape stays the same as Phase 2: every write goes through the Pending Actions queue with deterministic per-tool idempotency keys.

### Backend

- **Cross-cutting migration** adding `source` + `created_by_agent_token_id` to `subscriptions`, `contracts`, `warranties`, `ious`, `utility_bills`. `job_applications` already has a `source` column with different meaning (job-board source), so agent attribution for `jobs.*` is traced via the `PendingAction` row itself.
- **Service extractions** — `SubscriptionService`, `ContractService`, `WarrantyService`, `IouService`, `UtilityBillService`, `JobApplicationService`. Subscription and Contract controllers refactored to delegate; remaining controllers use the services through the Pending Actions path. Existing AI tools (`CreateContract`, `CreateWarranty`, `CreateIou`, `CreateJobApplication`, etc.) keep their current Eloquent paths for now — service migration is incremental.
- **`IdempotencyKey`** gains generators for `subscriptions.create`, `contracts.create`, `warranties.create`, `iou.create`, `utilityBills.create`, `jobs.updateStatus`, `jobs.addInterview`. All include `source_email_id` where applicable so re-runs over the same Gmail message collide.
- **`PendingActionApplier`** extended with validators, executors, reverts, and previews for the seven new tools. Validators reuse the existing `StoreXyzRequest` classes; reverts mirror the Phase 2 pattern (delete-by-id for create-style writes, restore-from-before for `jobs.updateStatus`).

### MCP write tools (registered on `LifeOsServer`)

- `subscriptions.create`
- `contracts.create`
- `warranties.create`
- `iou.create`
- `utilityBills.create`
- `jobs.updateStatus`
- `jobs.addInterview`

### Agent definition

- `agents/email-ingestion/agent.json` now lists 16 allowed tools (7 reads + 9 writes). Limits raised to 15 min / 300 calls to accommodate multi-module triage.
- `agents/email-ingestion/system.md` rewritten as a triage flow:
  1. Bucket each Gmail message into receipt / subscription / utility / contract / IOU / job-related / skip.
  2. Extract per bucket using the categorization skill.
  3. Skip on uncertainty.
  
  Hard rules forbid auto-apply, edits to existing records, invented categories, and >50 pending actions per run.

## Test plan

- [ ] `composer install` (CI)
- [ ] `php artisan migrate`
- [ ] `php artisan test --compact tests/Unit/Services/Agents tests/Feature/Mcp/Phase4WriteToolsTest.php`:
  - **`IdempotencyKeyPhase4Test`** (unit): collision/distinction behaviour for each new tool's natural-field set, including subscription cycle normalization, contract counterparty/start scoping, warranty serial-number disambiguation, IOU direction split, utility-bill period sensitivity, job-status email-id stability, and interview slot uniqueness.
  - **`Phase4WriteToolsTest`** (feature): each new MCP write tool queues a `pending_action` without mutating live data; agent attribution (`source = 'agent'`, `created_by_agent_token_id`) flows through to the row on apply; idempotency dedupes a re-submission; cross-tenant target lookups return errors; ability-layer rejection fires for restricted tokens.
- [ ] `vendor/bin/pint --dirty --format agent`
- [ ] `npm run build`
- [ ] **Manual.** With Phase 3's `agents:run email-ingestion` plumbing live and `AGENT_EMAIL_INGESTION_ENABLED=true`, run a session that's seen at least one of each of: subscription welcome, utility bill, contract, recruiter email. Approve a few in the dashboard and confirm the right module rows are created with `source = 'agent'`.

## Notes

- **Auto-apply** for new tools is plumbed but defaults off, matching the strict Phase 2 stance. Toggle per (tenant, tool) only after watching the queue for a week or so.
- **Further refactors deferred.** This PR keeps controller and existing-AI-tool refactors minimal so the diff stays focused on the agent expansion. The remaining controllers (`Warranty`, `Iou`, `UtilityBill`, `JobApplication`) and AI tools (`CreateContract`, `CreateWarranty`, `CreateIou`, `CreateJobApplication`, `UpdateContract`, etc.) still call Eloquent directly. They'll move to the new services as we touch them in later phases.
- **AGENTS.md** lives on the Phase 3 branch (PR #154); a small follow-up after #154 merges will refresh the email-ingestion entry to list the new tool surface and limits.

## Phase gate

Per the plan, each agent phase ends with a stop-and-confirm. After this merges, run the email-ingestion agent against a real mailbox covering at least one of each new module type and review the resulting pending actions. Tune the categorization skill and (later) introduce per-tool auto-apply rules for the most reliable patterns.

https://claude.ai/code/session_01AxKEBuMxrHVjg7DShsnGi2

---
_Generated by [Claude Code](https://claude.ai/code/session_01AxKEBuMxrHVjg7DShsnGi2)_