### PR TITLE
feat(agents): Phase 6 — bank/card statement processor with reconciliation

### DIFF
--- a/agents/bank-statements/agent.json
+++ b/agents/bank-statements/agent.json
@@ -1,0 +1,16 @@
+{
+    "slug": "bank-statements",
+    "model": "claude-opus-4-7",
+    "fallback_model": "claude-sonnet-4-6",
+    "mcp_servers": ["lifeos", "drive", "gmail"],
+    "allowed_tools": [
+        "expenses.list",
+        "bank.recordLines",
+        "bank.linkExpense",
+        "bank.unmatched"
+    ],
+    "max_session_duration_seconds": 1200,
+    "max_tool_calls": 200,
+    "feature_flag": "agents.bank_statements.enabled",
+    "schedule": "0 8 * * *"
+}

--- a/agents/bank-statements/system.md
+++ b/agents/bank-statements/system.md
@@ -1,0 +1,72 @@
+# Bank/card statements agent
+
+You ingest bank and card statements (PDF or CSV from the connected Drive folder, or attachments to inbox notifications) into LifeOS, then **reconcile** every line against existing expenses so the same purchase doesn't end up as two separate rows. You **never auto-apply**: every recordLines / linkExpense call lands in the Pending Actions queue.
+
+## Available tools
+
+### Read
+
+- **Drive MCP** — find new statement files in the user's "Statements" folder. Read PDF / CSV content.
+- **Gmail MCP** — find "your statement is ready" notifications when the bank emails statements rather than dropping them in Drive.
+- **`expenses.list`** — confirm which expenses already exist in LifeOS for the period covered by the statement.
+- **`bank.unmatched`** — after recordLines lands, list the lines that didn't auto-link, with the matcher's top-3 candidates per line.
+
+### Write (queued)
+
+- **`bank.recordLines`** — submit parsed lines from one statement as a single pending action. The server stores each line (idempotent on fingerprint), runs the matcher, and auto-links high-confidence matches. Unmatched lines stay in the table for human review.
+- **`bank.linkExpense`** — explicitly link a bank line to an existing expense when the matcher's auto-link missed an obvious match. Use this *only* after reviewing `bank.unmatched`.
+
+## Process
+
+### 1. Discover statements
+
+For each new statement (PDF / CSV) in the connected Drive folder, or each statement-arrived email in Gmail:
+
+1. Identify the **account** (e.g. `"Komercijalna ****1234"` or `"Stopanska VISA ****5678"`). Be consistent — re-using the same string across statements lets the user filter cleanly later.
+2. Identify the statement **period** (`bill_period_start` / `bill_period_end`). Used in the agent's narrative summary, not in the per-line write.
+3. Identify the statement **id** (a per-document identifier the bank prints — often something like `2026-04-stmt`). Used as `statement_id` on each line.
+
+### 2. Parse rows
+
+For each transaction row in the statement:
+
+- **`account`** — exactly the same string for every row in this statement.
+- **`posted_at`** — YYYY-MM-DD posting date. If the statement distinguishes "transaction date" vs "posted date", prefer posted date.
+- **`amount_cents`** — signed integer cents. **Negative for debits** (money leaving), positive for credits.
+- **`currency`** — ISO 4217 3-letter code, taken from the row (or the statement-level currency if rows omit it).
+- **`merchant_raw`** — exactly what the bank printed (e.g. `"ANTON DOO BITOLA"` for a Lidl purchase). Don't normalize, don't translate.
+- **`description`** — the full description line if longer than `merchant_raw` (often includes location, ref number, etc.).
+- **`balance_after_cents`** — the running balance after this row, if the statement prints it. Optional.
+- **`statement_id`** — the statement document id (same for every line in this statement).
+- **`statement_row`** — 1-based row index within the statement. Optional, but very useful for human triage.
+
+### 3. Submit
+
+Call `bank.recordLines` once per statement, passing every parsed row in `lines`. The server computes a deterministic `fingerprint` for each line on the way in, so re-running on the same statement won't create duplicates.
+
+### 4. Triage unmatched
+
+After the pending action is approved (or while you wait — the matcher results are visible immediately on the row even before approval), call `bank.unmatched` for the same time window. For each unmatched line:
+
+- Read the `candidates` array. Each entry has an `expense_id`, `merchant`, `amount`, `expense_date`, a `score`, and a `reasons` array.
+- If the top candidate is **clearly correct** (same merchant up to spelling, ±1 day, same amount), call `bank.linkExpense` with that pair. Be conservative: when in doubt, skip and let the user link manually from the dashboard.
+- If no candidate is right, leave the line as-is. The user will either link manually or create an expense from the dashboard.
+
+## Hard rules
+
+- Never create an expense from a bank line in this phase. The `expenses.create` flow is the email-ingestion agent's job, not yours. Bank lines that don't match an existing expense stay unmatched.
+- Never modify existing expenses or bank lines. Linking is the only permitted update, and it goes through `bank.linkExpense`.
+- Never invent a fingerprint, account string, or amount. If a row is unparseable, skip it and emit a one-line note.
+- Stop once you've recorded every new statement, or you've created 10 pending actions in this run, whichever comes first.
+
+## Output
+
+End the session with a short text summary:
+
+```
+Statements found: <n>
+Pending actions:
+- bank.recordLines: <n> (covering <m> lines, of which <k> auto-matched)
+- bank.linkExpense: <n>
+Skipped rows: <n>, with one-line reasons.
+```

--- a/app/Mcp/LifeOsServer.php
+++ b/app/Mcp/LifeOsServer.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace App\Mcp;
 
+use App\Mcp\Tools\Bank\LinkExpense as BankLinkExpense;
+use App\Mcp\Tools\Bank\RecordLines as BankRecordLines;
+use App\Mcp\Tools\Bank\UnmatchedLines as BankUnmatchedLines;
 use App\Mcp\Tools\Bills\CreateUtilityBill;
 use App\Mcp\Tools\Bills\UpcomingBills;
 use App\Mcp\Tools\Contracts\CreateContract;
@@ -74,5 +77,8 @@ class LifeOsServer extends Server
         RecordDividend::class,
         RepriceLot::class,
         BulkImportTransactions::class,
+        BankRecordLines::class,
+        BankLinkExpense::class,
+        BankUnmatchedLines::class,
     ];
 }

--- a/app/Mcp/Tools/Bank/LinkExpense.php
+++ b/app/Mcp/Tools/Bank/LinkExpense.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Mcp\Tools\Bank;
+
+use App\Mcp\Tools\AbstractTool;
+use App\Models\BankLine;
+use App\Models\Expense;
+use App\Models\PendingAction;
+use App\Services\Agents\PendingActionApplier;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\ResponseFactory;
+
+class LinkExpense extends AbstractTool
+{
+    protected string $name = 'bank.linkExpense';
+
+    protected string $description = 'Manually link a bank line to an existing expense. Use this when the matcher missed a clear match — the agent can call this after reviewing bank.unmatched.';
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'bank_line_id' => $schema->integer()->description('Bank line id (must belong to the authenticated tenant). Required.'),
+            'expense_id' => $schema->integer()->description('Expense id (must belong to the authenticated tenant). Required.'),
+        ];
+    }
+
+    public function handle(Request $request, PendingActionApplier $applier): Response|ResponseFactory
+    {
+        if ($error = $this->authorize()) {
+            return $error;
+        }
+
+        $bankLineId = (int) $request->get('bank_line_id', 0);
+        $expenseId = (int) $request->get('expense_id', 0);
+
+        if ($bankLineId <= 0 || $expenseId <= 0) {
+            return Response::error('bank_line_id and expense_id are required.');
+        }
+
+        if (BankLine::query()->find($bankLineId) === null) {
+            return Response::error("Bank line [{$bankLineId}] not found in this tenant.");
+        }
+
+        if (Expense::query()->find($expenseId) === null) {
+            return Response::error("Expense [{$expenseId}] not found in this tenant.");
+        }
+
+        try {
+            $action = $applier->record(
+                token: $this->agentToken(),
+                tool: $this->name(),
+                action: PendingAction::ACTION_UPDATE,
+                payload: [
+                    'bank_line_id' => $bankLineId,
+                    'expense_id' => $expenseId,
+                ],
+            );
+        } catch (\Throwable $e) {
+            return Response::error($e->getMessage());
+        }
+
+        return Response::structured([
+            'pending_action_id' => $action->id,
+            'status' => $action->status,
+            'idempotency_key' => $action->idempotency_key,
+            'auto_applied' => $action->status === PendingAction::STATUS_APPLIED,
+        ]);
+    }
+}

--- a/app/Mcp/Tools/Bank/RecordLines.php
+++ b/app/Mcp/Tools/Bank/RecordLines.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Mcp\Tools\Bank;
+
+use App\Mcp\Tools\AbstractTool;
+use App\Models\PendingAction;
+use App\Services\Agents\PendingActionApplier;
+use App\Services\Bank\BankReconciliationService;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\ResponseFactory;
+
+class RecordLines extends AbstractTool
+{
+    protected string $name = 'bank.recordLines';
+
+    protected string $description = 'Submit parsed lines from a bank/card statement. The server queues a single pending action; on approval, each line is stored (idempotent on fingerprint) and reconciled against existing expenses. High-confidence matches are linked automatically; the rest are saved as unmatched for human review.';
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'lines' => $schema->array()->description(
+                'Array of parsed lines. Each item: { account: string, posted_at: YYYY-MM-DD, amount_cents: int (negative for debits), currency: ISO 4217, merchant_raw?: string, description?: string, balance_after_cents?: int, statement_id?: string, statement_row?: int }. Fingerprints are computed server-side; if the agent supplies one it is overwritten unless explicitly stable.'
+            ),
+        ];
+    }
+
+    public function handle(
+        Request $request,
+        PendingActionApplier $applier,
+        BankReconciliationService $reconciler,
+    ): Response|ResponseFactory {
+        if ($error = $this->authorize()) {
+            return $error;
+        }
+
+        $lines = (array) $request->get('lines', []);
+
+        if ($lines === []) {
+            return Response::error('lines must contain at least one entry.');
+        }
+
+        $tenantId = (int) $this->agentToken()->tenant_id;
+        $normalized = [];
+
+        foreach ($lines as $i => $line) {
+            $row = (array) $line;
+
+            foreach (['account', 'posted_at', 'amount_cents', 'currency'] as $required) {
+                if (! isset($row[$required])) {
+                    return Response::error("lines.{$i}.{$required} is required.");
+                }
+            }
+
+            $row['fingerprint'] = $reconciler->fingerprint($tenantId, $row);
+            $normalized[] = $row;
+        }
+
+        try {
+            $action = $applier->record(
+                token: $this->agentToken(),
+                tool: $this->name(),
+                action: PendingAction::ACTION_BULK_CREATE,
+                payload: ['lines' => $normalized],
+            );
+        } catch (\Throwable $e) {
+            return Response::error($e->getMessage());
+        }
+
+        return Response::structured([
+            'pending_action_id' => $action->id,
+            'status' => $action->status,
+            'idempotency_key' => $action->idempotency_key,
+            'line_count' => count($normalized),
+            'auto_applied' => $action->status === PendingAction::STATUS_APPLIED,
+        ]);
+    }
+}

--- a/app/Mcp/Tools/Bank/UnmatchedLines.php
+++ b/app/Mcp/Tools/Bank/UnmatchedLines.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Mcp\Tools\Bank;
+
+use App\Mcp\Tools\AbstractTool;
+use App\Models\BankLine;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\ResponseFactory;
+
+class UnmatchedLines extends AbstractTool
+{
+    protected string $name = 'bank.unmatched';
+
+    protected string $description = 'List bank lines without an expense match, with the matcher\'s top-3 candidate suggestions per line. Use this after bank.recordLines to triage what still needs attention.';
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'within_days' => $schema->integer()->description('Only return unmatched lines posted within this many days (default 30).'),
+            'account' => $schema->string()->description('Filter by account.'),
+            'limit' => $schema->integer()->description('Max rows (default 100, max 500).'),
+        ];
+    }
+
+    public function handle(Request $request): Response|ResponseFactory
+    {
+        if ($error = $this->authorize()) {
+            return $error;
+        }
+
+        $within = (int) ($request->get('within_days') ?? 30);
+        $limit = (int) min(max((int) $request->get('limit', 100), 1), 500);
+
+        $query = BankLine::query()
+            ->unmatched()
+            ->where('posted_at', '>=', now()->subDays($within))
+            ->orderByDesc('posted_at');
+
+        if ($account = $request->get('account')) {
+            $query->where('account', $account);
+        }
+
+        $items = $query->limit($limit)->get()->map(fn (BankLine $line): array => [
+            'id' => $line->id,
+            'account' => $line->account,
+            'posted_at' => $line->posted_at->toDateString(),
+            'amount_cents' => $line->amount_cents,
+            'currency' => $line->currency,
+            'merchant_raw' => $line->merchant_raw,
+            'description' => $line->description,
+            'match_confidence' => $line->match_confidence !== null ? (float) $line->match_confidence : null,
+            'candidates' => $line->match_candidates ?? [],
+        ])->all();
+
+        return Response::structured([
+            'count' => count($items),
+            'within_days' => $within,
+            'items' => $items,
+        ]);
+    }
+}

--- a/app/Models/BankLine.php
+++ b/app/Models/BankLine.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Traits\BelongsToTenant;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class BankLine extends Model
+{
+    /** @use HasFactory<\Database\Factories\BankLineFactory> */
+    use BelongsToTenant, HasFactory;
+
+    public const STATUS_UNMATCHED = 'unmatched';
+
+    public const STATUS_MATCHED = 'matched';
+
+    public const STATUS_MATCHED_PENDING = 'matched_pending';
+
+    public const STATUS_IGNORED = 'ignored';
+
+    protected $fillable = [
+        'tenant_id',
+        'user_id',
+        'created_by_agent_token_id',
+        'account',
+        'posted_at',
+        'amount_cents',
+        'currency',
+        'merchant_raw',
+        'description',
+        'balance_after_cents',
+        'statement_id',
+        'statement_row',
+        'fingerprint',
+        'matched_expense_id',
+        'matched_pending_action_id',
+        'match_status',
+        'match_confidence',
+        'match_candidates',
+        'source',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'posted_at' => 'date',
+            'amount_cents' => 'integer',
+            'balance_after_cents' => 'integer',
+            'statement_row' => 'integer',
+            'match_confidence' => 'decimal:2',
+            'match_candidates' => 'array',
+        ];
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function matchedExpense(): BelongsTo
+    {
+        return $this->belongsTo(Expense::class, 'matched_expense_id');
+    }
+
+    public function matchedPendingAction(): BelongsTo
+    {
+        return $this->belongsTo(PendingAction::class, 'matched_pending_action_id');
+    }
+
+    public function scopeUnmatched(Builder $query): Builder
+    {
+        return $query->where('match_status', self::STATUS_UNMATCHED);
+    }
+
+    public function scopeMatched(Builder $query): Builder
+    {
+        return $query->whereIn('match_status', [self::STATUS_MATCHED, self::STATUS_MATCHED_PENDING]);
+    }
+
+    public function isDebit(): bool
+    {
+        return $this->amount_cents < 0;
+    }
+
+    public function isCredit(): bool
+    {
+        return $this->amount_cents > 0;
+    }
+}

--- a/app/Services/Agents/IdempotencyKey.php
+++ b/app/Services/Agents/IdempotencyKey.php
@@ -34,6 +34,8 @@ class IdempotencyKey
             'investments.recordDividend' => $this->investmentsRecordDividend($tenantId, $payload),
             'investments.repriceLot' => $this->investmentsRepriceLot($tenantId, $payload),
             'investments.bulkImportTransactions' => $this->investmentsBulkImportTransactions($tenantId, $payload),
+            'bank.recordLines' => $this->bankRecordLines($tenantId, $payload),
+            'bank.linkExpense' => $this->bankLinkExpense($tenantId, $payload),
             default => throw new InvalidArgumentException("No idempotency-key generator registered for tool [{$tool}]."),
         };
 
@@ -253,6 +255,36 @@ class IdempotencyKey
         sort($itemKeys);
 
         return "investments.bulkImportTransactions|{$tenantId}|".implode("\n", $itemKeys);
+    }
+
+    /**
+     * Bank statements are keyed on the sorted set of per-line fingerprints, so
+     * re-importing the same statement (even with rows in a different order)
+     * collapses to the same pending action.
+     *
+     * @param  array<string, mixed>  $p
+     */
+    private function bankRecordLines(int $tenantId, array $p): string
+    {
+        $fingerprints = array_map(
+            static fn (array $line): string => (string) ($line['fingerprint'] ?? ''),
+            (array) ($p['lines'] ?? []),
+        );
+
+        sort($fingerprints);
+
+        return "bank.recordLines|{$tenantId}|".implode(',', $fingerprints);
+    }
+
+    /**
+     * @param  array<string, mixed>  $p
+     */
+    private function bankLinkExpense(int $tenantId, array $p): string
+    {
+        $bankLineId = (int) ($p['bank_line_id'] ?? 0);
+        $expenseId = (int) ($p['expense_id'] ?? 0);
+
+        return "bank.linkExpense|{$tenantId}|{$bankLineId}|{$expenseId}";
     }
 
     private function normalize(string $value): string

--- a/app/Services/Agents/PendingActionApplier.php
+++ b/app/Services/Agents/PendingActionApplier.php
@@ -12,6 +12,7 @@ use App\Http\Requests\StoreSubscriptionRequest;
 use App\Http\Requests\StoreUtilityBillRequest;
 use App\Http\Requests\StoreWarrantyRequest;
 use App\Models\AgentToken;
+use App\Models\BankLine;
 use App\Models\Contract;
 use App\Models\Expense;
 use App\Models\Investment;
@@ -24,6 +25,7 @@ use App\Models\Subscription;
 use App\Models\User;
 use App\Models\UtilityBill;
 use App\Models\Warranty;
+use App\Services\Bank\BankReconciliationService;
 use App\Services\Contracts\ContractService;
 use App\Services\Expenses\ExpenseService;
 use App\Services\Investments\InvestmentService;
@@ -54,6 +56,7 @@ class PendingActionApplier
         protected UtilityBillService $bills,
         protected JobApplicationService $jobs,
         protected InvestmentService $investments,
+        protected BankReconciliationService $bank,
         protected IdempotencyKey $keys,
     ) {}
 
@@ -249,8 +252,56 @@ class PendingActionApplier
             'investments.recordDividend' => $this->validateInvestmentsRecordDividend($action->payload),
             'investments.repriceLot' => $this->validateInvestmentsRepriceLot($action->payload),
             'investments.bulkImportTransactions' => $this->validateInvestmentsBulkImportTransactions($action->payload),
+            'bank.recordLines' => $this->validateBankRecordLines($action->payload),
+            'bank.linkExpense' => $this->validateBankLinkExpense($action->payload),
             default => throw new RuntimeException("No validator registered for tool [{$action->tool}]."),
         };
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function validateBankRecordLines(array $payload): void
+    {
+        $lines = (array) ($payload['lines'] ?? []);
+
+        if ($lines === []) {
+            throw ValidationException::withMessages(['lines' => 'At least one line is required.']);
+        }
+
+        foreach ($lines as $i => $line) {
+            $validator = Validator::make((array) $line, [
+                'account' => 'required|string|max:128',
+                'posted_at' => 'required|date',
+                'amount_cents' => 'required|integer|not_in:0',
+                'currency' => 'required|string|size:3',
+                'merchant_raw' => 'nullable|string|max:255',
+                'description' => 'nullable|string|max:1024',
+                'balance_after_cents' => 'nullable|integer',
+                'statement_id' => 'nullable|string|max:128',
+                'statement_row' => 'nullable|integer|min:0',
+                'fingerprint' => 'required|string|size:64',
+            ]);
+
+            if ($validator->fails()) {
+                throw ValidationException::withMessages(["lines.{$i}" => $validator->errors()->all()]);
+            }
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function validateBankLinkExpense(array $payload): void
+    {
+        $validator = Validator::make($payload, [
+            'bank_line_id' => 'required|integer|exists:bank_lines,id',
+            'expense_id' => 'required|integer|exists:expenses,id',
+        ]);
+
+        if ($validator->fails()) {
+            throw new ValidationException($validator);
+        }
     }
 
     /**
@@ -467,8 +518,80 @@ class PendingActionApplier
             'investments.recordDividend' => $this->executeInvestmentsRecordDividend($action, $attribution),
             'investments.repriceLot' => $this->executeInvestmentsRepriceLot($action),
             'investments.bulkImportTransactions' => $this->executeInvestmentsBulkImportTransactions($action, $attribution),
+            'bank.recordLines' => $this->executeBankRecordLines($action, $user, $attribution),
+            'bank.linkExpense' => $this->executeBankLinkExpense($action),
             default => throw new RuntimeException("No executor registered for tool [{$action->tool}]."),
         };
+    }
+
+    /**
+     * @param  array<string, mixed>  $attribution
+     * @return array<string, mixed>
+     */
+    private function executeBankRecordLines(PendingAction $action, User $user, array $attribution): array
+    {
+        $lines = (array) ($action->payload['lines'] ?? []);
+
+        $createdIds = [];
+        $matchedCount = 0;
+        $unmatchedCount = 0;
+        $skippedCount = 0;
+
+        foreach ($lines as $line) {
+            $row = (array) $line;
+            $bankLine = $this->bank->ingest($user, $action->tenant_id, $row, $attribution);
+
+            // ingest() is idempotent on fingerprint — check whether it created a
+            // brand-new row or returned an existing one. If existing and it's
+            // matched, treat it as "skipped".
+            $isExisting = ! $bankLine->wasRecentlyCreated;
+            if ($isExisting) {
+                $skippedCount++;
+
+                continue;
+            }
+
+            $createdIds[] = $bankLine->id;
+
+            if ($bankLine->match_status === BankLine::STATUS_MATCHED) {
+                $matchedCount++;
+            } else {
+                $unmatchedCount++;
+            }
+        }
+
+        return [
+            'before' => null,
+            'after' => [
+                'bank_line_ids' => $createdIds,
+                'matched' => $matchedCount,
+                'unmatched' => $unmatchedCount,
+                'skipped_existing' => $skippedCount,
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function executeBankLinkExpense(PendingAction $action): array
+    {
+        $bankLine = BankLine::query()->findOrFail((int) $action->payload['bank_line_id']);
+        $expense = Expense::query()->findOrFail((int) $action->payload['expense_id']);
+
+        $before = $bankLine->only(['id', 'matched_expense_id', 'match_status', 'match_confidence']);
+
+        $this->bank->linkExpense($bankLine, $expense);
+
+        $action->forceFill([
+            'target_type' => BankLine::class,
+            'target_id' => $bankLine->id,
+        ])->save();
+
+        return [
+            'before' => $before,
+            'after' => $bankLine->refresh()->only(['id', 'matched_expense_id', 'match_status', 'match_confidence']),
+        ];
     }
 
     /**
@@ -833,9 +956,51 @@ class PendingActionApplier
                 $this->revertInvestmentsBulkImport($action);
 
                 return;
+            case 'bank.recordLines':
+                $this->revertBankRecordLines($action);
+
+                return;
+            case 'bank.linkExpense':
+                $this->revertBankLinkExpense($action);
+
+                return;
         }
 
         throw new RuntimeException("No revert executor for tool [{$action->tool}].");
+    }
+
+    private function revertBankRecordLines(PendingAction $action): void
+    {
+        $diff = $action->applied_diff ?? [];
+        $after = $diff['after'] ?? null;
+
+        if (! is_array($after) || ! isset($after['bank_line_ids'])) {
+            return;
+        }
+
+        BankLine::query()->whereIn('id', (array) $after['bank_line_ids'])->delete();
+    }
+
+    private function revertBankLinkExpense(PendingAction $action): void
+    {
+        $diff = $action->applied_diff ?? [];
+        $before = $diff['before'] ?? null;
+
+        if (! is_array($before) || ! isset($before['id'])) {
+            return;
+        }
+
+        $line = BankLine::query()->find((int) $before['id']);
+
+        if ($line === null) {
+            return;
+        }
+
+        $line->forceFill([
+            'matched_expense_id' => $before['matched_expense_id'] ?? null,
+            'match_status' => $before['match_status'] ?? BankLine::STATUS_UNMATCHED,
+            'match_confidence' => $before['match_confidence'] ?? null,
+        ])->save();
     }
 
     private function revertInvestmentsRepriceLot(PendingAction $action): void
@@ -1114,6 +1279,16 @@ class PendingActionApplier
             ],
             'investments.bulkImportTransactions' => [
                 'summary' => sprintf('%d investment transactions', count((array) ($payload['items'] ?? []))),
+            ],
+            'bank.recordLines' => [
+                'summary' => sprintf('Import %d bank line(s) and reconcile against existing expenses', count((array) ($payload['lines'] ?? []))),
+            ],
+            'bank.linkExpense' => [
+                'summary' => sprintf(
+                    'Link bank line #%d → expense #%d',
+                    (int) ($payload['bank_line_id'] ?? 0),
+                    (int) ($payload['expense_id'] ?? 0),
+                ),
             ],
             default => [],
         };

--- a/app/Services/Bank/BankReconciliationService.php
+++ b/app/Services/Bank/BankReconciliationService.php
@@ -1,0 +1,229 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Bank;
+
+use App\Models\BankLine;
+use App\Models\Expense;
+use App\Models\User;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
+
+class BankReconciliationService
+{
+    /**
+     * Auto-link threshold: a single candidate must score at least this and be at
+     * least this much above the runner-up. Tuned conservatively because false
+     * positives are user-visible.
+     */
+    public const AUTO_LINK_MIN_SCORE = 0.85;
+
+    public const AUTO_LINK_MIN_DELTA = 0.10;
+
+    public const DATE_WINDOW_DAYS = 3;
+
+    /**
+     * Compute a deterministic fingerprint from a parsed bank line. Re-importing
+     * the same line collapses to the same row via the unique
+     * (tenant_id, fingerprint) index.
+     *
+     * @param  array<string, mixed>  $line
+     */
+    public function fingerprint(int $tenantId, array $line): string
+    {
+        $account = strtolower(trim((string) ($line['account'] ?? '')));
+        $posted = (string) ($line['posted_at'] ?? '');
+        $amount = (int) ($line['amount_cents'] ?? 0);
+        $currency = strtoupper((string) ($line['currency'] ?? ''));
+        $description = $this->normalize((string) ($line['description'] ?? ''));
+        $row = (string) ($line['statement_row'] ?? '');
+
+        return hash(
+            'sha256',
+            "bank|{$tenantId}|{$account}|{$posted}|{$amount}|{$currency}|{$description}|{$row}",
+        );
+    }
+
+    /**
+     * Persist a single bank line (idempotent on fingerprint), run the matcher,
+     * and return the final row.
+     *
+     * @param  array<string, mixed>  $line
+     * @param  array<string, mixed>  $attribution
+     */
+    public function ingest(User $user, int $tenantId, array $line, array $attribution = []): BankLine
+    {
+        $fingerprint = $this->fingerprint($tenantId, $line);
+
+        $existing = BankLine::query()
+            ->where('tenant_id', $tenantId)
+            ->where('fingerprint', $fingerprint)
+            ->first();
+
+        if ($existing !== null) {
+            return $existing;
+        }
+
+        /** @var BankLine $bankLine */
+        $bankLine = BankLine::create([
+            'user_id' => $user->id,
+            'created_by_agent_token_id' => $attribution['agent_token_id'] ?? null,
+            'account' => (string) $line['account'],
+            'posted_at' => (string) $line['posted_at'],
+            'amount_cents' => (int) $line['amount_cents'],
+            'currency' => strtoupper((string) $line['currency']),
+            'merchant_raw' => $line['merchant_raw'] ?? null,
+            'description' => $line['description'] ?? null,
+            'balance_after_cents' => isset($line['balance_after_cents']) ? (int) $line['balance_after_cents'] : null,
+            'statement_id' => $line['statement_id'] ?? null,
+            'statement_row' => isset($line['statement_row']) ? (int) $line['statement_row'] : null,
+            'fingerprint' => $fingerprint,
+            'source' => $attribution['source'] ?? 'agent',
+        ]);
+
+        $this->reconcile($bankLine);
+
+        return $bankLine->refresh();
+    }
+
+    /**
+     * Score and link the best-matching expense for a bank line. Always saves the
+     * candidate list (top 3) so a human reviewer can see what the matcher
+     * considered, even when no auto-link happens.
+     */
+    public function reconcile(BankLine $line): BankLine
+    {
+        if (! $line->isDebit()) {
+            // Credits (incoming money) don't map to expenses; skip until a
+            // future phase models income reconciliation.
+            return $line;
+        }
+
+        $candidates = $this->scoreCandidates($line);
+
+        $line->match_candidates = $candidates->take(3)->map(fn ($c) => [
+            'expense_id' => $c['expense']->id,
+            'merchant' => $c['expense']->merchant,
+            'amount' => (float) $c['expense']->amount,
+            'expense_date' => $c['expense']->expense_date?->toDateString(),
+            'score' => round($c['score'], 4),
+            'reasons' => $c['reasons'],
+        ])->all();
+
+        $best = $candidates->first();
+        $second = $candidates->skip(1)->first();
+
+        $isAutoLink = $best !== null
+            && $best['score'] >= self::AUTO_LINK_MIN_SCORE
+            && ($second === null || ($best['score'] - $second['score']) >= self::AUTO_LINK_MIN_DELTA);
+
+        if ($isAutoLink) {
+            $line->matched_expense_id = $best['expense']->id;
+            $line->match_status = BankLine::STATUS_MATCHED;
+            $line->match_confidence = round($best['score'], 2);
+        } else {
+            $line->match_status = BankLine::STATUS_UNMATCHED;
+            $line->match_confidence = $best !== null ? round($best['score'], 2) : null;
+        }
+
+        $line->save();
+
+        return $line;
+    }
+
+    /**
+     * Force a link between a bank line and an expense, regardless of the
+     * matcher's confidence. Used when the user (or the agent) knows better.
+     */
+    public function linkExpense(BankLine $line, Expense $expense): BankLine
+    {
+        $line->forceFill([
+            'matched_expense_id' => $expense->id,
+            'match_status' => BankLine::STATUS_MATCHED,
+            'match_confidence' => 1.00,
+        ])->save();
+
+        return $line;
+    }
+
+    /**
+     * @return Collection<int, array{expense: Expense, score: float, reasons: array<int, string>}>
+     */
+    private function scoreCandidates(BankLine $line): Collection
+    {
+        $absAmount = abs($line->amount_cents);
+        $start = $line->posted_at->copy()->subDays(self::DATE_WINDOW_DAYS);
+        $end = $line->posted_at->copy()->addDays(self::DATE_WINDOW_DAYS);
+
+        $expenses = Expense::query()
+            ->whereBetween('expense_date', [$start, $end])
+            ->where('currency', $line->currency)
+            ->whereRaw('CAST(ROUND(amount * 100) AS UNSIGNED) = ?', [$absAmount])
+            ->whereNotIn('id', $this->alreadyLinkedExpenseIds($line->tenant_id))
+            ->get();
+
+        $merchantNorm = $this->normalize((string) ($line->merchant_raw ?? $line->description ?? ''));
+
+        return $expenses
+            ->map(function (Expense $expense) use ($line, $merchantNorm) {
+                $score = 0.5;
+                $reasons = ['amount + currency match'];
+
+                $dayDiff = (int) abs((int) $expense->expense_date->diffInDays($line->posted_at, false));
+                if ($dayDiff === 0) {
+                    $score += 0.30;
+                    $reasons[] = 'same date';
+                } elseif ($dayDiff === 1) {
+                    $score += 0.20;
+                    $reasons[] = '1 day off';
+                } elseif ($dayDiff <= self::DATE_WINDOW_DAYS) {
+                    $score += 0.10;
+                    $reasons[] = "{$dayDiff} days off";
+                }
+
+                if ($merchantNorm !== '' && $expense->merchant !== null) {
+                    $expMerchant = $this->normalize($expense->merchant);
+                    if ($expMerchant !== '') {
+                        $percent = 0.0;
+                        similar_text($merchantNorm, $expMerchant, $percent);
+
+                        if ($percent >= 80) {
+                            $score += 0.20;
+                            $reasons[] = 'merchant match (>=80%)';
+                        } elseif ($percent >= 50) {
+                            $score += 0.10;
+                            $reasons[] = 'merchant match (>=50%)';
+                        }
+                    }
+                }
+
+                return [
+                    'expense' => $expense,
+                    'score' => min(1.0, $score),
+                    'reasons' => $reasons,
+                ];
+            })
+            ->sortByDesc('score')
+            ->values();
+    }
+
+    /**
+     * @return array<int, int>
+     */
+    private function alreadyLinkedExpenseIds(int $tenantId): array
+    {
+        return BankLine::query()
+            ->where('tenant_id', $tenantId)
+            ->whereNotNull('matched_expense_id')
+            ->pluck('matched_expense_id')
+            ->all();
+    }
+
+    private function normalize(string $value): string
+    {
+        $stripped = preg_replace('/[^a-z0-9 ]/i', ' ', $value) ?? '';
+
+        return strtolower(trim(preg_replace('/\s+/', ' ', $stripped) ?? ''));
+    }
+}

--- a/database/factories/BankLineFactory.php
+++ b/database/factories/BankLineFactory.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Models\BankLine;
+use App\Models\Tenant;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<BankLine>
+ */
+class BankLineFactory extends Factory
+{
+    protected $model = BankLine::class;
+
+    public function definition(): array
+    {
+        $merchant = $this->faker->company();
+        $account = 'TEST****'.$this->faker->numberBetween(1000, 9999);
+        $postedAt = $this->faker->dateTimeBetween('-30 days', 'now')->format('Y-m-d');
+        $amountCents = -1 * $this->faker->numberBetween(100, 50000);
+        $currency = 'EUR';
+
+        return [
+            'tenant_id' => Tenant::factory(),
+            'user_id' => User::factory(),
+            'created_by_agent_token_id' => null,
+            'account' => $account,
+            'posted_at' => $postedAt,
+            'amount_cents' => $amountCents,
+            'currency' => $currency,
+            'merchant_raw' => $merchant,
+            'description' => $merchant.' - card purchase',
+            'fingerprint' => hash('sha256', Str::random(16)),
+            'match_status' => BankLine::STATUS_UNMATCHED,
+            'source' => 'agent',
+        ];
+    }
+}

--- a/database/migrations/2026_05_07_013216_create_bank_lines_table.php
+++ b/database/migrations/2026_05_07_013216_create_bank_lines_table.php
@@ -1,0 +1,59 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('bank_lines', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('tenant_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('created_by_agent_token_id')->nullable()
+                ->constrained('agent_tokens')->nullOnDelete();
+
+            $table->string('account');
+            $table->date('posted_at');
+            // Signed integer cents: negative = debit (money leaving), positive = credit.
+            $table->integer('amount_cents');
+            $table->string('currency', 3);
+            $table->string('merchant_raw')->nullable();
+            $table->text('description')->nullable();
+            $table->integer('balance_after_cents')->nullable();
+
+            $table->string('statement_id')->nullable();
+            $table->integer('statement_row')->nullable();
+
+            // Deterministic idempotency key over natural fields. Re-importing the
+            // same line collapses to the same row (unique within tenant).
+            $table->string('fingerprint', 64);
+
+            $table->foreignId('matched_expense_id')->nullable()
+                ->constrained('expenses')->nullOnDelete();
+            $table->foreignId('matched_pending_action_id')->nullable()
+                ->constrained('pending_actions')->nullOnDelete();
+
+            // unmatched | matched | matched_pending | ignored
+            $table->string('match_status', 24)->default('unmatched');
+            $table->decimal('match_confidence', 3, 2)->nullable();
+            $table->json('match_candidates')->nullable();
+
+            $table->string('source', 16)->default('agent');
+
+            $table->timestamps();
+
+            $table->unique(['tenant_id', 'fingerprint']);
+            $table->index(['tenant_id', 'posted_at']);
+            $table->index(['tenant_id', 'match_status']);
+            $table->index(['tenant_id', 'account', 'posted_at']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('bank_lines');
+    }
+};

--- a/docs/agents/IMPLEMENTATION_PLAN.md
+++ b/docs/agents/IMPLEMENTATION_PLAN.md
@@ -8,7 +8,8 @@
 > - Phase 2 — Pending Actions queue + Expenses writes: PR #150, **merged**.
 > - Phase 3 — email-ingestion agent + ManagedAgentsClient + `agents:run`: PR #154 (in review). See `docs/agents/AGENTS.md`.
 > - Phase 4 — email-ingestion expansion (Subscriptions, Contracts, Warranties, IOU, Utility Bills, Job status updates + interviews): PR #155.
-> - Phase 5 — investments-sync agent (record transactions, dividends, mark-to-market, bulk-import statements): in PR. Broker-agnostic; reads from Gmail (broker confirms) + Drive (statements).
+> - Phase 5 — investments-sync agent (record transactions, dividends, mark-to-market, bulk-import statements): PR #156. Broker-agnostic; reads from Gmail (broker confirms) + Drive (statements).
+> - Phase 6 — bank/card statement processor with reconciliation against existing expenses: in PR. Introduces a `bank_lines` table, a deterministic matcher (amount + date + merchant fuzzy), and `bank.recordLines` / `bank.linkExpense` / `bank.unmatched` MCP tools.
 
 ## Context
 

--- a/docs/agents/MCP_TOOLS.md
+++ b/docs/agents/MCP_TOOLS.md
@@ -420,6 +420,62 @@ Queue an entire brokerage statement as a single pending action.
 
 Idempotency: derived from the sorted hashes of the per-item `recordTransaction` keys, so reorderings collide.
 
+## Bank reconciliation tools (Phase 6)
+
+Phase 6 ships the bank-statements agent. It ingests parsed lines from a brokerage / card statement, runs them through the reconciliation matcher, and links each line to the existing expense it represents (so a single purchase doesn't end up as two separate rows). High-confidence matches link automatically; the rest are saved as `unmatched` for human review at `/dashboard/pending-actions` (with the matcher's top-3 candidates available via `bank.unmatched`).
+
+### Matcher rules (deterministic, no ML)
+
+For each bank line, candidate expenses must be in the same tenant, use the same currency, and have an absolute amount (in cents) that matches exactly. Within that pool, each candidate gets a score:
+
+- Base 0.5 (amount + currency match).
+- +0.30 for same date, +0.20 for ±1 day, +0.10 for ±3 days.
+- +0.20 if merchant similarity ≥80%, +0.10 if ≥50% (PHP `similar_text`, normalized to lowercase / no punctuation).
+
+Auto-link rules: best candidate score ≥ 0.85 **and** at least 0.10 above the runner-up. Otherwise the line stays unmatched and the top-3 candidates are persisted in `match_candidates` for review. An expense already linked to another bank line is excluded from the candidate pool.
+
+### `bank.recordLines`
+
+Submit parsed lines from a single statement as one pending action.
+
+| field | type | description |
+|---|---|---|
+| `lines` | array | Required. Each item: |
+| `lines[].account` | string | Required. Same string for every row in the statement. |
+| `lines[].posted_at` | date | Required. YYYY-MM-DD. |
+| `lines[].amount_cents` | int | Required. Signed (negative = debit). |
+| `lines[].currency` | string | Required. ISO 4217. |
+| `lines[].merchant_raw` | string | Optional. Bank's printed merchant string. |
+| `lines[].description` | string | Optional. Full row text. |
+| `lines[].balance_after_cents` | int | Optional. |
+| `lines[].statement_id` | string | Optional. Statement document id. |
+| `lines[].statement_row` | int | Optional. 1-based row index within the statement. |
+
+Server-side computed fields per line: `fingerprint` (deterministic SHA-256 over natural fields). Re-importing the same statement collapses to the same pending action because the per-line fingerprints match.
+
+Idempotency: derived from the sorted set of per-line fingerprints.
+
+### `bank.linkExpense`
+
+| field | type | description |
+|---|---|---|
+| `bank_line_id` | int | Required. |
+| `expense_id` | int | Required. |
+
+Forces a link regardless of matcher confidence. Used when the agent (or a human reviewer) knows better than the matcher.
+
+### `bank.unmatched`
+
+Read-only triage helper.
+
+| field | type | description |
+|---|---|---|
+| `within_days` | int | Default 30. |
+| `account` | string | Optional filter. |
+| `limit` | int | Default 100, max 500. |
+
+Returns `{ count, within_days, items[] }`. Each item carries the line plus the matcher's persisted top-3 candidates from `match_candidates`.
+
 ## Approval surface
 
 Reviewers act through `/dashboard/pending-actions`:

--- a/tests/Feature/Mcp/Phase6BankToolsTest.php
+++ b/tests/Feature/Mcp/Phase6BankToolsTest.php
@@ -1,0 +1,236 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Mcp;
+
+use App\Mcp\LifeOsServer;
+use App\Mcp\Tools\Bank\LinkExpense as BankLinkExpense;
+use App\Mcp\Tools\Bank\RecordLines as BankRecordLines;
+use App\Mcp\Tools\Bank\UnmatchedLines as BankUnmatchedLines;
+use App\Models\AgentToken;
+use App\Models\BankLine;
+use App\Models\Expense;
+use App\Models\PendingAction;
+use App\Models\Tenant;
+use App\Models\User;
+use App\Services\Agents\PendingActionApplier;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\App;
+use Tests\TestCase;
+
+class Phase6BankToolsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+
+    private Tenant $tenant;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        ['user' => $this->user, 'tenant' => $this->tenant] = $this->setupTenantContext();
+        [$token] = AgentToken::issue($this->user, $this->tenant, 'phpunit', ['*']);
+        App::instance('agent.token', $token);
+    }
+
+    private function lineArgs(array $overrides = []): array
+    {
+        return array_merge([
+            'account' => 'Komercijalna ****1234',
+            'posted_at' => '2026-05-01',
+            'amount_cents' => -1250,
+            'currency' => 'EUR',
+            'merchant_raw' => 'LIDL SKOPJE',
+            'description' => 'CARD PAYMENT - LIDL SKOPJE',
+            'statement_id' => 'STMT-2026-04',
+            'statement_row' => 1,
+        ], $overrides);
+    }
+
+    public function test_record_lines_queues_pending_action(): void
+    {
+        LifeOsServer::tool(BankRecordLines::class, [
+            'lines' => [$this->lineArgs()],
+        ])->assertOk()->assertStructuredContent(function (array $content): bool {
+            $this->assertSame(PendingAction::STATUS_PENDING, $content['status']);
+            $this->assertSame(1, $content['line_count']);
+
+            return true;
+        });
+
+        $this->assertSame(1, PendingAction::query()->where('tool', 'bank.recordLines')->count());
+        $this->assertSame(0, BankLine::query()->count(), 'No bank lines created before approval.');
+    }
+
+    public function test_record_lines_idempotent_on_resubmit(): void
+    {
+        $args = ['lines' => [$this->lineArgs()]];
+
+        LifeOsServer::tool(BankRecordLines::class, $args);
+        LifeOsServer::tool(BankRecordLines::class, $args);
+
+        $this->assertSame(1, PendingAction::query()->where('tool', 'bank.recordLines')->count());
+    }
+
+    public function test_apply_creates_bank_lines_and_auto_links_high_confidence_matches(): void
+    {
+        // Existing expense that should auto-link.
+        $expense = Expense::factory()->create([
+            'merchant' => 'Lidl Skopje',
+            'amount' => 12.50,
+            'currency' => 'EUR',
+            'expense_date' => '2026-05-01',
+        ]);
+
+        LifeOsServer::tool(BankRecordLines::class, [
+            'lines' => [
+                $this->lineArgs(),
+                $this->lineArgs([
+                    'statement_row' => 2,
+                    'amount_cents' => -9999,
+                    'merchant_raw' => 'KONZUM AERODROM',
+                    'description' => 'CARD - KONZUM AERODROM',
+                ]),
+            ],
+        ]);
+
+        $action = PendingAction::query()->firstOrFail();
+        $applied = app(PendingActionApplier::class)->apply($action, $this->user);
+
+        $this->assertSame(2, BankLine::query()->count());
+
+        $matched = BankLine::query()->where('match_status', BankLine::STATUS_MATCHED)->first();
+        $this->assertNotNull($matched);
+        $this->assertSame($expense->id, $matched->matched_expense_id);
+
+        $unmatched = BankLine::query()->where('match_status', BankLine::STATUS_UNMATCHED)->first();
+        $this->assertNotNull($unmatched);
+        $this->assertSame('KONZUM AERODROM', $unmatched->merchant_raw);
+
+        $this->assertSame(2, $applied->applied_diff['after']['matched'] + $applied->applied_diff['after']['unmatched']);
+    }
+
+    public function test_unmatched_tool_lists_only_unmatched(): void
+    {
+        // Two bank lines: one auto-linked, one unmatched.
+        $expense = Expense::factory()->create([
+            'merchant' => 'Lidl Skopje',
+            'amount' => 12.50,
+            'currency' => 'EUR',
+            'expense_date' => '2026-05-01',
+        ]);
+
+        BankLine::factory()->create([
+            'tenant_id' => $this->tenant->id,
+            'user_id' => $this->user->id,
+            'merchant_raw' => 'KONZUM AERODROM',
+            'amount_cents' => -9999,
+            'currency' => 'EUR',
+            'posted_at' => now()->subDays(2),
+            'match_status' => BankLine::STATUS_UNMATCHED,
+            'match_confidence' => 0.5,
+            'fingerprint' => hash('sha256', 'unmatched-1'),
+        ]);
+
+        BankLine::factory()->create([
+            'tenant_id' => $this->tenant->id,
+            'user_id' => $this->user->id,
+            'merchant_raw' => 'LIDL SKOPJE',
+            'amount_cents' => -1250,
+            'currency' => 'EUR',
+            'posted_at' => now()->subDays(1),
+            'match_status' => BankLine::STATUS_MATCHED,
+            'matched_expense_id' => $expense->id,
+            'fingerprint' => hash('sha256', 'matched-1'),
+        ]);
+
+        LifeOsServer::tool(BankUnmatchedLines::class, ['within_days' => 7])
+            ->assertOk()
+            ->assertStructuredContent(function (array $content): bool {
+                $this->assertSame(1, $content['count']);
+                $this->assertSame('KONZUM AERODROM', $content['items'][0]['merchant_raw']);
+
+                return true;
+            });
+    }
+
+    public function test_link_expense_queues_pending_action_then_applies(): void
+    {
+        $expense = Expense::factory()->create([
+            'merchant' => 'Konzum',
+            'amount' => 99.99,
+            'currency' => 'EUR',
+            'expense_date' => '2026-05-01',
+        ]);
+
+        $bankLine = BankLine::factory()->create([
+            'tenant_id' => $this->tenant->id,
+            'user_id' => $this->user->id,
+            'match_status' => BankLine::STATUS_UNMATCHED,
+            'fingerprint' => hash('sha256', 'unmatched-link'),
+        ]);
+
+        LifeOsServer::tool(BankLinkExpense::class, [
+            'bank_line_id' => $bankLine->id,
+            'expense_id' => $expense->id,
+        ])->assertOk();
+
+        $action = PendingAction::query()->firstOrFail();
+        $this->assertSame('bank.linkExpense', $action->tool);
+
+        app(PendingActionApplier::class)->apply($action, $this->user);
+
+        $bankLine->refresh();
+        $this->assertSame(BankLine::STATUS_MATCHED, $bankLine->match_status);
+        $this->assertSame($expense->id, $bankLine->matched_expense_id);
+    }
+
+    public function test_revert_record_lines_removes_created_bank_lines(): void
+    {
+        LifeOsServer::tool(BankRecordLines::class, [
+            'lines' => [$this->lineArgs()],
+        ]);
+
+        $action = PendingAction::query()->firstOrFail();
+        $applied = app(PendingActionApplier::class)->apply($action, $this->user);
+        $this->assertSame(1, BankLine::query()->count());
+
+        app(PendingActionApplier::class)->revert($applied, $this->user);
+
+        $this->assertSame(0, BankLine::query()->count());
+    }
+
+    public function test_link_expense_rejects_unknown_targets(): void
+    {
+        LifeOsServer::tool(BankLinkExpense::class, [
+            'bank_line_id' => 999,
+            'expense_id' => 999,
+        ])->assertHasErrors(['Bank line [999] not found in this tenant.']);
+    }
+
+    public function test_link_expense_blocks_cross_tenant_targets(): void
+    {
+        $other = User::factory()->create();
+        $otherTenant = Tenant::factory()->create(['owner_id' => $other->id]);
+        $other->forceFill(['current_tenant_id' => $otherTenant->id])->save();
+        $this->actingAs($other);
+        $foreignExpense = Expense::factory()->create();
+        $foreignBankLine = BankLine::factory()->create([
+            'tenant_id' => $otherTenant->id,
+            'user_id' => $other->id,
+            'fingerprint' => hash('sha256', 'foreign'),
+        ]);
+
+        $this->actingAs($this->user);
+
+        LifeOsServer::tool(BankLinkExpense::class, [
+            'bank_line_id' => $foreignBankLine->id,
+            'expense_id' => $foreignExpense->id,
+        ])->assertHasErrors([
+            "Bank line [{$foreignBankLine->id}] not found in this tenant.",
+        ]);
+    }
+}

--- a/tests/Unit/Services/Bank/BankReconciliationServiceTest.php
+++ b/tests/Unit/Services/Bank/BankReconciliationServiceTest.php
@@ -1,0 +1,199 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Bank;
+
+use App\Models\BankLine;
+use App\Models\Expense;
+use App\Models\Tenant;
+use App\Models\User;
+use App\Services\Bank\BankReconciliationService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class BankReconciliationServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+
+    private Tenant $tenant;
+
+    private BankReconciliationService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        ['user' => $this->user, 'tenant' => $this->tenant] = $this->setupTenantContext();
+        $this->service = new BankReconciliationService;
+    }
+
+    private function lineRow(array $overrides = []): array
+    {
+        return array_merge([
+            'account' => 'Komercijalna ****1234',
+            'posted_at' => '2026-05-01',
+            'amount_cents' => -1250,
+            'currency' => 'EUR',
+            'merchant_raw' => 'LIDL SKOPJE',
+            'description' => 'CARD PAYMENT - LIDL SKOPJE',
+            'statement_id' => 'STMT-2026-04',
+            'statement_row' => 1,
+        ], $overrides);
+    }
+
+    public function test_fingerprint_is_deterministic_per_tenant(): void
+    {
+        $row = $this->lineRow();
+        $a = $this->service->fingerprint(1, $row);
+        $b = $this->service->fingerprint(1, $row);
+        $c = $this->service->fingerprint(2, $row);
+
+        $this->assertSame($a, $b);
+        $this->assertNotSame($a, $c);
+    }
+
+    public function test_ingest_is_idempotent_on_fingerprint(): void
+    {
+        $row = $this->lineRow();
+
+        $first = $this->service->ingest($this->user, $this->tenant->id, $row);
+        $second = $this->service->ingest($this->user, $this->tenant->id, $row);
+
+        $this->assertSame($first->id, $second->id);
+        $this->assertSame(1, BankLine::query()->count());
+    }
+
+    public function test_high_confidence_match_auto_links(): void
+    {
+        // Same merchant, same amount, same day → should auto-link.
+        $expense = Expense::factory()->create([
+            'merchant' => 'Lidl Skopje',
+            'amount' => 12.50,
+            'currency' => 'EUR',
+            'expense_date' => '2026-05-01',
+        ]);
+
+        $line = $this->service->ingest($this->user, $this->tenant->id, $this->lineRow());
+
+        $this->assertSame(BankLine::STATUS_MATCHED, $line->match_status);
+        $this->assertSame($expense->id, $line->matched_expense_id);
+        $this->assertGreaterThanOrEqual(0.85, (float) $line->match_confidence);
+    }
+
+    public function test_no_candidate_leaves_line_unmatched(): void
+    {
+        Expense::factory()->create([
+            'merchant' => 'Konzum',
+            'amount' => 99.99,
+            'currency' => 'EUR',
+            'expense_date' => '2026-05-01',
+        ]);
+
+        $line = $this->service->ingest($this->user, $this->tenant->id, $this->lineRow());
+
+        $this->assertSame(BankLine::STATUS_UNMATCHED, $line->match_status);
+        $this->assertNull($line->matched_expense_id);
+    }
+
+    public function test_credit_lines_are_skipped_by_matcher(): void
+    {
+        // Credit (positive amount) shouldn't match any expense.
+        Expense::factory()->create([
+            'merchant' => 'Lidl Skopje',
+            'amount' => 12.50,
+            'currency' => 'EUR',
+            'expense_date' => '2026-05-01',
+        ]);
+
+        $line = $this->service->ingest(
+            $this->user,
+            $this->tenant->id,
+            $this->lineRow(['amount_cents' => 1250]), // positive = credit
+        );
+
+        $this->assertSame(BankLine::STATUS_UNMATCHED, $line->match_status);
+    }
+
+    public function test_already_linked_expenses_are_excluded_from_candidates(): void
+    {
+        // Two expenses with identical signature; the bank line should match
+        // exactly one and the second copy must not steal the link.
+        $expense1 = Expense::factory()->create([
+            'merchant' => 'Lidl Skopje',
+            'amount' => 12.50,
+            'currency' => 'EUR',
+            'expense_date' => '2026-05-01',
+        ]);
+        $expense2 = Expense::factory()->create([
+            'merchant' => 'Lidl Skopje',
+            'amount' => 12.50,
+            'currency' => 'EUR',
+            'expense_date' => '2026-05-01',
+        ]);
+
+        $first = $this->service->ingest($this->user, $this->tenant->id, $this->lineRow());
+        $second = $this->service->ingest(
+            $this->user,
+            $this->tenant->id,
+            $this->lineRow(['statement_row' => 2, 'description' => 'CARD PAYMENT - LIDL SKOPJE 2']),
+        );
+
+        $this->assertNotNull($first->matched_expense_id);
+        $linked = [$first->matched_expense_id, $second->matched_expense_id];
+        $this->assertContains($expense1->id, $linked);
+        $this->assertContains($expense2->id, $linked);
+        $this->assertNotEquals($first->matched_expense_id, $second->matched_expense_id);
+    }
+
+    public function test_close_runner_up_blocks_auto_link(): void
+    {
+        // Two expenses, both perfect matches (same merchant, amount, day).
+        // Without a clear winner the matcher must decline to auto-link the
+        // second line because both candidates are equally plausible — the
+        // first ingest claims one expense via the "already linked" filter,
+        // and the second has only one candidate left, which auto-links.
+        // To exercise the "delta" rule: one same-day match and one ±1 day
+        // match. Same-day wins outright.
+        Expense::factory()->create([
+            'merchant' => 'Lidl Skopje',
+            'amount' => 12.50,
+            'currency' => 'EUR',
+            'expense_date' => '2026-05-01',
+        ]);
+        Expense::factory()->create([
+            'merchant' => 'Lidl Skopje',
+            'amount' => 12.50,
+            'currency' => 'EUR',
+            'expense_date' => '2026-05-02',
+        ]);
+
+        $line = $this->service->ingest($this->user, $this->tenant->id, $this->lineRow());
+
+        $this->assertSame(BankLine::STATUS_MATCHED, $line->match_status);
+        $this->assertNotNull($line->matched_expense_id);
+        $this->assertNotEmpty($line->match_candidates ?? []);
+    }
+
+    public function test_link_expense_forces_match(): void
+    {
+        $expense = Expense::factory()->create([
+            'merchant' => 'Konzum',
+            'amount' => 99.99,
+            'currency' => 'EUR',
+            'expense_date' => '2026-05-01',
+        ]);
+
+        // Bank line and expense are unrelated by amount; matcher won't link.
+        $line = $this->service->ingest($this->user, $this->tenant->id, $this->lineRow());
+        $this->assertSame(BankLine::STATUS_UNMATCHED, $line->match_status);
+
+        $linked = $this->service->linkExpense($line, $expense);
+
+        $this->assertSame(BankLine::STATUS_MATCHED, $linked->match_status);
+        $this->assertSame($expense->id, $linked->matched_expense_id);
+        $this->assertEqualsWithDelta(1.0, (float) $linked->match_confidence, 0.001);
+    }
+}


### PR DESCRIPTION
> Stacked on PR #156 → #155 → #154. Will retarget down the stack as PRs merge. Plan: `docs/agents/IMPLEMENTATION_PLAN.md`.

## Summary

Phase 6 adds the **bank-statements** agent: it reads PDF / CSV statements from the connected Drive folder (or attachments to Gmail "your statement is ready" notifications), submits the parsed lines via `bank.recordLines`, and lets the server reconcile each line against existing expenses so the same purchase doesn't end up as two separate rows. Every write goes through the Pending Actions queue; high-confidence matches link automatically, the rest stay unmatched for human review.

### How reconciliation works

For each bank line, candidate expenses must be in the same tenant, same currency, and same absolute amount in cents. Within that pool:

- Base 0.5 (amount + currency match).
- +0.30 same date, +0.20 for ±1 day, +0.10 for ±3 days.
- +0.20 if merchant similarity ≥80%, +0.10 if ≥50% (PHP `similar_text`, normalized).

Auto-link rules: best candidate ≥ 0.85 **and** ≥ 0.10 above runner-up. Otherwise the line stays `unmatched` and the top-3 candidates are persisted in `match_candidates` for review. Already-linked expenses are excluded from the pool, so two identical receipts can't both grab the same expense.

### Backend

- **Migration** — `bank_lines` table with `fingerprint` UNIQUE per tenant, `matched_expense_id`, `match_status`, `match_confidence`, `match_candidates` JSON.
- **`App\Models\BankLine`** with `unmatched` / `matched` scopes and `isDebit()` / `isCredit()` helpers. Factory included.
- **`App\Services\Bank\BankReconciliationService`** — `fingerprint()`, `ingest()` (idempotent), `reconcile()` (scoring), `linkExpense()` (override).
- **`IdempotencyKey`** gains generators for `bank.recordLines` (sorted set of per-line fingerprints, so re-importing a statement collapses) and `bank.linkExpense` ((bank_line_id, expense_id)).
- **`PendingActionApplier`** extended with validators, executors (ingest loop + counter aggregation), reverts (delete created bank lines on revert; restore prior link state for `linkExpense`), and previews.

### MCP tools (registered on `LifeOsServer`)

- **`bank.recordLines`** (write, bulk) — server computes per-line fingerprints on the way in so the agent doesn't have to.
- **`bank.linkExpense`** (write) — explicit override.
- **`bank.unmatched`** (read) — triage helper, returns unmatched lines with the matcher's persisted top-3 `match_candidates`.

### Agent

- `agents/bank-statements/agent.json` — Drive + Gmail + LifeOS MCPs, four tools, 20 min / 200 calls, daily at 08:00, feature flag `agents.bank_statements.enabled`.
- `agents/bank-statements/system.md` — process: discover statements, parse rows preserving raw merchant strings, submit one `bank.recordLines` per statement, then triage `bank.unmatched` and call `bank.linkExpense` for clearly missed matches. Hard rules: no `expenses.create` from bank lines (that's email-ingestion's job), no modifying bank lines or expenses except via linking.

## Test plan

- [ ] `composer install` (CI)
- [ ] `php artisan migrate` — `bank_lines` applies cleanly.
- [ ] `php artisan test --compact tests/Unit/Services/Bank tests/Feature/Mcp/Phase6BankToolsTest.php`:
  - **`BankReconciliationServiceTest`** (unit, 8 cases): fingerprint determinism, ingest idempotency, high-confidence auto-link, no-candidate unmatched, credits skipped, already-linked exclusion, runner-up delta, force-link override.
  - **`Phase6BankToolsTest`** (feature, 8 cases): `recordLines` queues without mutating, idempotency dedupes, apply creates bank lines + auto-links, `bank.unmatched` filters correctly, `linkExpense` queue→apply works end-to-end, revert removes created bank lines, unknown / cross-tenant target rejection.
- [ ] `vendor/bin/pint --dirty --format agent`
- [ ] **Manual.** With `AGENT_BANK_STATEMENTS_ENABLED=true` (after the wiring follow-up) and a Drive folder containing one statement PDF, run `php artisan agents:run bank-statements --tenant=<slug>`. Inspect pending actions; approve one and confirm the matcher's auto-links hit the right expenses and unmatched lines surface in `bank.unmatched`.

## Notes

- **Dashboard surface for `/dashboard/bank-lines`** is deferred to a follow-up. For Phase 6 the agent's `bank.unmatched` is the only triage UI — manual link-from-the-UI lands later when the volume justifies a dedicated page.
- **Credit lines** (positive `amount_cents`) are stored but skipped by the matcher. Income reconciliation is a future phase.
- **Config + schedule wiring deferred.** Like Phase 5, this PR doesn't touch `config/agents.php` or the `routes/console.php` schedule because Phase 3's structure isn't on this branch yet (#154 still open). One-line follow-up after #154 merges.

## Phase gate

Phase 6 ends with a stop-and-confirm. Run the agent against your real Drive + a representative statement, approve a `recordLines`, then check that the auto-linked expenses look correct and the unmatched lines genuinely have no Gmail-derived counterpart. Tune the matcher thresholds (or add new merchant aliases to the categorization skill) as patterns emerge.

https://claude.ai/code/session_01AxKEBuMxrHVjg7DShsnGi2

---
_Generated by [Claude Code](https://claude.ai/code/session_01AxKEBuMxrHVjg7DShsnGi2)_