### PR TITLE
feat(agents): Phase 7 — receipts / documents OCR agent

### DIFF
--- a/agents/receipts-ocr/agent.json
+++ b/agents/receipts-ocr/agent.json
@@ -1,0 +1,19 @@
+{
+    "slug": "receipts-ocr",
+    "model": "claude-opus-4-7",
+    "fallback_model": "claude-sonnet-4-6",
+    "mcp_servers": ["lifeos", "drive"],
+    "allowed_tools": [
+        "expenses.list",
+        "warranties.list",
+        "bills.upcoming",
+        "receipts.processed",
+        "expenses.create",
+        "warranties.create",
+        "utilityBills.create"
+    ],
+    "max_session_duration_seconds": 1200,
+    "max_tool_calls": 200,
+    "feature_flag": "agents.receipts_ocr.enabled",
+    "schedule": "0 */6 * * *"
+}

--- a/agents/receipts-ocr/system.md
+++ b/agents/receipts-ocr/system.md
@@ -1,0 +1,71 @@
+# Receipts / documents OCR agent
+
+You watch the user's connected Drive folder for new receipt and bill scans (photos, PDFs of paper receipts, scanned warranty documents) and turn each one into a structured LifeOS write call. Vision is your job: every file you read is an image or a PDF, and you read it directly through the Drive MCP. You **never auto-apply**: every write tool you call lands in the Pending Actions queue.
+
+## Available tools
+
+### Read
+
+- **Drive MCP** — list and read files in the connected Receipts folder. PDFs and images come back as content you can analyze with vision.
+- **`receipts.processed`** — list of `source_file_id`s already submitted via any agent write tool. Call this **first** so you can skip files you've already OCR'd.
+- **`expenses.list`**, **`warranties.list`**, **`bills.upcoming`** — sanity-check that an extracted record isn't already in LifeOS under a different source.
+
+### Write (queued)
+
+- **`expenses.create`** — for general purchase receipts. Always set `source_file_id` to the Drive file id. Idempotency anchors include the file id, so re-submission of the same file collapses to one pending action.
+- **`warranties.create`** — when the receipt or document explicitly mentions warranty length / coverage and includes a serial / model number.
+- **`utilityBills.create`** — for utility-bill PDFs that arrived in Drive instead of Gmail.
+
+The Phase 4 email-ingestion agent owns subscriptions / contracts / IOU / job-status — those almost never come from Drive scans, so they're intentionally **not** in your allowlist.
+
+## Process
+
+### 1. Skip already-processed files
+
+Call `receipts.processed` with `within_days=60`. Build a set of file ids the agent has already submitted. As you list Drive contents, skip any file whose Drive id is in that set. **Idempotency on the write side is your safety net, but skipping here saves a vision call per file.**
+
+### 2. List and triage
+
+For each remaining file in the connected Receipts folder:
+
+1. Identify the file type (image vs PDF) and the document type (general receipt / warranty document / utility bill / unknown).
+2. If unknown, skip with a one-line note.
+3. Otherwise read the content via the Drive MCP (vision applies automatically — Anthropic's runtime decodes the image or PDF for you).
+
+### 3. Extract per type
+
+- **General receipt → `expenses.create`.**
+  - Extract: `amount`, `currency`, `expense_date`, `merchant`, `description` (a short one-line summary), `payment_method` if printed.
+  - Use the `expense-categorization` skill to assign `category` / `subcategory`. If no rule matches, use `"uncategorized"`.
+  - Set `source_file_id` to the Drive file id. Set `notes` to a short summary of any extra context worth keeping (e.g. "Items: coffee + croissant").
+- **Warranty document → both `expenses.create` AND `warranties.create`.**
+  - Submit `expenses.create` for the purchase first. Then submit `warranties.create` with `product_name`, `brand`, `model`, `serial_number` (if printed), `purchase_date`, `purchase_price`, `retailer`, `warranty_duration_months` (or `warranty_expiration_date`), `warranty_terms` (one-line). Pass the same `source_file_id` for both.
+- **Utility bill → `utilityBills.create`.**
+  - Set `utility_type` (best guess from provider / document title), `service_provider`, `bill_amount`, `currency`, `due_date`, `bill_period_end`. Pass `source_file_id`.
+
+### 4. Skip on uncertainty
+
+If the file is blurry, partially cut off, or you can't pin amount + date with confidence, **skip it**. Don't guess. Emit a one-line note explaining the skip.
+
+## Hard rules
+
+- Never auto-apply. Every write goes through Pending Actions.
+- Never invent values. Skip the file if any required field is unclear.
+- Never modify existing records. Only `expenses.create`, `warranties.create`, `utilityBills.create` are write tools available to you.
+- Always set `source_file_id` to the Drive file id on every write. Without it, repeated runs over the same file create distinct pending actions.
+- Stop once you've created 30 pending actions in this run, or you've gone 10 files without a successful classification, or you've already processed every file the user has dropped in the folder.
+
+## Output
+
+End the session with a short text summary:
+
+```
+Files seen: <n>
+Already processed (skipped): <n>
+Pending actions:
+- expenses.create: <n>
+- warranties.create: <n>
+- utilityBills.create: <n>
+Skipped:
+- <file id> — <one-line reason>
+```

--- a/app/Mcp/LifeOsServer.php
+++ b/app/Mcp/LifeOsServer.php
@@ -28,6 +28,7 @@ use App\Mcp\Tools\Jobs\AddInterview;
 use App\Mcp\Tools\Jobs\Pipeline;
 use App\Mcp\Tools\Jobs\UpdateJobStatus;
 use App\Mcp\Tools\Notifications\ListNotifications;
+use App\Mcp\Tools\Receipts\ProcessedFiles as ReceiptsProcessedFiles;
 use App\Mcp\Tools\Subscriptions\CreateSubscription;
 use App\Mcp\Tools\Subscriptions\ListSubscriptions;
 use App\Mcp\Tools\Warranties\CreateWarranty;
@@ -80,5 +81,6 @@ class LifeOsServer extends Server
         BankRecordLines::class,
         BankLinkExpense::class,
         BankUnmatchedLines::class,
+        ReceiptsProcessedFiles::class,
     ];
 }

--- a/app/Mcp/Tools/Bills/CreateUtilityBill.php
+++ b/app/Mcp/Tools/Bills/CreateUtilityBill.php
@@ -33,6 +33,7 @@ class CreateUtilityBill extends AbstractTool
             'bill_period_end' => $schema->string()->description('YYYY-MM-DD.'),
             'due_date' => $schema->string()->description('YYYY-MM-DD. Required.'),
             'source_email_id' => $schema->string()->description('Optional Gmail message id for idempotency.'),
+            'source_file_id' => $schema->string()->description('Optional Drive file id when extracted from a bill scan / PDF.'),
         ];
     }
 
@@ -56,6 +57,7 @@ class CreateUtilityBill extends AbstractTool
             'due_date' => $request->get('due_date'),
             'payment_status' => 'pending',
             'source_email_id' => $request->get('source_email_id'),
+            'source_file_id' => $request->get('source_file_id'),
         ], static fn ($v) => $v !== null);
 
         try {

--- a/app/Mcp/Tools/Expenses/CreateExpense.php
+++ b/app/Mcp/Tools/Expenses/CreateExpense.php
@@ -33,6 +33,7 @@ class CreateExpense extends AbstractTool
             'is_tax_deductible' => $schema->boolean()->description('Whether this expense is tax-deductible.'),
             'tags' => $schema->array()->description('Tag strings.'),
             'source_email_id' => $schema->string()->description('Optional Gmail message id used for idempotency disambiguation.'),
+            'source_file_id' => $schema->string()->description('Optional Drive file id when this expense was extracted from a receipt scan or PDF.'),
         ];
     }
 
@@ -57,6 +58,7 @@ class CreateExpense extends AbstractTool
             'is_tax_deductible' => $request->get('is_tax_deductible'),
             'tags' => $request->get('tags'),
             'source_email_id' => $request->get('source_email_id'),
+            'source_file_id' => $request->get('source_file_id'),
         ], static fn ($v) => $v !== null);
 
         try {

--- a/app/Mcp/Tools/Receipts/ProcessedFiles.php
+++ b/app/Mcp/Tools/Receipts/ProcessedFiles.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Mcp\Tools\Receipts;
+
+use App\Mcp\Tools\AbstractTool;
+use App\Models\PendingAction;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\ResponseFactory;
+
+/**
+ * Returns the set of `source_file_id` values already attached to pending or
+ * applied actions for the authenticated tenant. The receipts-OCR agent uses
+ * this to skip re-processing Drive files it has already submitted.
+ *
+ * Idempotency on the write side guarantees re-submission is safe; this tool
+ * exists purely as a *cost* optimization (avoid re-running vision over the
+ * same image), not as a correctness guarantee.
+ */
+class ProcessedFiles extends AbstractTool
+{
+    protected string $name = 'receipts.processed';
+
+    protected string $description = 'List Drive file ids already submitted via any agent write tool for this tenant. Use to skip re-OCR of files seen in earlier runs.';
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'within_days' => $schema->integer()->description('Only return file ids attached to actions created in the last N days (default 60).'),
+            'limit' => $schema->integer()->description('Max ids to return (default 500, max 2000).'),
+        ];
+    }
+
+    public function handle(Request $request): Response|ResponseFactory
+    {
+        if ($error = $this->authorize()) {
+            return $error;
+        }
+
+        $within = (int) ($request->get('within_days') ?? 60);
+        $limit = (int) min(max((int) $request->get('limit', 500), 1), 2000);
+
+        $rows = PendingAction::query()
+            ->where('created_at', '>=', now()->subDays($within))
+            ->whereIn('status', [
+                PendingAction::STATUS_PENDING,
+                PendingAction::STATUS_APPROVED,
+                PendingAction::STATUS_APPLIED,
+            ])
+            ->orderByDesc('created_at')
+            ->limit($limit * 4) // overshoot before deduping
+            ->get(['id', 'tool', 'payload', 'created_at']);
+
+        $seen = [];
+
+        foreach ($rows as $row) {
+            $payload = is_array($row->payload) ? $row->payload : [];
+
+            // Single-payload tools.
+            if (! empty($payload['source_file_id'])) {
+                $fileId = (string) $payload['source_file_id'];
+                $seen[$fileId] ??= [
+                    'source_file_id' => $fileId,
+                    'tool' => $row->tool,
+                    'pending_action_id' => $row->id,
+                    'first_seen_at' => $row->created_at?->toIso8601String(),
+                ];
+            }
+
+            // Bulk-style tools (e.g. expenses.bulkImport): walk items.
+            foreach ((array) ($payload['items'] ?? []) as $item) {
+                $itemFileId = is_array($item) ? ($item['source_file_id'] ?? null) : null;
+
+                if ($itemFileId !== null && $itemFileId !== '') {
+                    $fileId = (string) $itemFileId;
+                    $seen[$fileId] ??= [
+                        'source_file_id' => $fileId,
+                        'tool' => $row->tool,
+                        'pending_action_id' => $row->id,
+                        'first_seen_at' => $row->created_at?->toIso8601String(),
+                    ];
+                }
+            }
+
+            if (count($seen) >= $limit) {
+                break;
+            }
+        }
+
+        return Response::structured([
+            'count' => count($seen),
+            'within_days' => $within,
+            'items' => array_values($seen),
+        ]);
+    }
+}

--- a/app/Mcp/Tools/Warranties/CreateWarranty.php
+++ b/app/Mcp/Tools/Warranties/CreateWarranty.php
@@ -33,6 +33,7 @@ class CreateWarranty extends AbstractTool
             'warranty_type' => $schema->string()->description('"manufacturer", "extended", etc.'),
             'warranty_terms' => $schema->string()->description('Coverage details.'),
             'source_email_id' => $schema->string()->description('Optional Gmail message id for idempotency.'),
+            'source_file_id' => $schema->string()->description('Optional Drive file id when extracted from a receipt scan / PDF.'),
         ];
     }
 
@@ -56,6 +57,7 @@ class CreateWarranty extends AbstractTool
             'warranty_terms' => $request->get('warranty_terms'),
             'current_status' => 'active',
             'source_email_id' => $request->get('source_email_id'),
+            'source_file_id' => $request->get('source_file_id'),
         ], static fn ($v) => $v !== null);
 
         try {

--- a/app/Services/Agents/IdempotencyKey.php
+++ b/app/Services/Agents/IdempotencyKey.php
@@ -51,9 +51,9 @@ class IdempotencyKey
         $amount = $this->amountCents($p['amount'] ?? 0);
         $currency = strtoupper((string) ($p['currency'] ?? ''));
         $date = (string) ($p['expense_date'] ?? '');
-        $sourceEmail = (string) ($p['source_email_id'] ?? '');
+        $sourceRef = $this->sourceRef($p);
 
-        return "expenses.create|{$tenantId}|{$merchant}|{$amount}|{$currency}|{$date}|{$sourceEmail}";
+        return "expenses.create|{$tenantId}|{$merchant}|{$amount}|{$currency}|{$date}|{$sourceRef}";
     }
 
     /**
@@ -96,9 +96,9 @@ class IdempotencyKey
         $service = $this->normalize((string) ($p['service_name'] ?? ''));
         $currency = strtoupper((string) ($p['currency'] ?? ''));
         $cycle = $this->normalize((string) ($p['billing_cycle'] ?? ''));
-        $sourceEmail = (string) ($p['source_email_id'] ?? '');
+        $sourceRef = $this->sourceRef($p);
 
-        return "subscriptions.create|{$tenantId}|{$service}|{$currency}|{$cycle}|{$sourceEmail}";
+        return "subscriptions.create|{$tenantId}|{$service}|{$currency}|{$cycle}|{$sourceRef}";
     }
 
     /**
@@ -109,9 +109,9 @@ class IdempotencyKey
         $title = $this->normalize((string) ($p['title'] ?? ''));
         $counterparty = $this->normalize((string) ($p['counterparty'] ?? ''));
         $start = (string) ($p['start_date'] ?? '');
-        $sourceEmail = (string) ($p['source_email_id'] ?? '');
+        $sourceRef = $this->sourceRef($p);
 
-        return "contracts.create|{$tenantId}|{$title}|{$counterparty}|{$start}|{$sourceEmail}";
+        return "contracts.create|{$tenantId}|{$title}|{$counterparty}|{$start}|{$sourceRef}";
     }
 
     /**
@@ -122,9 +122,9 @@ class IdempotencyKey
         $product = $this->normalize((string) ($p['product_name'] ?? ''));
         $serial = $this->normalize((string) ($p['serial_number'] ?? ''));
         $purchase = (string) ($p['purchase_date'] ?? '');
-        $sourceEmail = (string) ($p['source_email_id'] ?? '');
+        $sourceRef = $this->sourceRef($p);
 
-        return "warranties.create|{$tenantId}|{$product}|{$serial}|{$purchase}|{$sourceEmail}";
+        return "warranties.create|{$tenantId}|{$product}|{$serial}|{$purchase}|{$sourceRef}";
     }
 
     /**
@@ -137,9 +137,9 @@ class IdempotencyKey
         $amount = $this->amountCents($p['amount'] ?? 0);
         $currency = strtoupper((string) ($p['currency'] ?? ''));
         $date = (string) ($p['transaction_date'] ?? '');
-        $sourceEmail = (string) ($p['source_email_id'] ?? '');
+        $sourceRef = $this->sourceRef($p);
 
-        return "iou.create|{$tenantId}|{$direction}|{$person}|{$amount}|{$currency}|{$date}|{$sourceEmail}";
+        return "iou.create|{$tenantId}|{$direction}|{$person}|{$amount}|{$currency}|{$date}|{$sourceRef}";
     }
 
     /**
@@ -153,9 +153,9 @@ class IdempotencyKey
         $currency = strtoupper((string) ($p['currency'] ?? ''));
         $due = (string) ($p['due_date'] ?? '');
         $period = (string) ($p['bill_period_end'] ?? '');
-        $sourceEmail = (string) ($p['source_email_id'] ?? '');
+        $sourceRef = $this->sourceRef($p);
 
-        return "utilityBills.create|{$tenantId}|{$type}|{$provider}|{$amount}|{$currency}|{$due}|{$period}|{$sourceEmail}";
+        return "utilityBills.create|{$tenantId}|{$type}|{$provider}|{$amount}|{$currency}|{$due}|{$period}|{$sourceRef}";
     }
 
     /**
@@ -285,6 +285,30 @@ class IdempotencyKey
         $expenseId = (int) ($p['expense_id'] ?? 0);
 
         return "bank.linkExpense|{$tenantId}|{$bankLineId}|{$expenseId}";
+    }
+
+    /**
+     * Compose a source-reference fragment for idempotency keys.
+     *
+     * Backward-compatibility contract: when only `source_email_id` is set the
+     * helper returns the legacy email-only encoding so existing pending_action
+     * keys continue to dedupe across agent runs. When `source_file_id` is also
+     * present (Phase 7's receipt OCR agent), the helper appends a `file:<id>`
+     * suffix so re-running OCR over the same Drive file collapses to the same
+     * pending action even when the OCR text drifts slightly.
+     *
+     * @param  array<string, mixed>  $p
+     */
+    private function sourceRef(array $p): string
+    {
+        $email = (string) ($p['source_email_id'] ?? '');
+        $file = (string) ($p['source_file_id'] ?? '');
+
+        if ($file === '') {
+            return $email;
+        }
+
+        return "{$email}|file:{$file}";
     }
 
     private function normalize(string $value): string

--- a/docs/agents/IMPLEMENTATION_PLAN.md
+++ b/docs/agents/IMPLEMENTATION_PLAN.md
@@ -9,7 +9,8 @@
 > - Phase 3 — email-ingestion agent + ManagedAgentsClient + `agents:run`: PR #154 (in review). See `docs/agents/AGENTS.md`.
 > - Phase 4 — email-ingestion expansion (Subscriptions, Contracts, Warranties, IOU, Utility Bills, Job status updates + interviews): PR #155.
 > - Phase 5 — investments-sync agent (record transactions, dividends, mark-to-market, bulk-import statements): PR #156. Broker-agnostic; reads from Gmail (broker confirms) + Drive (statements).
-> - Phase 6 — bank/card statement processor with reconciliation against existing expenses: in PR. Introduces a `bank_lines` table, a deterministic matcher (amount + date + merchant fuzzy), and `bank.recordLines` / `bank.linkExpense` / `bank.unmatched` MCP tools.
+> - Phase 6 — bank/card statement processor with reconciliation against existing expenses: PR #157. Introduces a `bank_lines` table, a deterministic matcher (amount + date + merchant fuzzy), and `bank.recordLines` / `bank.linkExpense` / `bank.unmatched` MCP tools.
+> - Phase 7 — receipts/documents OCR agent: in PR. Adds `source_file_id` (with backward-compatible idempotency keys) to `expenses.create`, `warranties.create`, `utilityBills.create`; new `receipts.processed` read tool to skip already-OCR'd Drive files. Vision via the user's Drive MCP — no new LifeOS infrastructure.
 
 ## Context
 

--- a/docs/agents/MCP_TOOLS.md
+++ b/docs/agents/MCP_TOOLS.md
@@ -476,6 +476,31 @@ Read-only triage helper.
 
 Returns `{ count, within_days, items[] }`. Each item carries the line plus the matcher's persisted top-3 candidates from `match_candidates`.
 
+## Receipts / OCR (Phase 7)
+
+Phase 7 adds the receipts-OCR agent. It uses Anthropic vision via the Drive MCP to extract structured fields from receipt photos and PDFs, then writes through the **existing** create-style tools — no new write tools per se, but every relevant tool now accepts a `source_file_id` and includes it in the idempotency key so re-running OCR over the same Drive file collapses to one pending action.
+
+### Tools updated to accept `source_file_id`
+
+| tool | new field | semantics |
+|---|---|---|
+| `expenses.create` | `source_file_id` | Drive file id when extracted from a receipt scan or PDF. Combined with `source_email_id` in the idempotency key. |
+| `warranties.create` | `source_file_id` | Drive file id of the warranty document or original receipt. |
+| `utilityBills.create` | `source_file_id` | Drive file id when the bill arrived as a PDF rather than an email. |
+
+Backward-compatibility: when `source_file_id` is absent, the legacy idempotency-key encoding is preserved verbatim, so existing pending-action rows continue to dedupe across agent runs. When `source_file_id` is present, the encoding extends with a `|file:<id>` suffix (still deterministic).
+
+### `receipts.processed` (read)
+
+| field | type | description |
+|---|---|---|
+| `within_days` | int | Default 60. Limit search to actions created in the last N days. |
+| `limit` | int | Default 500, max 2000. |
+
+Returns `{ count, within_days, items[] }` where each item is `{ source_file_id, tool, pending_action_id, first_seen_at }`. The agent calls this **once** at the start of a session and skips Drive files whose ids are in the result set, saving a vision call per skipped file.
+
+The tool walks both single-payload tools (`expenses.create`, `warranties.create`, `utilityBills.create`) and bulk-style tools (`expenses.bulkImport`) so any agent that attached `source_file_id` is reflected.
+
 ## Approval surface
 
 Reviewers act through `/dashboard/pending-actions`:

--- a/tests/Feature/Mcp/Phase7ReceiptsTest.php
+++ b/tests/Feature/Mcp/Phase7ReceiptsTest.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Mcp;
+
+use App\Mcp\LifeOsServer;
+use App\Mcp\Tools\Expenses\CreateExpense;
+use App\Mcp\Tools\Receipts\ProcessedFiles;
+use App\Models\AgentToken;
+use App\Models\PendingAction;
+use App\Models\Tenant;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\App;
+use Tests\TestCase;
+
+class Phase7ReceiptsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+
+    private Tenant $tenant;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        ['user' => $this->user, 'tenant' => $this->tenant] = $this->setupTenantContext();
+        [$token] = AgentToken::issue($this->user, $this->tenant, 'phpunit', ['*']);
+        App::instance('agent.token', $token);
+    }
+
+    public function test_expense_create_round_trip_with_file_id_is_idempotent(): void
+    {
+        $args = [
+            'amount' => 12.50,
+            'currency' => 'EUR',
+            'expense_date' => '2026-05-01',
+            'merchant' => 'Lidl',
+            'category' => 'groceries',
+            'description' => 'Groceries',
+            'source_file_id' => 'drive-receipt-001',
+        ];
+
+        LifeOsServer::tool(CreateExpense::class, $args);
+        LifeOsServer::tool(CreateExpense::class, $args);
+
+        $this->assertSame(1, PendingAction::query()->where('tool', 'expenses.create')->count());
+        $this->assertSame('drive-receipt-001', PendingAction::query()->first()->payload['source_file_id']);
+    }
+
+    public function test_expense_create_with_different_file_ids_creates_distinct_pending_actions(): void
+    {
+        $base = [
+            'amount' => 12.50,
+            'currency' => 'EUR',
+            'expense_date' => '2026-05-01',
+            'merchant' => 'Lidl',
+            'category' => 'groceries',
+            'description' => 'Groceries',
+        ];
+
+        LifeOsServer::tool(CreateExpense::class, [...$base, 'source_file_id' => 'drive-001']);
+        LifeOsServer::tool(CreateExpense::class, [...$base, 'source_file_id' => 'drive-002']);
+
+        $this->assertSame(2, PendingAction::query()->where('tool', 'expenses.create')->count());
+    }
+
+    public function test_processed_files_lists_seen_file_ids(): void
+    {
+        $base = [
+            'amount' => 12.50,
+            'currency' => 'EUR',
+            'expense_date' => '2026-05-01',
+            'merchant' => 'Lidl',
+            'category' => 'groceries',
+            'description' => 'Groceries',
+        ];
+
+        LifeOsServer::tool(CreateExpense::class, [...$base, 'source_file_id' => 'drive-001']);
+        LifeOsServer::tool(CreateExpense::class, [...$base, 'merchant' => 'Konzum', 'source_file_id' => 'drive-002']);
+        // A submission without a file_id should be ignored by the listing.
+        LifeOsServer::tool(CreateExpense::class, [...$base, 'merchant' => 'Tinex']);
+
+        LifeOsServer::tool(ProcessedFiles::class)
+            ->assertOk()
+            ->assertStructuredContent(function (array $content): bool {
+                $ids = collect($content['items'])->pluck('source_file_id')->all();
+                $this->assertSame(2, $content['count']);
+                $this->assertContains('drive-001', $ids);
+                $this->assertContains('drive-002', $ids);
+
+                return true;
+            });
+    }
+
+    public function test_processed_files_does_not_leak_other_tenants(): void
+    {
+        // Foreign tenant + foreign pending action with a Drive file id.
+        $other = User::factory()->create();
+        $otherTenant = Tenant::factory()->create(['owner_id' => $other->id]);
+        $other->forceFill(['current_tenant_id' => $otherTenant->id])->save();
+        [$otherToken] = AgentToken::issue($other, $otherTenant, 'foreign', ['*']);
+
+        $this->actingAs($other);
+        App::instance('agent.token', $otherToken);
+        LifeOsServer::tool(CreateExpense::class, [
+            'amount' => 99,
+            'currency' => 'EUR',
+            'expense_date' => '2026-05-01',
+            'merchant' => 'Foreign',
+            'category' => 'x',
+            'description' => 'x',
+            'source_file_id' => 'foreign-drive-id',
+        ]);
+
+        // Switch back to primary user.
+        $this->actingAs($this->user);
+        [$token] = AgentToken::issue($this->user, $this->tenant, 'primary', ['*']);
+        App::instance('agent.token', $token);
+
+        LifeOsServer::tool(ProcessedFiles::class)
+            ->assertOk()
+            ->assertStructuredContent(function (array $content): bool {
+                $this->assertSame(0, $content['count']);
+
+                return true;
+            });
+    }
+
+    public function test_processed_files_picks_up_bulk_import_items(): void
+    {
+        // Simulate a bulk import payload that carries source_file_id per item.
+        PendingAction::query()->create([
+            'tenant_id' => $this->tenant->id,
+            'user_id' => $this->user->id,
+            'tool' => 'expenses.bulkImport',
+            'action' => PendingAction::ACTION_BULK_CREATE,
+            'idempotency_key' => hash('sha256', 'phase7-bulk'),
+            'status' => PendingAction::STATUS_PENDING,
+            'payload' => [
+                'items' => [
+                    [
+                        'amount' => 5,
+                        'currency' => 'EUR',
+                        'expense_date' => '2026-05-01',
+                        'merchant' => 'Lidl',
+                        'category' => 'groceries',
+                        'description' => 'Bagel',
+                        'source_file_id' => 'drive-bulk-001',
+                    ],
+                ],
+            ],
+        ]);
+
+        LifeOsServer::tool(ProcessedFiles::class)
+            ->assertOk()
+            ->assertStructuredContent(function (array $content): bool {
+                $this->assertSame(1, $content['count']);
+                $this->assertSame('drive-bulk-001', $content['items'][0]['source_file_id']);
+
+                return true;
+            });
+    }
+}

--- a/tests/Unit/Services/Agents/IdempotencyKeyPhase7Test.php
+++ b/tests/Unit/Services/Agents/IdempotencyKeyPhase7Test.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Agents;
+
+use App\Services\Agents\IdempotencyKey;
+use Tests\TestCase;
+
+class IdempotencyKeyPhase7Test extends TestCase
+{
+    private IdempotencyKey $keys;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->keys = new IdempotencyKey;
+    }
+
+    private function expensePayload(array $overrides = []): array
+    {
+        return array_merge([
+            'amount' => 12.50,
+            'currency' => 'EUR',
+            'expense_date' => '2026-05-01',
+            'merchant' => 'Lidl',
+        ], $overrides);
+    }
+
+    public function test_legacy_email_only_keys_are_stable_across_phase7(): void
+    {
+        // The Phase 7 key generator must produce the same key for inputs that
+        // don't carry source_file_id, so existing pending_action rows continue
+        // to dedupe across agent runs.
+        $a = $this->keys->for('expenses.create', 1, $this->expensePayload([
+            'source_email_id' => 'gmail-msg-abc',
+        ]));
+
+        $expected = hash(
+            'sha256',
+            'expenses.create|1|lidl|1250|EUR|2026-05-01|gmail-msg-abc',
+        );
+
+        $this->assertSame($expected, $a);
+    }
+
+    public function test_no_source_at_all_uses_legacy_empty_suffix(): void
+    {
+        $a = $this->keys->for('expenses.create', 1, $this->expensePayload());
+
+        $expected = hash(
+            'sha256',
+            'expenses.create|1|lidl|1250|EUR|2026-05-01|',
+        );
+
+        $this->assertSame($expected, $a);
+    }
+
+    public function test_file_id_changes_the_key_when_email_id_is_absent(): void
+    {
+        $emailOnly = $this->keys->for('expenses.create', 1, $this->expensePayload());
+        $withFile = $this->keys->for('expenses.create', 1, $this->expensePayload([
+            'source_file_id' => 'drive-abc',
+        ]));
+
+        $this->assertNotSame($emailOnly, $withFile);
+    }
+
+    public function test_same_file_id_collapses_resubmits(): void
+    {
+        $a = $this->keys->for('expenses.create', 1, $this->expensePayload([
+            'source_file_id' => 'drive-abc',
+        ]));
+        $b = $this->keys->for('expenses.create', 1, $this->expensePayload([
+            'source_file_id' => 'drive-abc',
+        ]));
+
+        $this->assertSame($a, $b);
+    }
+
+    public function test_different_file_ids_distinguish_otherwise_identical_payloads(): void
+    {
+        $a = $this->keys->for('expenses.create', 1, $this->expensePayload([
+            'source_file_id' => 'drive-abc',
+        ]));
+        $b = $this->keys->for('expenses.create', 1, $this->expensePayload([
+            'source_file_id' => 'drive-xyz',
+        ]));
+
+        $this->assertNotSame($a, $b);
+    }
+
+    public function test_email_id_plus_file_id_appends_file_suffix(): void
+    {
+        $a = $this->keys->for('expenses.create', 1, $this->expensePayload([
+            'source_email_id' => 'gmail-1',
+            'source_file_id' => 'drive-1',
+        ]));
+
+        $expected = hash(
+            'sha256',
+            'expenses.create|1|lidl|1250|EUR|2026-05-01|gmail-1|file:drive-1',
+        );
+
+        $this->assertSame($expected, $a);
+    }
+
+    public function test_warranties_create_honours_file_id(): void
+    {
+        $a = $this->keys->for('warranties.create', 1, [
+            'product_name' => 'Laptop',
+            'serial_number' => 'ABC',
+            'purchase_date' => '2026-05-01',
+            'source_file_id' => 'drive-receipt-1',
+        ]);
+        $b = $this->keys->for('warranties.create', 1, [
+            'product_name' => 'Laptop',
+            'serial_number' => 'ABC',
+            'purchase_date' => '2026-05-01',
+            'source_file_id' => 'drive-receipt-1',
+        ]);
+        $c = $this->keys->for('warranties.create', 1, [
+            'product_name' => 'Laptop',
+            'serial_number' => 'ABC',
+            'purchase_date' => '2026-05-01',
+            'source_file_id' => 'drive-receipt-2',
+        ]);
+
+        $this->assertSame($a, $b);
+        $this->assertNotSame($a, $c);
+    }
+
+    public function test_utility_bills_create_honours_file_id(): void
+    {
+        $a = $this->keys->for('utilityBills.create', 1, [
+            'utility_type' => 'electricity',
+            'service_provider' => 'EVN',
+            'bill_amount' => 100,
+            'currency' => 'EUR',
+            'due_date' => '2026-05-15',
+            'source_file_id' => 'drive-bill-1',
+        ]);
+        $b = $this->keys->for('utilityBills.create', 1, [
+            'utility_type' => 'electricity',
+            'service_provider' => 'EVN',
+            'bill_amount' => 100,
+            'currency' => 'EUR',
+            'due_date' => '2026-05-15',
+            'source_file_id' => 'drive-bill-1',
+        ]);
+
+        $this->assertSame($a, $b);
+    }
+}


### PR DESCRIPTION
> Stacked on PR #157 → #156 → #155 → #154. Will retarget down the stack as PRs merge. Plan: `docs/agents/IMPLEMENTATION_PLAN.md`.

## Summary

Phase 7 adds the **receipts-OCR** agent. It watches the user's connected Drive folder for receipt photos / PDFs / scanned warranty documents, uses Anthropic vision (passed through the Drive MCP) to extract structured fields, and writes through the **existing** create-style tools. No new LifeOS infrastructure beyond a single `source_file_id` field and a tiny read tool that lets the agent skip files it has already processed.

### How it stays small

Every relevant tool already exists (`expenses.create`, `warranties.create`, `utilityBills.create`). What's new:

1. **`source_file_id`** flows through to the idempotency key, so re-running OCR over the same Drive file collapses to one pending action — even if the OCR text drifts slightly between runs.
2. **`receipts.processed`** is a one-call helper the agent uses at session start to skip files it has already OCR'd. Idempotency on the write side is the correctness safety net; this tool is the *cost* optimization (avoids a vision call per skipped file).

### Backend

- **`IdempotencyKey::sourceRef()`** — backward-compatible helper. Legacy email-only inputs produce identical keys to Phase 4/5/6, so existing pending-action rows continue to dedupe. With `source_file_id` present, the encoding extends with a deterministic `|file:<id>` suffix.
- Applied to `expenses.create`, `subscriptions.create`, `contracts.create`, `warranties.create`, `iou.create`, `utilityBills.create`.

### MCP tool changes

- **`expenses.create`**, **`warranties.create`**, **`utilityBills.create`** gain an optional `source_file_id` field. It flows into the payload and the idempotency key.
- **New read tool `receipts.processed`** — returns the set of `source_file_id`s attached to pending or applied actions for the authenticated tenant in the last N days. Walks single-payload tools and bulk-import items.

### Agent

- `agents/receipts-ocr/agent.json` — Drive + LifeOS MCPs, seven tools (four reads + three writes), 20 min / 200 calls, every 6 hours, feature flag `agents.receipts_ocr.enabled`.
- `agents/receipts-ocr/system.md` — process:
  1. Call `receipts.processed` first to build a skip-set.
  2. Classify each remaining Drive file: general receipt / warranty doc / utility bill / unknown.
  3. Extract per type, always setting `source_file_id` on every write.
  4. Skip on uncertainty, ≤30 pending actions per run.

## Test plan

- [ ] `composer install` (CI)
- [ ] `php artisan test --compact tests/Unit/Services/Agents/IdempotencyKeyPhase7Test.php tests/Feature/Mcp/Phase7ReceiptsTest.php`:
  - **`IdempotencyKeyPhase7Test`** (unit, 8 cases): legacy email-only inputs produce identical keys (backward-compat invariant); no source uses the legacy empty suffix; file_id alone changes the key; same file_id collapses resubmits; different file_ids distinguish; email+file appends the file suffix; warranties + utilityBills honor file_id symmetrically.
  - **`Phase7ReceiptsTest`** (feature, 5 cases): expense create with file_id is idempotent; different file_ids create distinct pending actions; `receipts.processed` lists seen file_ids; doesn't leak across tenants; picks up bulk-import items.
- [ ] `vendor/bin/pint --dirty --format agent`
- [ ] **Manual.** With `AGENT_RECEIPTS_OCR_ENABLED=true` (after the wiring follow-up) and a Drive folder containing one receipt photo + one warranty PDF, run `php artisan agents:run receipts-ocr --tenant=<slug>`. Inspect pending actions; approve a sample and confirm the right `expenses.create` + `warranties.create` rows land with `source_file_id` populated.

## Notes

- **Vision** is handled by the Anthropic runtime when the agent reads a Drive file through the Drive MCP. No LifeOS code path passes image bytes — this PR is about giving the agent the right idempotency primitives and a way to deduplicate work, not about adding vision plumbing.
- **Backward-compatibility invariant** is tested explicitly: `IdempotencyKeyPhase7Test::test_legacy_email_only_keys_are_stable_across_phase7` asserts the exact pre-Phase-7 key for an email-only payload still matches.
- **Config + schedule wiring** depends on PR #154's `config/agents.php` and `routes/console.php` structure; same one-line follow-up pattern as Phases 5 and 6.

## Phase gate

Run `agents:run receipts-ocr --tenant=<slug>` against your real Receipts folder. Approve a sample and verify: (a) re-running the agent doesn't create duplicate pending actions for the same files (idempotency working), and (b) `receipts.processed` correctly skips them on the next run (the cost optimization working). Tune the system prompt's classification rules if some receipt types get misrouted before Phase 8 starts.

https://claude.ai/code/session_01AxKEBuMxrHVjg7DShsnGi2

---
_Generated by [Claude Code](https://claude.ai/code/session_01AxKEBuMxrHVjg7DShsnGi2)_