### PR TITLE
feat(agents): Phase 5 — investments-sync agent

### DIFF
--- a/agents/investments-sync/agent.json
+++ b/agents/investments-sync/agent.json
@@ -1,0 +1,17 @@
+{
+    "slug": "investments-sync",
+    "model": "claude-opus-4-7",
+    "fallback_model": "claude-sonnet-4-6",
+    "mcp_servers": ["lifeos", "gmail", "drive"],
+    "allowed_tools": [
+        "investments.portfolio",
+        "investments.recordTransaction",
+        "investments.recordDividend",
+        "investments.repriceLot",
+        "investments.bulkImportTransactions"
+    ],
+    "max_session_duration_seconds": 900,
+    "max_tool_calls": 200,
+    "feature_flag": "agents.investments_sync.enabled",
+    "schedule": "0 7 * * *"
+}

--- a/agents/investments-sync/system.md
+++ b/agents/investments-sync/system.md
@@ -1,0 +1,72 @@
+# Investments sync agent
+
+You keep the LifeOS investments module in sync with the user's actual brokerage activity. You read confirmation emails (Gmail MCP) and brokerage statements (Drive MCP) and propose write calls against the LifeOS investments tools. You **never auto-apply**: every proposal lands in the Pending Actions queue for human approval.
+
+## Available tools
+
+You may only call the tools listed in your session config:
+
+### Read
+
+- **Gmail MCP** — broker confirmation emails (trade confirms, dividend notices, statement-arrived notifications).
+- **Drive MCP** — brokerage statements (PDFs, CSVs) the user has dropped in their Drive folder.
+- **`investments.portfolio`** — the LifeOS view of the current portfolio (positions, cost basis, last-priced timestamp). Always check this first so you know which `investment_id` values map to the symbols you see in confirmation emails.
+
+### Write (queued)
+
+- **`investments.recordTransaction`** — one buy/sell/transfer/dividend-reinvest entry. Idempotency anchors on `order_id` (or `confirmation_number`) when present, so re-runs on the same broker confirm collapse to the same row.
+- **`investments.recordDividend`** — one dividend payment. Idempotency anchors on (investment, payment_date, amount).
+- **`investments.repriceLot`** — mark-to-market: update an investment's per-share `current_value`. One pending action per (investment, as_of date), so re-running the same day is safe.
+- **`investments.bulkImportTransactions`** — when you've parsed an entire brokerage statement and want a single pending action covering all rows. Validate each row passes `recordTransaction`'s rules; cross-tenant or unknown investments fail the whole batch.
+
+## Process
+
+### 1. Map symbols to investments
+
+Call `investments.portfolio` first. Note the (`id`, `name`, `symbol_identifier`) for each row. Use `symbol_identifier` to match what the broker calls the security in confirmation emails / statements. If you can't find a match in the portfolio:
+
+- For known securities the user just hasn't logged yet, **skip** and emit a one-line note. Creating the parent `Investment` row is out of scope in this phase — that's a manual setup the user does once.
+- For obvious stale data (e.g. a position the user has since fully sold), still **skip** and note it.
+
+### 2. Process broker confirmation emails
+
+For each unread / recently received Gmail message that looks like a broker confirm:
+
+1. Read the message body. Identify the broker, the investment symbol, and the transaction details: type (buy/sell), quantity, price per share, fees, taxes, date, currency.
+2. Locate the matching investment via the portfolio map. Skip if not found.
+3. Call `investments.recordTransaction` with `source_email_id` set to the Gmail message id. Always include `order_id` if the broker provides one (it's the strongest idempotency anchor). Include `broker` so the user can filter by broker later.
+4. If the email is a dividend notice (not a trade), use `investments.recordDividend` instead. Include `tax_withheld` if the broker reports it.
+
+### 3. Process brokerage statements
+
+Statements arrive as PDFs or CSVs in the connected Drive folder. For each statement:
+
+1. Extract the line items. A typical monthly statement has a transactions section and (optionally) a dividends section.
+2. Convert each row into the `investments.recordTransaction` shape. Reuse broker `order_id` / `confirmation_number` if the statement prints them; otherwise the `(investment, type, qty, price, date, source_email_id="")` tuple becomes the idempotency anchor.
+3. Prefer `investments.bulkImportTransactions` over many individual `recordTransaction` calls when the statement covers ≥10 rows. The reviewer approves the whole batch at once.
+
+### 4. Mark-to-market
+
+Once a session, after recording new transactions and dividends, call `investments.repriceLot` for each position whose `last_price_update` is older than today. Use the most recent price you can find in the source emails / statements (or the broker's portfolio summary in the email body). Skip the call if you don't have a price you'd defend in front of the user.
+
+## Hard rules
+
+- Never auto-apply.
+- Never create a parent `Investment` row. The user maintains the list of holdings; this phase only records activity against existing rows.
+- Never invent prices, dates, or quantities. If a field is unclear, skip the row and emit a note.
+- Always set `currency` from the source. The investment's default currency is a fallback only when the source is unambiguous.
+- Stop once you've created 50 pending actions in this run, or you've processed every new message / statement, whichever comes first.
+
+## Output
+
+End the session with a short text summary:
+
+```
+Sources scanned: <n emails, m statements>
+Pending actions:
+- investments.recordTransaction: <n>
+- investments.recordDividend: <n>
+- investments.repriceLot: <n>
+- investments.bulkImportTransactions: <n>
+Skipped: <n>, with one-line reasons.
+```

--- a/app/Ai/Tools/RecordInvestmentTransaction.php
+++ b/app/Ai/Tools/RecordInvestmentTransaction.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace App\Ai\Tools;
 
 use App\Models\Investment;
-use App\Models\InvestmentTransaction;
+use App\Services\Investments\InvestmentService;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Laravel\Ai\Tools\Request;
 
@@ -86,16 +86,13 @@ class RecordInvestmentTransaction extends TenantScopedTool
 
         $totalAmount = (float) $validated['quantity'] * (float) $validated['price_per_share'];
 
-        InvestmentTransaction::create([
-            'tenant_id' => $this->tenantId,
-            'investment_id' => $investment->id,
+        app(InvestmentService::class)->recordTransaction($investment, [
             'transaction_type' => $validated['transaction_type'],
             'quantity' => $validated['quantity'],
             'price_per_share' => $validated['price_per_share'],
             'total_amount' => $totalAmount,
             'fees' => $validated['fees'],
             'transaction_date' => $validated['transaction_date'],
-            'currency' => $investment->currency ?? 'MKD',
             'notes' => $validated['notes'],
         ]);
 

--- a/app/Mcp/LifeOsServer.php
+++ b/app/Mcp/LifeOsServer.php
@@ -14,7 +14,11 @@ use App\Mcp\Tools\Expenses\BulkImportExpenses;
 use App\Mcp\Tools\Expenses\CategorizeExpense;
 use App\Mcp\Tools\Expenses\CreateExpense;
 use App\Mcp\Tools\Expenses\ListExpenses;
+use App\Mcp\Tools\Investments\BulkImportTransactions;
 use App\Mcp\Tools\Investments\Portfolio;
+use App\Mcp\Tools\Investments\RecordDividend;
+use App\Mcp\Tools\Investments\RecordTransaction;
+use App\Mcp\Tools\Investments\RepriceLot;
 use App\Mcp\Tools\Iou\CreateIou;
 use App\Mcp\Tools\Iou\ListIou;
 use App\Mcp\Tools\Jobs\AddInterview;
@@ -66,5 +70,9 @@ class LifeOsServer extends Server
         CreateUtilityBill::class,
         UpdateJobStatus::class,
         AddInterview::class,
+        RecordTransaction::class,
+        RecordDividend::class,
+        RepriceLot::class,
+        BulkImportTransactions::class,
     ];
 }

--- a/app/Mcp/Tools/Investments/BulkImportTransactions.php
+++ b/app/Mcp/Tools/Investments/BulkImportTransactions.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Mcp\Tools\Investments;
+
+use App\Mcp\Tools\AbstractTool;
+use App\Models\Investment;
+use App\Models\PendingAction;
+use App\Services\Agents\PendingActionApplier;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\ResponseFactory;
+
+class BulkImportTransactions extends AbstractTool
+{
+    protected string $name = 'investments.bulkImportTransactions';
+
+    protected string $description = 'Queue a batch of investment transactions parsed from a brokerage statement as a single pending action. Each item validates the same way as investments.recordTransaction.';
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'items' => $schema->array()->description('Array of transaction payloads. Each item uses the same shape as investments.recordTransaction.'),
+        ];
+    }
+
+    public function handle(Request $request, PendingActionApplier $applier): Response|ResponseFactory
+    {
+        if ($error = $this->authorize()) {
+            return $error;
+        }
+
+        $items = (array) $request->get('items', []);
+
+        if ($items === []) {
+            return Response::error('items must contain at least one transaction.');
+        }
+
+        $normalized = [];
+
+        foreach ($items as $i => $item) {
+            $row = (array) $item;
+            $invId = (int) ($row['investment_id'] ?? 0);
+
+            if ($invId <= 0 || Investment::query()->find($invId) === null) {
+                return Response::error("items.{$i}: investment [{$invId}] not found in this tenant.");
+            }
+
+            $normalized[] = array_filter($row, static fn ($v) => $v !== null);
+        }
+
+        try {
+            $action = $applier->record(
+                token: $this->agentToken(),
+                tool: $this->name(),
+                action: PendingAction::ACTION_BULK_CREATE,
+                payload: ['items' => $normalized],
+            );
+        } catch (\Throwable $e) {
+            return Response::error($e->getMessage());
+        }
+
+        return Response::structured([
+            'pending_action_id' => $action->id,
+            'status' => $action->status,
+            'idempotency_key' => $action->idempotency_key,
+            'item_count' => count($normalized),
+            'auto_applied' => $action->status === PendingAction::STATUS_APPLIED,
+        ]);
+    }
+}

--- a/app/Mcp/Tools/Investments/RecordDividend.php
+++ b/app/Mcp/Tools/Investments/RecordDividend.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Mcp\Tools\Investments;
+
+use App\Mcp\Tools\AbstractTool;
+use App\Models\Investment;
+use App\Models\PendingAction;
+use App\Services\Agents\PendingActionApplier;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\ResponseFactory;
+
+class RecordDividend extends AbstractTool
+{
+    protected string $name = 'investments.recordDividend';
+
+    protected string $description = 'Record a dividend payment against an existing investment. Queued as a pending action. One dividend per (investment, payment_date, amount).';
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'investment_id' => $schema->integer()->description('Investment id. Required.'),
+            'amount' => $schema->number()->description('Total dividend amount. Required.'),
+            'payment_date' => $schema->string()->description('YYYY-MM-DD. Required.'),
+            'record_date' => $schema->string()->description('YYYY-MM-DD.'),
+            'ex_dividend_date' => $schema->string()->description('YYYY-MM-DD.'),
+            'dividend_type' => $schema->string()->description('"ordinary", "qualified", "special", etc.'),
+            'frequency' => $schema->string()->description('"quarterly", "annual", "monthly", etc.'),
+            'dividend_per_share' => $schema->number()->description('Per-share rate.'),
+            'shares_held' => $schema->number()->description('Shares held at record date.'),
+            'tax_withheld' => $schema->number()->description('Tax withheld at source.'),
+            'currency' => $schema->string()->description('ISO 4217. Defaults to investment currency.'),
+            'reinvested' => $schema->boolean()->description('True if dividend was reinvested.'),
+            'notes' => $schema->string()->description('Free-text notes.'),
+            'source_email_id' => $schema->string()->description('Optional Gmail message id.'),
+        ];
+    }
+
+    public function handle(Request $request, PendingActionApplier $applier): Response|ResponseFactory
+    {
+        if ($error = $this->authorize()) {
+            return $error;
+        }
+
+        $investmentId = (int) $request->get('investment_id', 0);
+
+        if ($investmentId <= 0) {
+            return Response::error('investment_id is required.');
+        }
+
+        $investment = Investment::query()->find($investmentId);
+
+        if ($investment === null) {
+            return Response::error("Investment [{$investmentId}] not found in this tenant.");
+        }
+
+        $payload = array_filter([
+            'investment_id' => $investment->id,
+            'amount' => $request->get('amount'),
+            'payment_date' => $request->get('payment_date'),
+            'record_date' => $request->get('record_date'),
+            'ex_dividend_date' => $request->get('ex_dividend_date'),
+            'dividend_type' => $request->get('dividend_type'),
+            'frequency' => $request->get('frequency'),
+            'dividend_per_share' => $request->get('dividend_per_share'),
+            'shares_held' => $request->get('shares_held'),
+            'tax_withheld' => $request->get('tax_withheld'),
+            'currency' => $request->get('currency') ?? $investment->currency,
+            'reinvested' => $request->get('reinvested'),
+            'notes' => $request->get('notes'),
+            'source_email_id' => $request->get('source_email_id'),
+        ], static fn ($v) => $v !== null);
+
+        try {
+            $action = $applier->record(
+                token: $this->agentToken(),
+                tool: $this->name(),
+                action: PendingAction::ACTION_CREATE,
+                payload: $payload,
+            );
+        } catch (\Throwable $e) {
+            return Response::error($e->getMessage());
+        }
+
+        return Response::structured([
+            'pending_action_id' => $action->id,
+            'status' => $action->status,
+            'idempotency_key' => $action->idempotency_key,
+            'auto_applied' => $action->status === PendingAction::STATUS_APPLIED,
+        ]);
+    }
+}

--- a/app/Mcp/Tools/Investments/RecordTransaction.php
+++ b/app/Mcp/Tools/Investments/RecordTransaction.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Mcp\Tools\Investments;
+
+use App\Mcp\Tools\AbstractTool;
+use App\Models\Investment;
+use App\Models\PendingAction;
+use App\Services\Agents\PendingActionApplier;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\ResponseFactory;
+
+class RecordTransaction extends AbstractTool
+{
+    protected string $name = 'investments.recordTransaction';
+
+    protected string $description = 'Record a buy / sell / transfer transaction against an existing investment. Queued as a pending action. Idempotency anchors on broker order_id when present.';
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'investment_id' => $schema->integer()->description('Investment id (must belong to the authenticated tenant). Required.'),
+            'transaction_type' => $schema->string()->description('"buy", "sell", "dividend_reinvestment", "transfer_in", "transfer_out", "stock_split", "stock_dividend". Required.'),
+            'quantity' => $schema->number()->description('Shares / units transacted. Required.'),
+            'price_per_share' => $schema->number()->description('Price per share. Required.'),
+            'total_amount' => $schema->number()->description('Computed if not provided.'),
+            'fees' => $schema->number()->description('Transaction fees.'),
+            'taxes' => $schema->number()->description('Transaction taxes.'),
+            'transaction_date' => $schema->string()->description('YYYY-MM-DD. Required.'),
+            'settlement_date' => $schema->string()->description('YYYY-MM-DD.'),
+            'order_id' => $schema->string()->description('Broker order id (used for idempotency).'),
+            'confirmation_number' => $schema->string()->description('Broker confirmation number (fallback idempotency anchor).'),
+            'broker' => $schema->string()->description('Broker name.'),
+            'currency' => $schema->string()->description('ISO 4217. Defaults to investment currency.'),
+            'notes' => $schema->string()->description('Free-text notes.'),
+            'source_email_id' => $schema->string()->description('Optional Gmail message id when extracted from a confirm.'),
+        ];
+    }
+
+    public function handle(Request $request, PendingActionApplier $applier): Response|ResponseFactory
+    {
+        if ($error = $this->authorize()) {
+            return $error;
+        }
+
+        $investmentId = (int) $request->get('investment_id', 0);
+
+        if ($investmentId <= 0) {
+            return Response::error('investment_id is required.');
+        }
+
+        $investment = Investment::query()->find($investmentId);
+
+        if ($investment === null) {
+            return Response::error("Investment [{$investmentId}] not found in this tenant.");
+        }
+
+        $payload = array_filter([
+            'investment_id' => $investment->id,
+            'transaction_type' => $request->get('transaction_type'),
+            'quantity' => $request->get('quantity'),
+            'price_per_share' => $request->get('price_per_share'),
+            'total_amount' => $request->get('total_amount'),
+            'fees' => $request->get('fees'),
+            'taxes' => $request->get('taxes'),
+            'transaction_date' => $request->get('transaction_date'),
+            'settlement_date' => $request->get('settlement_date'),
+            'order_id' => $request->get('order_id'),
+            'confirmation_number' => $request->get('confirmation_number'),
+            'broker' => $request->get('broker'),
+            'currency' => $request->get('currency') ?? $investment->currency,
+            'notes' => $request->get('notes'),
+            'source_email_id' => $request->get('source_email_id'),
+        ], static fn ($v) => $v !== null);
+
+        try {
+            $action = $applier->record(
+                token: $this->agentToken(),
+                tool: $this->name(),
+                action: PendingAction::ACTION_CREATE,
+                payload: $payload,
+            );
+        } catch (\Throwable $e) {
+            return Response::error($e->getMessage());
+        }
+
+        return Response::structured([
+            'pending_action_id' => $action->id,
+            'status' => $action->status,
+            'idempotency_key' => $action->idempotency_key,
+            'auto_applied' => $action->status === PendingAction::STATUS_APPLIED,
+        ]);
+    }
+}

--- a/app/Mcp/Tools/Investments/RepriceLot.php
+++ b/app/Mcp/Tools/Investments/RepriceLot.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Mcp\Tools\Investments;
+
+use App\Mcp\Tools\AbstractTool;
+use App\Models\Investment;
+use App\Models\PendingAction;
+use App\Services\Agents\PendingActionApplier;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\ResponseFactory;
+
+class RepriceLot extends AbstractTool
+{
+    protected string $name = 'investments.repriceLot';
+
+    protected string $description = 'Mark-to-market: update an investment\'s current per-share value. One pending action per (investment, as_of date).';
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'investment_id' => $schema->integer()->description('Investment id. Required.'),
+            'current_value' => $schema->number()->description('New per-share value. Required.'),
+            'as_of' => $schema->string()->description('YYYY-MM-DD. Defaults to today.'),
+        ];
+    }
+
+    public function handle(Request $request, PendingActionApplier $applier): Response|ResponseFactory
+    {
+        if ($error = $this->authorize()) {
+            return $error;
+        }
+
+        $investmentId = (int) $request->get('investment_id', 0);
+
+        if ($investmentId <= 0) {
+            return Response::error('investment_id is required.');
+        }
+
+        $investment = Investment::query()->find($investmentId);
+
+        if ($investment === null) {
+            return Response::error("Investment [{$investmentId}] not found in this tenant.");
+        }
+
+        $payload = array_filter([
+            'investment_id' => $investment->id,
+            'current_value' => $request->get('current_value'),
+            'as_of' => $request->get('as_of') ?? date('Y-m-d'),
+        ], static fn ($v) => $v !== null);
+
+        try {
+            $action = $applier->record(
+                token: $this->agentToken(),
+                tool: $this->name(),
+                action: PendingAction::ACTION_UPDATE,
+                payload: $payload,
+            );
+        } catch (\Throwable $e) {
+            return Response::error($e->getMessage());
+        }
+
+        return Response::structured([
+            'pending_action_id' => $action->id,
+            'status' => $action->status,
+            'idempotency_key' => $action->idempotency_key,
+            'auto_applied' => $action->status === PendingAction::STATUS_APPLIED,
+        ]);
+    }
+}

--- a/app/Models/Investment.php
+++ b/app/Models/Investment.php
@@ -36,6 +36,8 @@ class Investment extends Model
         'last_price_update',
         'notes',
         'status',
+        'source',
+        'created_by_agent_token_id',
     ];
 
     protected function casts(): array

--- a/app/Models/InvestmentDividend.php
+++ b/app/Models/InvestmentDividend.php
@@ -27,6 +27,8 @@ class InvestmentDividend extends Model
         'currency',
         'reinvested',
         'notes',
+        'source',
+        'created_by_agent_token_id',
     ];
 
     protected function casts(): array

--- a/app/Models/InvestmentTransaction.php
+++ b/app/Models/InvestmentTransaction.php
@@ -34,6 +34,8 @@ class InvestmentTransaction extends Model
         'stop_price',
         'notes',
         'tax_lot_info',
+        'source',
+        'created_by_agent_token_id',
     ];
 
     protected function casts(): array

--- a/app/Services/Agents/IdempotencyKey.php
+++ b/app/Services/Agents/IdempotencyKey.php
@@ -30,6 +30,10 @@ class IdempotencyKey
             'utilityBills.create' => $this->utilityBillsCreate($tenantId, $payload),
             'jobs.updateStatus' => $this->jobsUpdateStatus($tenantId, $payload),
             'jobs.addInterview' => $this->jobsAddInterview($tenantId, $payload),
+            'investments.recordTransaction' => $this->investmentsRecordTransaction($tenantId, $payload),
+            'investments.recordDividend' => $this->investmentsRecordDividend($tenantId, $payload),
+            'investments.repriceLot' => $this->investmentsRepriceLot($tenantId, $payload),
+            'investments.bulkImportTransactions' => $this->investmentsBulkImportTransactions($tenantId, $payload),
             default => throw new InvalidArgumentException("No idempotency-key generator registered for tool [{$tool}]."),
         };
 
@@ -175,6 +179,80 @@ class IdempotencyKey
         $sourceEmail = (string) ($p['source_email_id'] ?? '');
 
         return "jobs.addInterview|{$tenantId}|{$jobId}|{$scheduledAt}|{$type}|{$sourceEmail}";
+    }
+
+    /**
+     * Investment transactions are keyed on broker-provided fields when present
+     * (order_id / confirmation_number), falling back to (investment, type, qty,
+     * price, date). The order_id collapses any retry of the same broker action.
+     *
+     * @param  array<string, mixed>  $p
+     */
+    private function investmentsRecordTransaction(int $tenantId, array $p): string
+    {
+        $investmentId = (int) ($p['investment_id'] ?? 0);
+        $orderId = $this->normalize((string) ($p['order_id'] ?? ''));
+        $confirmation = $this->normalize((string) ($p['confirmation_number'] ?? ''));
+
+        if ($orderId !== '') {
+            return "investments.recordTransaction|{$tenantId}|{$investmentId}|order:{$orderId}";
+        }
+
+        if ($confirmation !== '') {
+            return "investments.recordTransaction|{$tenantId}|{$investmentId}|conf:{$confirmation}";
+        }
+
+        $type = $this->normalize((string) ($p['transaction_type'] ?? ''));
+        $qty = $this->amountCents($p['quantity'] ?? 0);
+        $price = $this->amountCents($p['price_per_share'] ?? 0);
+        $date = (string) ($p['transaction_date'] ?? '');
+        $sourceEmail = (string) ($p['source_email_id'] ?? '');
+
+        return "investments.recordTransaction|{$tenantId}|{$investmentId}|{$type}|{$qty}|{$price}|{$date}|{$sourceEmail}";
+    }
+
+    /**
+     * @param  array<string, mixed>  $p
+     */
+    private function investmentsRecordDividend(int $tenantId, array $p): string
+    {
+        $investmentId = (int) ($p['investment_id'] ?? 0);
+        $amount = $this->amountCents($p['amount'] ?? 0);
+        $payment = (string) ($p['payment_date'] ?? '');
+        $sourceEmail = (string) ($p['source_email_id'] ?? '');
+
+        return "investments.recordDividend|{$tenantId}|{$investmentId}|{$amount}|{$payment}|{$sourceEmail}";
+    }
+
+    /**
+     * Mark-to-market: one logical price per (investment, as_of date). Re-running
+     * the agent on the same day collapses to the same row.
+     *
+     * @param  array<string, mixed>  $p
+     */
+    private function investmentsRepriceLot(int $tenantId, array $p): string
+    {
+        $investmentId = (int) ($p['investment_id'] ?? 0);
+        $asOf = (string) ($p['as_of'] ?? date('Y-m-d'));
+
+        return "investments.repriceLot|{$tenantId}|{$investmentId}|{$asOf}";
+    }
+
+    /**
+     * @param  array<string, mixed>  $p
+     */
+    private function investmentsBulkImportTransactions(int $tenantId, array $p): string
+    {
+        $items = (array) ($p['items'] ?? []);
+
+        $itemKeys = array_map(
+            fn (array $item): string => $this->investmentsRecordTransaction($tenantId, $item),
+            $items,
+        );
+
+        sort($itemKeys);
+
+        return "investments.bulkImportTransactions|{$tenantId}|".implode("\n", $itemKeys);
     }
 
     private function normalize(string $value): string

--- a/app/Services/Agents/PendingActionApplier.php
+++ b/app/Services/Agents/PendingActionApplier.php
@@ -14,6 +14,9 @@ use App\Http\Requests\StoreWarrantyRequest;
 use App\Models\AgentToken;
 use App\Models\Contract;
 use App\Models\Expense;
+use App\Models\Investment;
+use App\Models\InvestmentDividend;
+use App\Models\InvestmentTransaction;
 use App\Models\Iou;
 use App\Models\JobApplication;
 use App\Models\PendingAction;
@@ -23,6 +26,7 @@ use App\Models\UtilityBill;
 use App\Models\Warranty;
 use App\Services\Contracts\ContractService;
 use App\Services\Expenses\ExpenseService;
+use App\Services\Investments\InvestmentService;
 use App\Services\Iou\IouService;
 use App\Services\Jobs\JobApplicationService;
 use App\Services\Subscriptions\SubscriptionService;
@@ -49,6 +53,7 @@ class PendingActionApplier
         protected IouService $ious,
         protected UtilityBillService $bills,
         protected JobApplicationService $jobs,
+        protected InvestmentService $investments,
         protected IdempotencyKey $keys,
     ) {}
 
@@ -240,8 +245,101 @@ class PendingActionApplier
             'utilityBills.create' => $this->validateWithFormRequest(StoreUtilityBillRequest::class, $action->payload),
             'jobs.updateStatus' => $this->validateJobsUpdateStatus($action->payload),
             'jobs.addInterview' => $this->validateJobsAddInterview($action->payload),
+            'investments.recordTransaction' => $this->validateInvestmentsRecordTransaction($action->payload),
+            'investments.recordDividend' => $this->validateInvestmentsRecordDividend($action->payload),
+            'investments.repriceLot' => $this->validateInvestmentsRepriceLot($action->payload),
+            'investments.bulkImportTransactions' => $this->validateInvestmentsBulkImportTransactions($action->payload),
             default => throw new RuntimeException("No validator registered for tool [{$action->tool}]."),
         };
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function validateInvestmentsRecordTransaction(array $payload): void
+    {
+        $validator = Validator::make($payload, [
+            'investment_id' => 'required|integer|exists:investments,id',
+            'transaction_type' => 'required|string|in:buy,sell,dividend_reinvestment,transfer_in,transfer_out,stock_split,stock_dividend',
+            'quantity' => 'required|numeric|min:0.00000001',
+            'price_per_share' => 'required|numeric|min:0',
+            'total_amount' => 'nullable|numeric',
+            'fees' => 'nullable|numeric|min:0',
+            'taxes' => 'nullable|numeric|min:0',
+            'transaction_date' => 'required|date',
+            'settlement_date' => 'nullable|date',
+            'order_id' => 'nullable|string|max:128',
+            'confirmation_number' => 'nullable|string|max:128',
+            'broker' => 'nullable|string|max:128',
+            'currency' => 'nullable|string|size:3',
+            'notes' => 'nullable|string|max:65535',
+        ]);
+
+        if ($validator->fails()) {
+            throw new ValidationException($validator);
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function validateInvestmentsRecordDividend(array $payload): void
+    {
+        $validator = Validator::make($payload, [
+            'investment_id' => 'required|integer|exists:investments,id',
+            'amount' => 'required|numeric|min:0',
+            'payment_date' => 'required|date',
+            'record_date' => 'nullable|date',
+            'ex_dividend_date' => 'nullable|date',
+            'dividend_type' => 'nullable|string|max:64',
+            'frequency' => 'nullable|string|max:64',
+            'dividend_per_share' => 'nullable|numeric|min:0',
+            'shares_held' => 'nullable|numeric|min:0',
+            'tax_withheld' => 'nullable|numeric|min:0',
+            'currency' => 'nullable|string|size:3',
+            'reinvested' => 'nullable|boolean',
+            'notes' => 'nullable|string|max:65535',
+        ]);
+
+        if ($validator->fails()) {
+            throw new ValidationException($validator);
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function validateInvestmentsRepriceLot(array $payload): void
+    {
+        $validator = Validator::make($payload, [
+            'investment_id' => 'required|integer|exists:investments,id',
+            'current_value' => 'required|numeric|min:0',
+            'as_of' => 'nullable|date',
+        ]);
+
+        if ($validator->fails()) {
+            throw new ValidationException($validator);
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function validateInvestmentsBulkImportTransactions(array $payload): void
+    {
+        $items = (array) ($payload['items'] ?? []);
+
+        if ($items === []) {
+            throw ValidationException::withMessages(['items' => 'At least one item is required.']);
+        }
+
+        foreach ($items as $i => $item) {
+            try {
+                $this->validateInvestmentsRecordTransaction((array) $item);
+            } catch (ValidationException $e) {
+                throw ValidationException::withMessages(["items.{$i}" => $e->errors()]);
+            }
+        }
     }
 
     /**
@@ -365,8 +463,109 @@ class PendingActionApplier
             'utilityBills.create' => $this->executeUtilityBillCreate($action, $user, $attribution),
             'jobs.updateStatus' => $this->executeJobsUpdateStatus($action),
             'jobs.addInterview' => $this->executeJobsAddInterview($action),
+            'investments.recordTransaction' => $this->executeInvestmentsRecordTransaction($action, $attribution),
+            'investments.recordDividend' => $this->executeInvestmentsRecordDividend($action, $attribution),
+            'investments.repriceLot' => $this->executeInvestmentsRepriceLot($action),
+            'investments.bulkImportTransactions' => $this->executeInvestmentsBulkImportTransactions($action, $attribution),
             default => throw new RuntimeException("No executor registered for tool [{$action->tool}]."),
         };
+    }
+
+    /**
+     * @param  array<string, mixed>  $attribution
+     * @return array<string, mixed>
+     */
+    private function executeInvestmentsRecordTransaction(PendingAction $action, array $attribution): array
+    {
+        $investment = Investment::query()->findOrFail((int) $action->payload['investment_id']);
+
+        $transaction = $this->investments->recordTransaction(
+            $investment,
+            collect($action->payload)->except(['investment_id', 'source_email_id'])->all(),
+            $attribution,
+        );
+
+        $action->forceFill([
+            'target_type' => InvestmentTransaction::class,
+            'target_id' => $transaction->id,
+        ])->save();
+
+        return [
+            'before' => null,
+            'after' => $transaction->only(['id', 'investment_id', 'transaction_type', 'quantity', 'price_per_share', 'total_amount', 'transaction_date', 'currency']),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $attribution
+     * @return array<string, mixed>
+     */
+    private function executeInvestmentsRecordDividend(PendingAction $action, array $attribution): array
+    {
+        $investment = Investment::query()->findOrFail((int) $action->payload['investment_id']);
+
+        $dividend = $this->investments->recordDividend(
+            $investment,
+            collect($action->payload)->except(['investment_id', 'source_email_id'])->all(),
+            $attribution,
+        );
+
+        $action->forceFill([
+            'target_type' => InvestmentDividend::class,
+            'target_id' => $dividend->id,
+        ])->save();
+
+        return [
+            'before' => null,
+            'after' => $dividend->only(['id', 'investment_id', 'amount', 'payment_date', 'currency']),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function executeInvestmentsRepriceLot(PendingAction $action): array
+    {
+        $investment = Investment::query()->findOrFail((int) $action->payload['investment_id']);
+        $before = $investment->only(['id', 'current_value', 'last_price_update']);
+
+        $asOf = isset($action->payload['as_of'])
+            ? new \DateTimeImmutable((string) $action->payload['as_of'])
+            : null;
+
+        $this->investments->repriceLot(
+            $investment,
+            (float) $action->payload['current_value'],
+            $asOf,
+        );
+
+        $action->forceFill([
+            'target_type' => Investment::class,
+            'target_id' => $investment->id,
+        ])->save();
+
+        return [
+            'before' => $before,
+            'after' => $investment->refresh()->only(['id', 'current_value', 'last_price_update']),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $attribution
+     * @return array<string, mixed>
+     */
+    private function executeInvestmentsBulkImportTransactions(PendingAction $action, array $attribution): array
+    {
+        $rows = (array) ($action->payload['items'] ?? []);
+        $created = $this->investments->bulkRecordTransactions($rows, $attribution);
+
+        return [
+            'before' => null,
+            'after' => array_map(
+                fn (InvestmentTransaction $t): array => $t->only(['id', 'investment_id', 'transaction_type', 'quantity', 'price_per_share']),
+                $created,
+            ),
+        ];
     }
 
     /**
@@ -618,9 +817,67 @@ class PendingActionApplier
                 $this->revertJobsAddInterview($action);
 
                 return;
+            case 'investments.recordTransaction':
+                $this->revertCreateById($action, InvestmentTransaction::class);
+
+                return;
+            case 'investments.recordDividend':
+                $this->revertCreateById($action, InvestmentDividend::class);
+
+                return;
+            case 'investments.repriceLot':
+                $this->revertInvestmentsRepriceLot($action);
+
+                return;
+            case 'investments.bulkImportTransactions':
+                $this->revertInvestmentsBulkImport($action);
+
+                return;
         }
 
         throw new RuntimeException("No revert executor for tool [{$action->tool}].");
+    }
+
+    private function revertInvestmentsRepriceLot(PendingAction $action): void
+    {
+        $diff = $action->applied_diff ?? [];
+        $before = $diff['before'] ?? null;
+
+        if (! is_array($before) || ! isset($before['id'])) {
+            return;
+        }
+
+        $investment = Investment::query()->find((int) $before['id']);
+
+        if ($investment === null) {
+            return;
+        }
+
+        $investment->update([
+            'current_value' => $before['current_value'] ?? null,
+            'last_price_update' => $before['last_price_update'] ?? null,
+        ]);
+    }
+
+    private function revertInvestmentsBulkImport(PendingAction $action): void
+    {
+        $diff = $action->applied_diff ?? [];
+        $after = $diff['after'] ?? null;
+
+        if (! is_array($after)) {
+            return;
+        }
+
+        $ids = array_values(array_filter(array_map(
+            static fn ($row) => is_array($row) && isset($row['id']) ? (int) $row['id'] : null,
+            $after,
+        )));
+
+        if ($ids === []) {
+            return;
+        }
+
+        InvestmentTransaction::query()->whereIn('id', $ids)->delete();
     }
 
     /**
@@ -827,6 +1084,36 @@ class PendingActionApplier
                     (int) ($payload['job_application_id'] ?? 0),
                     (string) ($payload['scheduled_at'] ?? ''),
                 ),
+            ],
+            'investments.recordTransaction' => [
+                'summary' => sprintf(
+                    '%s %s @ %s on investment #%d (%s)',
+                    (string) ($payload['transaction_type'] ?? '?'),
+                    number_format((float) ($payload['quantity'] ?? 0), 4),
+                    number_format((float) ($payload['price_per_share'] ?? 0), 4),
+                    (int) ($payload['investment_id'] ?? 0),
+                    (string) ($payload['transaction_date'] ?? ''),
+                ),
+            ],
+            'investments.recordDividend' => [
+                'summary' => sprintf(
+                    'Dividend %s %s on investment #%d (%s)',
+                    number_format((float) ($payload['amount'] ?? 0), 2),
+                    (string) ($payload['currency'] ?? ''),
+                    (int) ($payload['investment_id'] ?? 0),
+                    (string) ($payload['payment_date'] ?? ''),
+                ),
+            ],
+            'investments.repriceLot' => [
+                'summary' => sprintf(
+                    'Reprice investment #%d → %s as of %s',
+                    (int) ($payload['investment_id'] ?? 0),
+                    number_format((float) ($payload['current_value'] ?? 0), 4),
+                    (string) ($payload['as_of'] ?? date('Y-m-d')),
+                ),
+            ],
+            'investments.bulkImportTransactions' => [
+                'summary' => sprintf('%d investment transactions', count((array) ($payload['items'] ?? []))),
             ],
             default => [],
         };

--- a/app/Services/Investments/InvestmentService.php
+++ b/app/Services/Investments/InvestmentService.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Investments;
+
+use App\Models\Investment;
+use App\Models\InvestmentDividend;
+use App\Models\InvestmentTransaction;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use RuntimeException;
+
+class InvestmentService
+{
+    /**
+     * Create a new Investment row (e.g. when an agent discovers a position
+     * the user hasn't entered manually).
+     *
+     * @param  array<string, mixed>  $data
+     * @param  array<string, mixed>  $attribution
+     */
+    public function create(User $user, array $data, array $attribution = []): Investment
+    {
+        return Investment::create([
+            'user_id' => $user->id,
+            ...$data,
+            'source' => $attribution['source'] ?? 'user',
+            'created_by_agent_token_id' => $attribution['agent_token_id'] ?? null,
+        ]);
+    }
+
+    /**
+     * Record a buy / sell / transfer / dividend-reinvestment transaction.
+     *
+     * @param  array<string, mixed>  $data
+     * @param  array<string, mixed>  $attribution
+     */
+    public function recordTransaction(Investment $investment, array $data, array $attribution = []): InvestmentTransaction
+    {
+        $payload = [
+            'investment_id' => $investment->id,
+            ...$data,
+            'source' => $attribution['source'] ?? 'user',
+            'created_by_agent_token_id' => $attribution['agent_token_id'] ?? null,
+        ];
+
+        if (! isset($payload['total_amount']) && isset($payload['quantity'], $payload['price_per_share'])) {
+            $payload['total_amount'] = (float) $payload['quantity'] * (float) $payload['price_per_share'];
+        }
+
+        if (! isset($payload['currency'])) {
+            $payload['currency'] = $investment->currency ?? 'MKD';
+        }
+
+        return InvestmentTransaction::create($payload);
+    }
+
+    /**
+     * Record a dividend payment.
+     *
+     * @param  array<string, mixed>  $data
+     * @param  array<string, mixed>  $attribution
+     */
+    public function recordDividend(Investment $investment, array $data, array $attribution = []): InvestmentDividend
+    {
+        return InvestmentDividend::create([
+            'investment_id' => $investment->id,
+            ...$data,
+            'source' => $attribution['source'] ?? 'user',
+            'created_by_agent_token_id' => $attribution['agent_token_id'] ?? null,
+        ]);
+    }
+
+    /**
+     * Mark-to-market: update current_value (per-share) and last_price_update.
+     * Quantity is preserved; the dashboard recomputes market value from
+     * quantity * current_value.
+     */
+    public function repriceLot(Investment $investment, float $currentValue, ?\DateTimeInterface $asOf = null): Investment
+    {
+        $asOf ??= now();
+
+        $investment->update([
+            'current_value' => $currentValue,
+            'last_price_update' => $asOf->format('Y-m-d'),
+        ]);
+
+        return $investment->refresh();
+    }
+
+    /**
+     * Bulk-create transactions inside a single DB transaction.
+     *
+     * @param  array<int, array<string, mixed>>  $rows  Each row needs investment_id and the
+     *   InvestmentTransaction fields. The applier resolves investment_id ahead
+     *   of time so this method stays naive about resolution rules.
+     * @param  array<string, mixed>  $attribution
+     * @return array<int, InvestmentTransaction>
+     */
+    public function bulkRecordTransactions(array $rows, array $attribution = []): array
+    {
+        return DB::transaction(function () use ($rows, $attribution): array {
+            $created = [];
+
+            foreach ($rows as $row) {
+                if (! isset($row['investment_id'])) {
+                    throw new RuntimeException('investment_id missing from a bulk-import row.');
+                }
+
+                $investment = Investment::query()->find((int) $row['investment_id']);
+
+                if ($investment === null) {
+                    throw new RuntimeException("Investment {$row['investment_id']} not found in this tenant.");
+                }
+
+                $created[] = $this->recordTransaction($investment, $row, $attribution);
+            }
+
+            return $created;
+        });
+    }
+}

--- a/database/migrations/2026_05_07_011955_add_agent_attribution_to_investments_module.php
+++ b/database/migrations/2026_05_07_011955_add_agent_attribution_to_investments_module.php
@@ -1,0 +1,59 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Phase 5: agent attribution columns on the investments module's tables.
+     * Same shape as the columns added in Phase 2 (expenses) and Phase 4
+     * (subscriptions, contracts, warranties, ious, utility_bills).
+     */
+    private array $tables = [
+        'investments',
+        'investment_transactions',
+        'investment_dividends',
+    ];
+
+    public function up(): void
+    {
+        foreach ($this->tables as $name) {
+            if (! Schema::hasTable($name)) {
+                continue;
+            }
+
+            Schema::table($name, function (Blueprint $table) use ($name): void {
+                if (! Schema::hasColumn($name, 'source')) {
+                    $table->string('source', 16)->default('user');
+                }
+
+                if (! Schema::hasColumn($name, 'created_by_agent_token_id')) {
+                    $table->foreignId('created_by_agent_token_id')->nullable()
+                        ->constrained('agent_tokens')->nullOnDelete();
+                }
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        foreach ($this->tables as $name) {
+            if (! Schema::hasTable($name)) {
+                continue;
+            }
+
+            Schema::table($name, function (Blueprint $table) use ($name): void {
+                if (Schema::hasColumn($name, 'created_by_agent_token_id')) {
+                    $table->dropForeign(['created_by_agent_token_id']);
+                    $table->dropColumn('created_by_agent_token_id');
+                }
+
+                if (Schema::hasColumn($name, 'source')) {
+                    $table->dropColumn('source');
+                }
+            });
+        }
+    }
+};

--- a/docs/agents/IMPLEMENTATION_PLAN.md
+++ b/docs/agents/IMPLEMENTATION_PLAN.md
@@ -7,7 +7,8 @@
 > - Phase 1 — read-only MCP server: PR #148, **merged**.
 > - Phase 2 — Pending Actions queue + Expenses writes: PR #150, **merged**.
 > - Phase 3 — email-ingestion agent + ManagedAgentsClient + `agents:run`: PR #154 (in review). See `docs/agents/AGENTS.md`.
-> - Phase 4 — email-ingestion expansion (Subscriptions, Contracts, Warranties, IOU, Utility Bills, Job status updates + interviews): in PR.
+> - Phase 4 — email-ingestion expansion (Subscriptions, Contracts, Warranties, IOU, Utility Bills, Job status updates + interviews): PR #155.
+> - Phase 5 — investments-sync agent (record transactions, dividends, mark-to-market, bulk-import statements): in PR. Broker-agnostic; reads from Gmail (broker confirms) + Drive (statements).
 
 ## Context
 

--- a/docs/agents/MCP_TOOLS.md
+++ b/docs/agents/MCP_TOOLS.md
@@ -354,6 +354,72 @@ Idempotency key: `sha256("subscriptions.create|<tenant>|<service_normalized>|<cu
 | `notes` | string | Optional. |
 | `source_email_id` | string | Optional. |
 
+## Write tools (Phase 5)
+
+Phase 5 adds the investments-sync agent's tool surface. None of these create the parent `Investment` row — that's a one-time manual setup the user does. All four record activity *against* an existing investment.
+
+### `investments.recordTransaction`
+
+| field | type | description |
+|---|---|---|
+| `investment_id` | int | Required. Must belong to the authenticated tenant. |
+| `transaction_type` | string | Required. One of `buy`, `sell`, `dividend_reinvestment`, `transfer_in`, `transfer_out`, `stock_split`, `stock_dividend`. |
+| `quantity` | number | Required. |
+| `price_per_share` | number | Required. |
+| `total_amount` | number | Auto-computed from `quantity * price_per_share` if absent. |
+| `fees`, `taxes` | number | Optional. |
+| `transaction_date` | date | Required. |
+| `settlement_date` | date | Optional. |
+| `order_id` | string | Broker order id. **Strongest idempotency anchor.** |
+| `confirmation_number` | string | Broker confirmation number. Fallback idempotency anchor. |
+| `broker` | string | Optional. |
+| `currency` | string | ISO 4217. Defaults to investment currency. |
+| `notes` | string | Optional. |
+| `source_email_id` | string | Optional Gmail message id. |
+
+Idempotency: `order_id` (when present) → `confirmation_number` (when present) → `(investment, type, qty, price, date, source_email_id)`.
+
+### `investments.recordDividend`
+
+| field | type | description |
+|---|---|---|
+| `investment_id` | int | Required. |
+| `amount` | number | Required. Total dividend amount. |
+| `payment_date` | date | Required. |
+| `record_date`, `ex_dividend_date` | date | Optional. |
+| `dividend_type` | string | Optional. `"ordinary"`, `"qualified"`, `"special"`, etc. |
+| `frequency` | string | Optional. |
+| `dividend_per_share`, `shares_held` | number | Optional. |
+| `tax_withheld` | number | Optional. |
+| `currency` | string | Defaults to investment currency. |
+| `reinvested` | bool | Optional. |
+| `notes` | string | Optional. |
+| `source_email_id` | string | Optional. |
+
+Idempotency: `(investment, payment_date, amount, source_email_id)`.
+
+### `investments.repriceLot`
+
+Mark-to-market — update an investment's per-share `current_value`.
+
+| field | type | description |
+|---|---|---|
+| `investment_id` | int | Required. |
+| `current_value` | number | Required. New per-share value. |
+| `as_of` | date | Defaults to today. |
+
+Idempotency: `(investment, as_of)`. Re-running on the same date collapses to the same pending action so the agent can call this once per position per session safely. Revert restores the prior `current_value` and `last_price_update`.
+
+### `investments.bulkImportTransactions`
+
+Queue an entire brokerage statement as a single pending action.
+
+| field | type | description |
+|---|---|---|
+| `items` | array | Each item uses the same shape as `investments.recordTransaction`. |
+
+Idempotency: derived from the sorted hashes of the per-item `recordTransaction` keys, so reorderings collide.
+
 ## Approval surface
 
 Reviewers act through `/dashboard/pending-actions`:

--- a/tests/Feature/Mcp/Phase5InvestmentsToolsTest.php
+++ b/tests/Feature/Mcp/Phase5InvestmentsToolsTest.php
@@ -1,0 +1,231 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Mcp;
+
+use App\Mcp\LifeOsServer;
+use App\Mcp\Tools\Investments\BulkImportTransactions;
+use App\Mcp\Tools\Investments\RecordDividend;
+use App\Mcp\Tools\Investments\RecordTransaction;
+use App\Mcp\Tools\Investments\RepriceLot;
+use App\Models\AgentToken;
+use App\Models\Investment;
+use App\Models\InvestmentDividend;
+use App\Models\InvestmentTransaction;
+use App\Models\PendingAction;
+use App\Models\Tenant;
+use App\Models\User;
+use App\Services\Agents\PendingActionApplier;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\App;
+use Tests\TestCase;
+
+class Phase5InvestmentsToolsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+
+    private Tenant $tenant;
+
+    private Investment $investment;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        ['user' => $this->user, 'tenant' => $this->tenant] = $this->setupTenantContext();
+        [$token] = AgentToken::issue($this->user, $this->tenant, 'phpunit', ['*']);
+        App::instance('agent.token', $token);
+
+        $this->investment = Investment::factory()->create([
+            'name' => 'VWCE',
+            'symbol_identifier' => 'VWCE',
+            'investment_type' => 'etf',
+            'currency' => 'EUR',
+            'quantity' => 10,
+            'purchase_price' => 100,
+            'current_value' => 100,
+        ]);
+    }
+
+    public function test_record_transaction_queues_pending_action(): void
+    {
+        LifeOsServer::tool(RecordTransaction::class, [
+            'investment_id' => $this->investment->id,
+            'transaction_type' => 'buy',
+            'quantity' => 5,
+            'price_per_share' => 110,
+            'transaction_date' => '2026-05-01',
+            'order_id' => 'BRK-001',
+        ])->assertOk()->assertStructuredContent(function (array $content): bool {
+            $this->assertSame(PendingAction::STATUS_PENDING, $content['status']);
+
+            return true;
+        });
+
+        $this->assertSame(1, PendingAction::query()->where('tool', 'investments.recordTransaction')->count());
+        $this->assertSame(0, InvestmentTransaction::query()->count());
+    }
+
+    public function test_record_transaction_idempotent_by_order_id(): void
+    {
+        $args = [
+            'investment_id' => $this->investment->id,
+            'transaction_type' => 'buy',
+            'quantity' => 5,
+            'price_per_share' => 110,
+            'transaction_date' => '2026-05-01',
+            'order_id' => 'BRK-001',
+        ];
+
+        LifeOsServer::tool(RecordTransaction::class, $args);
+        LifeOsServer::tool(RecordTransaction::class, $args);
+
+        $this->assertSame(1, PendingAction::query()->count());
+    }
+
+    public function test_apply_record_transaction_writes_with_attribution(): void
+    {
+        LifeOsServer::tool(RecordTransaction::class, [
+            'investment_id' => $this->investment->id,
+            'transaction_type' => 'buy',
+            'quantity' => 5,
+            'price_per_share' => 110,
+            'transaction_date' => '2026-05-01',
+            'order_id' => 'BRK-002',
+        ]);
+
+        $action = PendingAction::query()->firstOrFail();
+        app(PendingActionApplier::class)->apply($action, $this->user);
+
+        $this->assertSame(1, InvestmentTransaction::query()->count());
+        $tx = InvestmentTransaction::query()->first();
+        $this->assertSame($this->investment->id, $tx->investment_id);
+        $this->assertSame('agent', $tx->source);
+        $this->assertNotNull($tx->created_by_agent_token_id);
+        $this->assertEquals(550.0, (float) $tx->total_amount, 'total_amount auto-computed.');
+    }
+
+    public function test_record_dividend_queues_pending_action(): void
+    {
+        LifeOsServer::tool(RecordDividend::class, [
+            'investment_id' => $this->investment->id,
+            'amount' => 12.50,
+            'payment_date' => '2026-04-30',
+            'tax_withheld' => 1.25,
+        ])->assertOk();
+
+        $this->assertSame(1, PendingAction::query()->where('tool', 'investments.recordDividend')->count());
+        $this->assertSame(0, InvestmentDividend::query()->count());
+    }
+
+    public function test_reprice_lot_queues_pending_action(): void
+    {
+        LifeOsServer::tool(RepriceLot::class, [
+            'investment_id' => $this->investment->id,
+            'current_value' => 115,
+            'as_of' => '2026-05-07',
+        ])->assertOk();
+
+        $action = PendingAction::query()->firstOrFail();
+        $this->assertSame('investments.repriceLot', $action->tool);
+        $this->assertSame((float) 100, (float) $this->investment->fresh()->current_value, 'Investment unchanged before approval.');
+    }
+
+    public function test_apply_reprice_lot_updates_current_value(): void
+    {
+        LifeOsServer::tool(RepriceLot::class, [
+            'investment_id' => $this->investment->id,
+            'current_value' => 115,
+            'as_of' => '2026-05-07',
+        ]);
+
+        $action = PendingAction::query()->firstOrFail();
+        app(PendingActionApplier::class)->apply($action, $this->user);
+
+        $this->investment->refresh();
+        $this->assertEquals(115.0, (float) $this->investment->current_value);
+        $this->assertSame('2026-05-07', $this->investment->last_price_update?->toDateString());
+    }
+
+    public function test_revert_reprice_restores_previous_value(): void
+    {
+        LifeOsServer::tool(RepriceLot::class, [
+            'investment_id' => $this->investment->id,
+            'current_value' => 115,
+            'as_of' => '2026-05-07',
+        ]);
+        $action = PendingAction::query()->firstOrFail();
+        $applied = app(PendingActionApplier::class)->apply($action, $this->user);
+
+        app(PendingActionApplier::class)->revert($applied, $this->user);
+
+        $this->investment->refresh();
+        $this->assertEquals(100.0, (float) $this->investment->current_value);
+    }
+
+    public function test_record_transaction_rejects_unknown_investment(): void
+    {
+        LifeOsServer::tool(RecordTransaction::class, [
+            'investment_id' => 999999,
+            'transaction_type' => 'buy',
+            'quantity' => 1,
+            'price_per_share' => 1,
+            'transaction_date' => '2026-05-01',
+        ])->assertHasErrors(['Investment [999999] not found in this tenant.']);
+    }
+
+    public function test_record_transaction_blocks_cross_tenant_target(): void
+    {
+        $other = User::factory()->create();
+        $otherTenant = Tenant::factory()->create(['owner_id' => $other->id]);
+        $other->forceFill(['current_tenant_id' => $otherTenant->id])->save();
+
+        $this->actingAs($other);
+        $foreign = Investment::factory()->create();
+
+        $this->actingAs($this->user);
+
+        LifeOsServer::tool(RecordTransaction::class, [
+            'investment_id' => $foreign->id,
+            'transaction_type' => 'buy',
+            'quantity' => 1,
+            'price_per_share' => 1,
+            'transaction_date' => '2026-05-01',
+        ])->assertHasErrors([
+            "Investment [{$foreign->id}] not found in this tenant.",
+        ]);
+    }
+
+    public function test_bulk_import_queues_single_pending_action(): void
+    {
+        LifeOsServer::tool(BulkImportTransactions::class, [
+            'items' => [
+                [
+                    'investment_id' => $this->investment->id,
+                    'transaction_type' => 'buy',
+                    'quantity' => 5,
+                    'price_per_share' => 100,
+                    'transaction_date' => '2026-05-01',
+                    'order_id' => 'BRK-1',
+                ],
+                [
+                    'investment_id' => $this->investment->id,
+                    'transaction_type' => 'sell',
+                    'quantity' => 2,
+                    'price_per_share' => 110,
+                    'transaction_date' => '2026-05-05',
+                    'order_id' => 'BRK-2',
+                ],
+            ],
+        ])->assertOk()->assertStructuredContent(function (array $content): bool {
+            $this->assertSame(2, $content['item_count']);
+
+            return true;
+        });
+
+        $this->assertSame(1, PendingAction::query()->where('tool', 'investments.bulkImportTransactions')->count());
+    }
+}

--- a/tests/Unit/Services/Agents/IdempotencyKeyPhase5Test.php
+++ b/tests/Unit/Services/Agents/IdempotencyKeyPhase5Test.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Agents;
+
+use App\Services\Agents\IdempotencyKey;
+use Tests\TestCase;
+
+class IdempotencyKeyPhase5Test extends TestCase
+{
+    private IdempotencyKey $keys;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->keys = new IdempotencyKey;
+    }
+
+    public function test_record_transaction_anchors_on_order_id_when_present(): void
+    {
+        $a = $this->keys->for('investments.recordTransaction', 1, [
+            'investment_id' => 7,
+            'order_id' => 'BRK-12345',
+            'transaction_type' => 'buy',
+            'quantity' => 10,
+            'price_per_share' => 100,
+            'transaction_date' => '2026-05-01',
+        ]);
+
+        // Different qty + date should still collide because order_id is set.
+        $b = $this->keys->for('investments.recordTransaction', 1, [
+            'investment_id' => 7,
+            'order_id' => 'BRK-12345',
+            'transaction_type' => 'buy',
+            'quantity' => 11,
+            'price_per_share' => 99,
+            'transaction_date' => '2026-05-02',
+        ]);
+
+        $this->assertSame($a, $b);
+    }
+
+    public function test_record_transaction_falls_back_to_natural_fields(): void
+    {
+        $a = $this->keys->for('investments.recordTransaction', 1, [
+            'investment_id' => 7,
+            'transaction_type' => 'buy',
+            'quantity' => 10,
+            'price_per_share' => 100,
+            'transaction_date' => '2026-05-01',
+        ]);
+
+        $b = $this->keys->for('investments.recordTransaction', 1, [
+            'investment_id' => 7,
+            'transaction_type' => 'buy',
+            'quantity' => 10,
+            'price_per_share' => 100,
+            'transaction_date' => '2026-05-01',
+        ]);
+
+        $this->assertSame($a, $b);
+    }
+
+    public function test_record_transaction_distinguishes_by_quantity_without_order_id(): void
+    {
+        $a = $this->keys->for('investments.recordTransaction', 1, [
+            'investment_id' => 7,
+            'transaction_type' => 'buy',
+            'quantity' => 10,
+            'price_per_share' => 100,
+            'transaction_date' => '2026-05-01',
+        ]);
+
+        $b = $this->keys->for('investments.recordTransaction', 1, [
+            'investment_id' => 7,
+            'transaction_type' => 'buy',
+            'quantity' => 11,
+            'price_per_share' => 100,
+            'transaction_date' => '2026-05-01',
+        ]);
+
+        $this->assertNotSame($a, $b);
+    }
+
+    public function test_record_dividend_uses_payment_date_and_amount(): void
+    {
+        $a = $this->keys->for('investments.recordDividend', 1, [
+            'investment_id' => 7,
+            'amount' => 25.50,
+            'payment_date' => '2026-04-30',
+        ]);
+
+        $b = $this->keys->for('investments.recordDividend', 1, [
+            'investment_id' => 7,
+            'amount' => 25.50,
+            'payment_date' => '2026-04-30',
+        ]);
+
+        $this->assertSame($a, $b);
+
+        $different = $this->keys->for('investments.recordDividend', 1, [
+            'investment_id' => 7,
+            'amount' => 25.50,
+            'payment_date' => '2026-05-31',
+        ]);
+
+        $this->assertNotSame($a, $different);
+    }
+
+    public function test_reprice_lot_collapses_per_day(): void
+    {
+        $a = $this->keys->for('investments.repriceLot', 1, [
+            'investment_id' => 7,
+            'current_value' => 110,
+            'as_of' => '2026-05-07',
+        ]);
+
+        // Same as_of, different current_value — same key (one reprice per day).
+        $b = $this->keys->for('investments.repriceLot', 1, [
+            'investment_id' => 7,
+            'current_value' => 115,
+            'as_of' => '2026-05-07',
+        ]);
+
+        $this->assertSame($a, $b);
+
+        // Different day — different key.
+        $c = $this->keys->for('investments.repriceLot', 1, [
+            'investment_id' => 7,
+            'current_value' => 115,
+            'as_of' => '2026-05-08',
+        ]);
+
+        $this->assertNotSame($a, $c);
+    }
+
+    public function test_bulk_import_is_order_insensitive(): void
+    {
+        $a = $this->keys->for('investments.bulkImportTransactions', 1, [
+            'items' => [
+                ['investment_id' => 7, 'order_id' => 'A', 'transaction_type' => 'buy', 'quantity' => 1, 'price_per_share' => 1, 'transaction_date' => '2026-05-01'],
+                ['investment_id' => 8, 'order_id' => 'B', 'transaction_type' => 'sell', 'quantity' => 1, 'price_per_share' => 1, 'transaction_date' => '2026-05-02'],
+            ],
+        ]);
+
+        $b = $this->keys->for('investments.bulkImportTransactions', 1, [
+            'items' => [
+                ['investment_id' => 8, 'order_id' => 'B', 'transaction_type' => 'sell', 'quantity' => 1, 'price_per_share' => 1, 'transaction_date' => '2026-05-02'],
+                ['investment_id' => 7, 'order_id' => 'A', 'transaction_type' => 'buy', 'quantity' => 1, 'price_per_share' => 1, 'transaction_date' => '2026-05-01'],
+            ],
+        ]);
+
+        $this->assertSame($a, $b);
+    }
+}


### PR DESCRIPTION
> Stacked on PR #155 (Phase 4), which is stacked on PR #154 (Phase 3). Will retarget down the stack as PRs merge. Plan: `docs/agents/IMPLEMENTATION_PLAN.md`.

## Summary

Phase 5 adds the **investments-sync** agent: it reads broker confirmation emails (Gmail MCP) and brokerage statements (Drive MCP) and proposes recordings against the LifeOS investments module. Broker-agnostic — any MCP server you attach feeds the agent. Every proposal lands in the Pending Actions queue with deterministic per-tool idempotency keys, so re-running over the same broker confirm collapses to the same row.

### Backend

- **Migration** — `source` + `created_by_agent_token_id` on `investments`, `investment_transactions`, `investment_dividends`. Same shape as the Phase 2/4 attribution columns.
- **`App\Services\Investments\InvestmentService`** — `create()`, `recordTransaction()`, `recordDividend()`, `repriceLot()`, `bulkRecordTransactions()`. The existing `RecordInvestmentTransaction` AI tool is refactored to delegate, so the in-app assistant and the MCP server share one write path.
- **`IdempotencyKey`** gains four generators with a clear precedence:
  - `recordTransaction`: `order_id` → `confirmation_number` → `(investment, type, qty, price, date, source_email_id)`.
  - `recordDividend`: `(investment, payment_date, amount, source_email_id)`.
  - `repriceLot`: `(investment, as_of)` — collapses per day so the agent can call this once per stale position safely.
  - `bulkImportTransactions`: sorted-hash of per-item `recordTransaction` keys; reorderings collide.
- **`PendingActionApplier`** extended with validators (FormRequest-style rules), executors (with agent attribution), reverts (delete-by-id for create-style writes; restore-from-before for `repriceLot`; bulk delete for bulk imports), and human-readable previews.

### MCP write tools (registered on `LifeOsServer`)

- `investments.recordTransaction`
- `investments.recordDividend`
- `investments.repriceLot`
- `investments.bulkImportTransactions`

### Agent definition

- `agents/investments-sync/agent.json` — Gmail + Drive + LifeOS MCPs, five investments tools (one read + four writes), 15 min / 200 calls, daily at 07:00, feature flag `agents.investments_sync.enabled`.
- `agents/investments-sync/system.md` — process:
  1. Map broker symbols to `investments.portfolio` first (skip if not found, since the parent `Investment` row is user-managed).
  2. Process broker confirmation emails one tool call per record.
  3. Prefer `bulkImportTransactions` for ≥10-row statements.
  4. Mark-to-market once per session per stale position.
  
  Hard rules: no parent-row creation, no inventing prices/dates/quantities, ≤50 pending actions per run.

## Test plan

- [ ] `composer install` (CI)
- [ ] `php artisan migrate`
- [ ] `php artisan test --compact tests/Unit/Services/Agents/IdempotencyKeyPhase5Test.php tests/Feature/Mcp/Phase5InvestmentsToolsTest.php`:
  - **`IdempotencyKeyPhase5Test`** (unit): `order_id` wins over natural fields; natural-field collisions; dividend payment-date sensitivity; reprice per-day collapse; bulk-import order insensitivity.
  - **`Phase5InvestmentsToolsTest`** (feature): each MCP tool queues without mutating; idempotency dedupes; agent attribution on apply; `repriceLot` apply + revert restores prior `current_value`; unknown-investment rejection; cross-tenant rejection; bulk-import single pending action.
- [ ] `vendor/bin/pint --dirty --format agent`
- [ ] **Manual.** With `AGENT_INVESTMENTS_SYNC_ENABLED=true` (after the wiring follow-up) and a Drive folder containing one brokerage statement plus a Gmail mailbox with a couple of trade confirms, run `php artisan agents:run investments-sync --tenant=<slug>`. Inspect pending actions; approve a couple and confirm the right investment / transaction / dividend rows are created with `source = 'agent'`.

## Notes

- **No parent-`Investment` creation.** Phase 5 deliberately doesn't ship a `investments.create` tool. The user maintains the list of holdings; this phase records *activity*.
- **Config + schedule wiring deferred.** `config/agents.php` (Phase 3) and the `routes/console.php` schedule entries aren't on this branch yet (PR #154 still open). When #154 lands, a one-line follow-up adds `'agents.investments_sync.enabled' => env('AGENT_INVESTMENTS_SYNC_ENABLED', false)` to `config/agents.php` and a daily 07:00 cron entry to `routes/console.php`. Until then the agent runs only via direct `php artisan agents:run investments-sync --tenant=<slug>` invocations.
- **Auto-apply** stays plumbed-but-off, matching Phase 2's strict default. Toggle per (tenant, tool) only after watching the queue settle.
- **Specific brokers / scrapers.** Plan called out a `wvp-fondovi-scraper` skill — confirmed not needed. The agent works against whatever MCPs you attach.

## Phase gate

Phase 5 ends with a stop-and-confirm. Run the agent against your real Gmail + Drive for a session or two, approve a sample of pending actions, and confirm the resulting `investment_transactions` / `investment_dividends` rows match the broker source. Tune as needed before Phase 6 (bank/card statement processor) starts.

https://claude.ai/code/session_01AxKEBuMxrHVjg7DShsnGi2

---
_Generated by [Claude Code](https://claude.ai/code/session_01AxKEBuMxrHVjg7DShsnGi2)_