### PR TITLE
Add job-search and cycle-menu-planner agents with Phase 8-9 tools

### DIFF
--- a/agents/cycle-menu-planner/agent.json
+++ b/agents/cycle-menu-planner/agent.json
@@ -1,0 +1,17 @@
+{
+    "slug": "cycle-menu-planner",
+    "model": "claude-sonnet-4-6",
+    "fallback_model": "claude-haiku-4-5-20251001",
+    "mcp_servers": ["lifeos"],
+    "allowed_tools": [
+        "cycleMenu.currentWeek",
+        "cycleMenu.shoppingList",
+        "cycleMenu.addItem",
+        "cycleMenu.setWeek",
+        "expenses.list"
+    ],
+    "max_session_duration_seconds": 600,
+    "max_tool_calls": 100,
+    "feature_flag": "agents.cycle_menu_planner.enabled",
+    "schedule": "0 9 * * 0"
+}

--- a/agents/cycle-menu-planner/system.md
+++ b/agents/cycle-menu-planner/system.md
@@ -1,0 +1,66 @@
+# Cycle-menu planner agent
+
+You plan the meals for the upcoming week based on the user's existing cycle menu, then generate a shopping list aggregating what's needed. You **never auto-apply**: every write tool you call lands in the Pending Actions queue.
+
+## Available tools
+
+### Read
+
+- **`cycleMenu.currentWeek`** — see what's currently scheduled across the next 7 days, mapped against the active rotation.
+- **`cycleMenu.shoppingList`** — aggregate the next N days into a structured shopping list. Use this **after** any `setWeek` / `addItem` calls to produce the final report.
+- **`expenses.list`** — optionally check recent grocery expenses (category=`groceries`) to ground the shopping list in what was bought lately.
+
+### Write (queued)
+
+- **`cycleMenu.setWeek`** — bulk-replace items across multiple day_indexes in one pending action. **Preferred** when planning a whole week. Existing items on those days are deleted on apply; revert restores them.
+- **`cycleMenu.addItem`** — add a single item to a single day. Use for surgical edits ("add a snack to day 3"), not for whole-week planning.
+
+## Process
+
+### 1. Read the current state
+
+Call `cycleMenu.currentWeek`. Note:
+
+- Whether an active menu exists. If none, exit with a one-line note. Don't create a menu — the user does that.
+- Today's `day_index` in the rotation.
+- Which days for the next 7 are already populated and which are empty.
+
+### 2. Plan only the gaps
+
+The user maintains the rotation. Your job is to **fill empty days, not overwrite populated ones.**
+
+- For each of the next 7 days that is empty (no items in `cycleMenu.currentWeek`), propose a sensible meal set: breakfast, lunch, dinner. Snack/other are optional.
+- For each item, choose `meal_type`, a clear `title`, and (when natural) a `quantity` string like `"1 serving"` or `"250 g"`. `time_of_day` is optional; only set it when a slot is time-bound (e.g. `"08:00"` for breakfast).
+
+If you propose changes spanning multiple empty days, batch them via `cycleMenu.setWeek`. If you only have a single-item addition (e.g. one missing snack), use `cycleMenu.addItem`.
+
+### 3. Don't overwrite
+
+If a day already has items, leave it alone. If you believe an item is poorly placed (e.g. a heavy dinner on a "light" day), record that as a one-line note in your run summary — do **not** call `setWeek` to replace it. Replacement is the user's call.
+
+### 4. Generate the shopping list
+
+After planning is complete (or if no planning was needed), call `cycleMenu.shoppingList` with `window_days=7`. Include the structured result in your run summary so the user can copy it into a notes app or grocery shopping app.
+
+## Hard rules
+
+- Never auto-apply.
+- Never create a parent `CycleMenu` row. The rotation is user-owned.
+- Never overwrite an already-populated day. Only fill empty days.
+- Never invent ingredients in the shopping list. The list aggregates the items you and the user already chose; quantity is whatever string the schema carries.
+- Stop once you've created 5 pending actions in this run, or you've planned every empty day for the next 7, whichever comes first.
+
+## Output
+
+End the session with a short text summary:
+
+```
+Active menu: <name> (cycle_length_days=N, today_day_index=K)
+Empty days in next 7: <list>
+Pending actions:
+- cycleMenu.setWeek: <n> (covering <m> day_indexes, <p> items)
+- cycleMenu.addItem: <n>
+Shopping list (next 7 days):
+- <title> × <count>  [<meal_type>; quantities: <list>]
+- ...
+```

--- a/app/Mcp/LifeOsServer.php
+++ b/app/Mcp/LifeOsServer.php
@@ -11,7 +11,10 @@ use App\Mcp\Tools\Bills\CreateUtilityBill;
 use App\Mcp\Tools\Bills\UpcomingBills;
 use App\Mcp\Tools\Contracts\CreateContract;
 use App\Mcp\Tools\Contracts\ListContracts;
+use App\Mcp\Tools\CycleMenu\AddItem as CycleMenuAddItem;
 use App\Mcp\Tools\CycleMenu\CurrentWeekCycleMenu;
+use App\Mcp\Tools\CycleMenu\SetWeek as CycleMenuSetWeek;
+use App\Mcp\Tools\CycleMenu\ShoppingList as CycleMenuShoppingList;
 use App\Mcp\Tools\Dashboard\Summary;
 use App\Mcp\Tools\Expenses\BulkImportExpenses;
 use App\Mcp\Tools\Expenses\CategorizeExpense;
@@ -84,5 +87,8 @@ class LifeOsServer extends Server
         BankLinkExpense::class,
         BankUnmatchedLines::class,
         ReceiptsProcessedFiles::class,
+        CycleMenuAddItem::class,
+        CycleMenuSetWeek::class,
+        CycleMenuShoppingList::class,
     ];
 }

--- a/app/Mcp/Tools/CycleMenu/AddItem.php
+++ b/app/Mcp/Tools/CycleMenu/AddItem.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Mcp\Tools\CycleMenu;
+
+use App\Mcp\Tools\AbstractTool;
+use App\Models\CycleMenu;
+use App\Models\PendingAction;
+use App\Services\Agents\PendingActionApplier;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\ResponseFactory;
+
+class AddItem extends AbstractTool
+{
+    protected string $name = 'cycleMenu.addItem';
+
+    protected string $description = 'Add a single item to a specific day of an existing cycle menu. Idempotent on (menu, day_index, title, meal_type).';
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'cycle_menu_id' => $schema->integer()->description('Cycle menu id (must belong to the authenticated tenant). Required.'),
+            'day_index' => $schema->integer()->description('0-based day in the rotation. Required.'),
+            'title' => $schema->string()->description('Dish name. Required.'),
+            'meal_type' => $schema->string()->description('"breakfast", "lunch", "dinner", "snack", or "other". Required.'),
+            'time_of_day' => $schema->string()->description('Optional HH:MM.'),
+            'quantity' => $schema->string()->description('Optional free-text serving (e.g. "1 bowl", "250 g").'),
+        ];
+    }
+
+    public function handle(Request $request, PendingActionApplier $applier): Response|ResponseFactory
+    {
+        if ($error = $this->authorize()) {
+            return $error;
+        }
+
+        $menuId = (int) $request->get('cycle_menu_id', 0);
+
+        if ($menuId <= 0) {
+            return Response::error('cycle_menu_id is required.');
+        }
+
+        $menu = CycleMenu::query()->find($menuId);
+
+        if ($menu === null) {
+            return Response::error("Cycle menu [{$menuId}] not found in this tenant.");
+        }
+
+        $payload = array_filter([
+            'cycle_menu_id' => $menu->id,
+            'day_index' => $request->get('day_index'),
+            'title' => $request->get('title'),
+            'meal_type' => $request->get('meal_type'),
+            'time_of_day' => $request->get('time_of_day'),
+            'quantity' => $request->get('quantity'),
+        ], static fn ($v) => $v !== null);
+
+        try {
+            $action = $applier->record(
+                token: $this->agentToken(),
+                tool: $this->name(),
+                action: PendingAction::ACTION_CREATE,
+                payload: $payload,
+            );
+        } catch (\Throwable $e) {
+            return Response::error($e->getMessage());
+        }
+
+        return Response::structured([
+            'pending_action_id' => $action->id,
+            'status' => $action->status,
+            'idempotency_key' => $action->idempotency_key,
+            'auto_applied' => $action->status === PendingAction::STATUS_APPLIED,
+        ]);
+    }
+}

--- a/app/Mcp/Tools/CycleMenu/SetWeek.php
+++ b/app/Mcp/Tools/CycleMenu/SetWeek.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Mcp\Tools\CycleMenu;
+
+use App\Mcp\Tools\AbstractTool;
+use App\Models\CycleMenu;
+use App\Models\PendingAction;
+use App\Services\Agents\PendingActionApplier;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\ResponseFactory;
+
+class SetWeek extends AbstractTool
+{
+    protected string $name = 'cycleMenu.setWeek';
+
+    protected string $description = 'Replace the items on multiple consecutive day_indexes of a cycle menu in one transaction. Existing items on those days are deleted; revert restores them. Idempotent on (menu, sorted day list, sorted item set per day).';
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'cycle_menu_id' => $schema->integer()->description('Cycle menu id. Required.'),
+            'items_by_day_index' => $schema->object()->description(
+                'Map of day_index → list of items. Each item: { title, meal_type, time_of_day?, quantity? }. Required.'
+            ),
+        ];
+    }
+
+    public function handle(Request $request, PendingActionApplier $applier): Response|ResponseFactory
+    {
+        if ($error = $this->authorize()) {
+            return $error;
+        }
+
+        $menuId = (int) $request->get('cycle_menu_id', 0);
+
+        if ($menuId <= 0) {
+            return Response::error('cycle_menu_id is required.');
+        }
+
+        $menu = CycleMenu::query()->find($menuId);
+
+        if ($menu === null) {
+            return Response::error("Cycle menu [{$menuId}] not found in this tenant.");
+        }
+
+        $itemsByDay = (array) $request->get('items_by_day_index', []);
+
+        if ($itemsByDay === []) {
+            return Response::error('items_by_day_index must contain at least one day.');
+        }
+
+        $cycleLength = (int) $menu->cycle_length_days;
+        foreach (array_keys($itemsByDay) as $dayIndex) {
+            $idx = (int) $dayIndex;
+            if ($idx < 0 || $idx >= $cycleLength) {
+                return Response::error("day_index {$idx} is outside menu cycle (0..".($cycleLength - 1).').');
+            }
+        }
+
+        try {
+            $action = $applier->record(
+                token: $this->agentToken(),
+                tool: $this->name(),
+                action: PendingAction::ACTION_BULK_CREATE,
+                payload: [
+                    'cycle_menu_id' => $menu->id,
+                    'items_by_day_index' => $itemsByDay,
+                ],
+            );
+        } catch (\Throwable $e) {
+            return Response::error($e->getMessage());
+        }
+
+        $itemTotal = collect($itemsByDay)->sum(fn ($items) => count((array) $items));
+
+        return Response::structured([
+            'pending_action_id' => $action->id,
+            'status' => $action->status,
+            'idempotency_key' => $action->idempotency_key,
+            'day_count' => count($itemsByDay),
+            'item_count' => $itemTotal,
+            'auto_applied' => $action->status === PendingAction::STATUS_APPLIED,
+        ]);
+    }
+}

--- a/app/Mcp/Tools/CycleMenu/ShoppingList.php
+++ b/app/Mcp/Tools/CycleMenu/ShoppingList.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Mcp\Tools\CycleMenu;
+
+use App\Mcp\Tools\AbstractTool;
+use App\Models\CycleMenu;
+use App\Services\CycleMenu\CycleMenuService;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\ResponseFactory;
+
+class ShoppingList extends AbstractTool
+{
+    protected string $name = 'cycleMenu.shoppingList';
+
+    protected string $description = 'Aggregate the items scheduled across the next N days (default 7) of the active cycle menu into a structured shopping list. Read-only. Free-text quantities are returned as a list rather than summed because the schema doesn\'t carry units.';
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'cycle_menu_id' => $schema->integer()->description('Cycle menu id. Optional — defaults to the tenant\'s active menu.'),
+            'window_days' => $schema->integer()->description('How many days forward to aggregate. Default 7, max 30.'),
+        ];
+    }
+
+    public function handle(Request $request, CycleMenuService $service): Response|ResponseFactory
+    {
+        if ($error = $this->authorize()) {
+            return $error;
+        }
+
+        $window = (int) min(max((int) ($request->get('window_days') ?? 7), 1), 30);
+
+        $menu = null;
+        $menuId = (int) $request->get('cycle_menu_id', 0);
+
+        if ($menuId > 0) {
+            $menu = CycleMenu::query()->find($menuId);
+
+            if ($menu === null) {
+                return Response::error("Cycle menu [{$menuId}] not found in this tenant.");
+            }
+        } else {
+            $menu = CycleMenu::query()->where('is_active', true)->orderByDesc('id')->first();
+
+            if ($menu === null) {
+                return Response::structured([
+                    'menu' => null,
+                    'window_days' => $window,
+                    'items' => [],
+                ]);
+            }
+        }
+
+        $items = $service->shoppingList($menu, $window);
+
+        return Response::structured([
+            'menu' => [
+                'id' => $menu->id,
+                'name' => $menu->name,
+                'cycle_length_days' => (int) $menu->cycle_length_days,
+            ],
+            'window_days' => $window,
+            'item_count' => count($items),
+            'items' => $items,
+        ]);
+    }
+}

--- a/app/Services/Agents/IdempotencyKey.php
+++ b/app/Services/Agents/IdempotencyKey.php
@@ -31,6 +31,8 @@ class IdempotencyKey
             'jobs.updateStatus' => $this->jobsUpdateStatus($tenantId, $payload),
             'jobs.addInterview' => $this->jobsAddInterview($tenantId, $payload),
             'jobs.createApplication' => $this->jobsCreateApplication($tenantId, $payload),
+            'cycleMenu.addItem' => $this->cycleMenuAddItem($tenantId, $payload),
+            'cycleMenu.setWeek' => $this->cycleMenuSetWeek($tenantId, $payload),
             'investments.recordTransaction' => $this->investmentsRecordTransaction($tenantId, $payload),
             'investments.recordDividend' => $this->investmentsRecordDividend($tenantId, $payload),
             'investments.repriceLot' => $this->investmentsRepriceLot($tenantId, $payload),
@@ -206,6 +208,56 @@ class IdempotencyKey
         $anchor = $sourceRef !== '' ? $sourceRef : strtolower(trim($url));
 
         return "jobs.createApplication|{$tenantId}|{$company}|{$title}|{$anchor}";
+    }
+
+    /**
+     * Cycle-menu item add. Anchors on (tenant, menu, day_index, normalized
+     * title, meal_type). Re-running with the same item collapses, but adding
+     * a second copy of the same dish on the same day is intentional and
+     * goes through linked write paths (different position).
+     *
+     * @param  array<string, mixed>  $p
+     */
+    private function cycleMenuAddItem(int $tenantId, array $p): string
+    {
+        $menuId = (int) ($p['cycle_menu_id'] ?? 0);
+        $dayIndex = (int) ($p['day_index'] ?? -1);
+        $title = $this->normalize((string) ($p['title'] ?? ''));
+        $mealType = $this->normalize((string) ($p['meal_type'] ?? ''));
+
+        return "cycleMenu.addItem|{$tenantId}|{$menuId}|{$dayIndex}|{$title}|{$mealType}";
+    }
+
+    /**
+     * Cycle-menu set-week. Anchors on (tenant, menu, sorted day-index list,
+     * canonicalized item set per day). Re-running the same plan collapses;
+     * tweaking any item produces a distinct key.
+     *
+     * @param  array<string, mixed>  $p
+     */
+    private function cycleMenuSetWeek(int $tenantId, array $p): string
+    {
+        $menuId = (int) ($p['cycle_menu_id'] ?? 0);
+        $itemsByDayIndex = (array) ($p['items_by_day_index'] ?? []);
+
+        ksort($itemsByDayIndex);
+
+        $perDay = [];
+
+        foreach ($itemsByDayIndex as $dayIndex => $items) {
+            $rows = array_map(
+                fn (array $item): string => sprintf(
+                    '%s/%s',
+                    $this->normalize((string) ($item['title'] ?? '')),
+                    $this->normalize((string) ($item['meal_type'] ?? '')),
+                ),
+                (array) $items,
+            );
+            sort($rows);
+            $perDay[] = "{$dayIndex}=".implode(',', $rows);
+        }
+
+        return "cycleMenu.setWeek|{$tenantId}|{$menuId}|".implode(';', $perDay);
     }
 
     /**

--- a/app/Services/Agents/PendingActionApplier.php
+++ b/app/Services/Agents/PendingActionApplier.php
@@ -14,6 +14,8 @@ use App\Http\Requests\StoreWarrantyRequest;
 use App\Models\AgentToken;
 use App\Models\BankLine;
 use App\Models\Contract;
+use App\Models\CycleMenu;
+use App\Models\CycleMenuItem;
 use App\Models\Expense;
 use App\Models\Investment;
 use App\Models\InvestmentDividend;
@@ -27,6 +29,7 @@ use App\Models\UtilityBill;
 use App\Models\Warranty;
 use App\Services\Bank\BankReconciliationService;
 use App\Services\Contracts\ContractService;
+use App\Services\CycleMenu\CycleMenuService;
 use App\Services\Expenses\ExpenseService;
 use App\Services\Investments\InvestmentService;
 use App\Services\Iou\IouService;
@@ -57,6 +60,7 @@ class PendingActionApplier
         protected JobApplicationService $jobs,
         protected InvestmentService $investments,
         protected BankReconciliationService $bank,
+        protected CycleMenuService $cycleMenus,
         protected IdempotencyKey $keys,
     ) {}
 
@@ -255,6 +259,8 @@ class PendingActionApplier
             'investments.bulkImportTransactions' => $this->validateInvestmentsBulkImportTransactions($action->payload),
             'bank.recordLines' => $this->validateBankRecordLines($action->payload),
             'bank.linkExpense' => $this->validateBankLinkExpense($action->payload),
+            'cycleMenu.addItem' => $this->validateCycleMenuAddItem($action->payload),
+            'cycleMenu.setWeek' => $this->validateCycleMenuSetWeek($action->payload),
             default => throw new RuntimeException("No validator registered for tool [{$action->tool}]."),
         };
     }
@@ -287,6 +293,45 @@ class PendingActionApplier
             if ($validator->fails()) {
                 throw ValidationException::withMessages(["lines.{$i}" => $validator->errors()->all()]);
             }
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function validateCycleMenuAddItem(array $payload): void
+    {
+        $validator = Validator::make($payload, [
+            'cycle_menu_id' => 'required|integer|exists:cycle_menus,id',
+            'day_index' => 'required|integer|min:0',
+            'title' => 'required|string|max:255',
+            'meal_type' => 'required|string|max:32',
+            'time_of_day' => 'nullable|string|max:10',
+            'quantity' => 'nullable|string|max:255',
+        ]);
+
+        if ($validator->fails()) {
+            throw new ValidationException($validator);
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function validateCycleMenuSetWeek(array $payload): void
+    {
+        $validator = Validator::make($payload, [
+            'cycle_menu_id' => 'required|integer|exists:cycle_menus,id',
+            'items_by_day_index' => 'required|array|min:1',
+            'items_by_day_index.*' => 'array',
+            'items_by_day_index.*.*.title' => 'required|string|max:255',
+            'items_by_day_index.*.*.meal_type' => 'required|string|max:32',
+            'items_by_day_index.*.*.time_of_day' => 'nullable|string|max:10',
+            'items_by_day_index.*.*.quantity' => 'nullable|string|max:255',
+        ]);
+
+        if ($validator->fails()) {
+            throw new ValidationException($validator);
         }
     }
 
@@ -550,6 +595,8 @@ class PendingActionApplier
             'investments.bulkImportTransactions' => $this->executeInvestmentsBulkImportTransactions($action, $attribution),
             'bank.recordLines' => $this->executeBankRecordLines($action, $user, $attribution),
             'bank.linkExpense' => $this->executeBankLinkExpense($action),
+            'cycleMenu.addItem' => $this->executeCycleMenuAddItem($action),
+            'cycleMenu.setWeek' => $this->executeCycleMenuSetWeek($action),
             default => throw new RuntimeException("No executor registered for tool [{$action->tool}]."),
         };
     }
@@ -597,6 +644,82 @@ class PendingActionApplier
                 'matched' => $matchedCount,
                 'unmatched' => $unmatchedCount,
                 'skipped_existing' => $skippedCount,
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function executeCycleMenuAddItem(PendingAction $action): array
+    {
+        $menu = CycleMenu::query()->findOrFail((int) $action->payload['cycle_menu_id']);
+
+        $item = $this->cycleMenus->addItem(
+            $menu,
+            (int) $action->payload['day_index'],
+            [
+                'title' => (string) $action->payload['title'],
+                'meal_type' => (string) $action->payload['meal_type'],
+                'time_of_day' => $action->payload['time_of_day'] ?? null,
+                'quantity' => $action->payload['quantity'] ?? null,
+            ],
+        );
+
+        $action->forceFill([
+            'target_type' => CycleMenuItem::class,
+            'target_id' => $item->id,
+        ])->save();
+
+        return [
+            'before' => null,
+            'after' => $item->only(['id', 'cycle_menu_day_id', 'title', 'meal_type', 'time_of_day', 'quantity', 'position']),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function executeCycleMenuSetWeek(PendingAction $action): array
+    {
+        $menu = CycleMenu::query()->findOrFail((int) $action->payload['cycle_menu_id']);
+
+        // Capture the prior state so revert can fully restore the affected
+        // day rows to what they looked like before approval.
+        $itemsByDayIndex = (array) $action->payload['items_by_day_index'];
+        $before = [];
+
+        foreach (array_keys($itemsByDayIndex) as $dayIndex) {
+            $day = $menu->days()->where('day_index', (int) $dayIndex)->with('items')->first();
+            $before[(int) $dayIndex] = $day === null ? [] : $day->items->map(fn (CycleMenuItem $i): array => [
+                'title' => $i->title,
+                'meal_type' => is_object($i->meal_type) ? $i->meal_type?->value : $i->meal_type,
+                'time_of_day' => $i->time_of_day,
+                'quantity' => $i->quantity,
+                'position' => $i->position,
+            ])->all();
+        }
+
+        $created = $this->cycleMenus->replaceWeek($menu, $itemsByDayIndex);
+
+        $action->forceFill([
+            'target_type' => CycleMenu::class,
+            'target_id' => $menu->id,
+        ])->save();
+
+        $afterIds = [];
+        foreach ($created as $dayIndex => $items) {
+            $afterIds[$dayIndex] = array_map(fn (CycleMenuItem $i) => $i->id, $items);
+        }
+
+        return [
+            'before' => [
+                'menu_id' => $menu->id,
+                'items_by_day_index' => $before,
+            ],
+            'after' => [
+                'menu_id' => $menu->id,
+                'item_ids_by_day_index' => $afterIds,
             ],
         ];
     }
@@ -1020,6 +1143,14 @@ class PendingActionApplier
                 $this->revertBankLinkExpense($action);
 
                 return;
+            case 'cycleMenu.addItem':
+                $this->revertCreateById($action, CycleMenuItem::class);
+
+                return;
+            case 'cycleMenu.setWeek':
+                $this->revertCycleMenuSetWeek($action);
+
+                return;
         }
 
         throw new RuntimeException("No revert executor for tool [{$action->tool}].");
@@ -1035,6 +1166,24 @@ class PendingActionApplier
         }
 
         BankLine::query()->whereIn('id', (array) $after['bank_line_ids'])->delete();
+    }
+
+    private function revertCycleMenuSetWeek(PendingAction $action): void
+    {
+        $diff = $action->applied_diff ?? [];
+        $before = $diff['before'] ?? null;
+
+        if (! is_array($before) || ! isset($before['menu_id'], $before['items_by_day_index'])) {
+            return;
+        }
+
+        $menu = CycleMenu::query()->find((int) $before['menu_id']);
+
+        if ($menu === null) {
+            return;
+        }
+
+        $this->cycleMenus->replaceWeek($menu, (array) $before['items_by_day_index']);
     }
 
     private function revertBankLinkExpense(PendingAction $action): void
@@ -1354,6 +1503,22 @@ class PendingActionApplier
                     'Link bank line #%d → expense #%d',
                     (int) ($payload['bank_line_id'] ?? 0),
                     (int) ($payload['expense_id'] ?? 0),
+                ),
+            ],
+            'cycleMenu.addItem' => [
+                'summary' => sprintf(
+                    'Menu #%d day %d: %s (%s)',
+                    (int) ($payload['cycle_menu_id'] ?? 0),
+                    (int) ($payload['day_index'] ?? 0),
+                    (string) ($payload['title'] ?? '?'),
+                    (string) ($payload['meal_type'] ?? ''),
+                ),
+            ],
+            'cycleMenu.setWeek' => [
+                'summary' => sprintf(
+                    'Plan menu #%d across %d day(s)',
+                    (int) ($payload['cycle_menu_id'] ?? 0),
+                    count((array) ($payload['items_by_day_index'] ?? [])),
                 ),
             ],
             default => [],

--- a/app/Services/CycleMenu/CycleMenuService.php
+++ b/app/Services/CycleMenu/CycleMenuService.php
@@ -1,0 +1,182 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\CycleMenu;
+
+use App\Enums\MealType;
+use App\Models\CycleMenu;
+use App\Models\CycleMenuDay;
+use App\Models\CycleMenuItem;
+use Illuminate\Support\Facades\DB;
+use RuntimeException;
+
+class CycleMenuService
+{
+    /**
+     * Add a single item to a specific day of a cycle menu, creating the
+     * CycleMenuDay row if it doesn't exist. Returns the created item.
+     *
+     * @param  array<string, mixed>  $data
+     */
+    public function addItem(CycleMenu $menu, int $dayIndex, array $data): CycleMenuItem
+    {
+        $this->guardDayIndex($menu, $dayIndex);
+
+        $day = $this->findOrCreateDay($menu, $dayIndex);
+        $maxPosition = (int) (CycleMenuItem::query()
+            ->where('cycle_menu_day_id', $day->id)
+            ->max('position') ?? -1);
+
+        return CycleMenuItem::create([
+            'cycle_menu_day_id' => $day->id,
+            'title' => (string) $data['title'],
+            'meal_type' => $data['meal_type'] ?? MealType::Other,
+            'time_of_day' => $data['time_of_day'] ?? null,
+            'quantity' => $data['quantity'] ?? null,
+            'position' => array_key_exists('position', $data) ? (int) $data['position'] : $maxPosition + 1,
+        ]);
+    }
+
+    /**
+     * Replace the entire content of one day with the supplied items. Existing
+     * items on the day are deleted in the same transaction. Returns the
+     * created items.
+     *
+     * @param  array<int, array<string, mixed>>  $items
+     * @return array<int, CycleMenuItem>
+     */
+    public function replaceDay(CycleMenu $menu, int $dayIndex, array $items): array
+    {
+        $this->guardDayIndex($menu, $dayIndex);
+
+        return DB::transaction(function () use ($menu, $dayIndex, $items): array {
+            $day = $this->findOrCreateDay($menu, $dayIndex);
+
+            CycleMenuItem::query()->where('cycle_menu_day_id', $day->id)->delete();
+
+            $created = [];
+            $position = 0;
+
+            foreach ($items as $itemData) {
+                $row = (array) $itemData;
+                $row['position'] = $row['position'] ?? $position++;
+                $created[] = CycleMenuItem::create([
+                    'cycle_menu_day_id' => $day->id,
+                    'title' => (string) $row['title'],
+                    'meal_type' => $row['meal_type'] ?? MealType::Other,
+                    'time_of_day' => $row['time_of_day'] ?? null,
+                    'quantity' => $row['quantity'] ?? null,
+                    'position' => (int) $row['position'],
+                ]);
+            }
+
+            return $created;
+        });
+    }
+
+    /**
+     * Replace items across multiple consecutive day indices in one transaction.
+     *
+     * @param  array<int, array<int, array<string, mixed>>>  $itemsByDayIndex
+     *   Outer key = day_index; value = array of items for that day.
+     * @return array<int, array<int, CycleMenuItem>>
+     */
+    public function replaceWeek(CycleMenu $menu, array $itemsByDayIndex): array
+    {
+        return DB::transaction(function () use ($menu, $itemsByDayIndex): array {
+            $result = [];
+
+            foreach ($itemsByDayIndex as $dayIndex => $items) {
+                $result[(int) $dayIndex] = $this->replaceDay($menu, (int) $dayIndex, $items);
+            }
+
+            return $result;
+        });
+    }
+
+    /**
+     * Build a shopping-list aggregation for the next $window days starting
+     * from the active menu's mapped "today" index. Aggregates by normalized
+     * title + meal_type and counts occurrences. Quantity strings are returned
+     * as a list (not summed) since they're free-text in this schema.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public function shoppingList(CycleMenu $menu, int $window): array
+    {
+        $cycleLength = max(1, (int) $menu->cycle_length_days);
+        $window = max(1, $window);
+
+        $startsOn = $menu->starts_on?->startOfDay() ?? now()->startOfDay();
+        $today = now()->startOfDay();
+        $daysSinceStart = (int) $today->diffInDays($startsOn, false);
+        $todayIndex = (($daysSinceStart % $cycleLength) + $cycleLength) % $cycleLength;
+
+        $daysByIndex = $menu->days()->with('items')->get()->keyBy('day_index');
+
+        $aggregate = [];
+
+        for ($offset = 0; $offset < $window; $offset++) {
+            $dayIndex = ($todayIndex + $offset) % $cycleLength;
+            $day = $daysByIndex->get($dayIndex);
+
+            if (! $day instanceof CycleMenuDay) {
+                continue;
+            }
+
+            $date = $today->copy()->addDays($offset)->toDateString();
+
+            foreach ($day->items as $item) {
+                $title = trim((string) $item->title);
+                $titleKey = strtolower($title);
+                $mealType = is_object($item->meal_type) ? $item->meal_type?->value : (string) $item->meal_type;
+                $key = $titleKey.'|'.($mealType ?? '');
+
+                if (! isset($aggregate[$key])) {
+                    $aggregate[$key] = [
+                        'title' => $title,
+                        'meal_type' => $mealType,
+                        'count' => 0,
+                        'quantities' => [],
+                        'days' => [],
+                    ];
+                }
+
+                $aggregate[$key]['count']++;
+                if ($item->quantity !== null && $item->quantity !== '') {
+                    $aggregate[$key]['quantities'][] = (string) $item->quantity;
+                }
+                $aggregate[$key]['days'][] = ['day_index' => $dayIndex, 'date' => $date];
+            }
+        }
+
+        return array_values($aggregate);
+    }
+
+    private function findOrCreateDay(CycleMenu $menu, int $dayIndex): CycleMenuDay
+    {
+        $day = CycleMenuDay::query()
+            ->where('cycle_menu_id', $menu->id)
+            ->where('day_index', $dayIndex)
+            ->first();
+
+        if ($day === null) {
+            $day = CycleMenuDay::create([
+                'cycle_menu_id' => $menu->id,
+                'day_index' => $dayIndex,
+            ]);
+        }
+
+        return $day;
+    }
+
+    private function guardDayIndex(CycleMenu $menu, int $dayIndex): void
+    {
+        $max = (int) $menu->cycle_length_days - 1;
+
+        if ($dayIndex < 0 || $dayIndex > $max) {
+            throw new RuntimeException("day_index {$dayIndex} is outside menu cycle (0..{$max}).");
+        }
+    }
+}

--- a/docs/agents/IMPLEMENTATION_PLAN.md
+++ b/docs/agents/IMPLEMENTATION_PLAN.md
@@ -12,6 +12,7 @@
 > - Phase 6 — bank/card statement processor with reconciliation against existing expenses: PR #157. Introduces a `bank_lines` table, a deterministic matcher (amount + date + merchant fuzzy), and `bank.recordLines` / `bank.linkExpense` / `bank.unmatched` MCP tools.
 > - Phase 7 — receipts/documents OCR agent: PR #158. Adds `source_file_id` (with backward-compatible idempotency keys) to `expenses.create`, `warranties.create`, `utilityBills.create`; new `receipts.processed` read tool to skip already-OCR'd Drive files. Vision via the user's Drive MCP — no new LifeOS infrastructure.
 > - Phase 8 — job-search hunter agent: in PR. Gated by `agents.job_search.enabled` AND a per-skill active-search window. New `jobs.createApplication` MCP tool + starter `cv` and `job-criteria` skills (placeholder content the user replaces).
+> - Phase 9 — cycle-menu planner agent: in PR. New `cycleMenu.addItem`, `cycleMenu.setWeek`, `cycleMenu.shoppingList` tools. The agent fills empty days only (never overwrites the user's plan) and produces a structured shopping list aggregation for the next 7 days.
 
 ## Context
 

--- a/docs/agents/MCP_TOOLS.md
+++ b/docs/agents/MCP_TOOLS.md
@@ -533,6 +533,41 @@ Idempotency: `(tenant, normalized company, normalized title, source_email_id || 
 - **`cv`** — the user's CV. Authoritative for fit assessment. Replace placeholder content before enabling the agent.
 - **`job-criteria`** — hard and soft criteria, plus an active-search-window date range. The agent exits immediately if today is outside the window or if either skill is still placeholder content.
 
+## Cycle menu (Phase 9)
+
+Phase 9 adds three tools backing the cycle-menu-planner agent. The agent never creates the parent `CycleMenu` row (the user owns the rotation), and never overwrites a populated day — it only fills empty days.
+
+### `cycleMenu.addItem` (write)
+
+| field | type | description |
+|---|---|---|
+| `cycle_menu_id` | int | Required. |
+| `day_index` | int | Required. 0-based day in the rotation. |
+| `title` | string | Required. |
+| `meal_type` | string | Required. `"breakfast"`, `"lunch"`, `"dinner"`, `"snack"`, or `"other"`. |
+| `time_of_day` | string | Optional `HH:MM`. |
+| `quantity` | string | Optional free-text serving (e.g. `"1 bowl"`, `"250 g"`). |
+
+Idempotency: `(tenant, menu, day_index, normalized title, meal_type)`.
+
+### `cycleMenu.setWeek` (write, bulk)
+
+| field | type | description |
+|---|---|---|
+| `cycle_menu_id` | int | Required. |
+| `items_by_day_index` | object | Required. Map of `day_index → array of items`. Each item = `{ title, meal_type, time_of_day?, quantity? }`. |
+
+Existing items on every covered `day_index` are deleted on apply; revert fully restores them. Idempotency is order-insensitive within a day and across days.
+
+### `cycleMenu.shoppingList` (read)
+
+| field | type | description |
+|---|---|---|
+| `cycle_menu_id` | int | Optional — defaults to the tenant's active menu. |
+| `window_days` | int | Default 7, max 30. |
+
+Returns `{ menu, window_days, item_count, items[] }` where each item is `{ title, meal_type, count, quantities[], days[] }`. Quantities are returned as a list rather than summed because the schema carries free-text (`"1 bowl"`, `"250 g"`).
+
 ## Approval surface
 
 Reviewers act through `/dashboard/pending-actions`:

--- a/tests/Feature/Mcp/Phase9CycleMenuToolsTest.php
+++ b/tests/Feature/Mcp/Phase9CycleMenuToolsTest.php
@@ -1,0 +1,222 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Mcp;
+
+use App\Mcp\LifeOsServer;
+use App\Mcp\Tools\CycleMenu\AddItem as AddCycleMenuItem;
+use App\Mcp\Tools\CycleMenu\SetWeek as SetCycleMenuWeek;
+use App\Mcp\Tools\CycleMenu\ShoppingList as CycleMenuShoppingList;
+use App\Models\AgentToken;
+use App\Models\CycleMenu;
+use App\Models\CycleMenuDay;
+use App\Models\CycleMenuItem;
+use App\Models\PendingAction;
+use App\Models\Tenant;
+use App\Models\User;
+use App\Services\Agents\PendingActionApplier;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\App;
+use Tests\TestCase;
+
+class Phase9CycleMenuToolsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+
+    private Tenant $tenant;
+
+    private CycleMenu $menu;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        ['user' => $this->user, 'tenant' => $this->tenant] = $this->setupTenantContext();
+        [$token] = AgentToken::issue($this->user, $this->tenant, 'phpunit', ['*']);
+        App::instance('agent.token', $token);
+
+        $this->menu = CycleMenu::factory()->create([
+            'name' => 'Test Cycle',
+            'is_active' => true,
+            'starts_on' => now()->subDays(3)->toDateString(),
+            'cycle_length_days' => 7,
+        ]);
+    }
+
+    public function test_add_item_queues_pending_action(): void
+    {
+        LifeOsServer::tool(AddCycleMenuItem::class, [
+            'cycle_menu_id' => $this->menu->id,
+            'day_index' => 2,
+            'title' => 'Pasta Bolognese',
+            'meal_type' => 'dinner',
+        ])->assertOk();
+
+        $this->assertSame(1, PendingAction::query()->where('tool', 'cycleMenu.addItem')->count());
+        $this->assertSame(0, CycleMenuItem::query()->count());
+    }
+
+    public function test_add_item_idempotency(): void
+    {
+        $args = [
+            'cycle_menu_id' => $this->menu->id,
+            'day_index' => 2,
+            'title' => 'Pasta Bolognese',
+            'meal_type' => 'dinner',
+        ];
+
+        LifeOsServer::tool(AddCycleMenuItem::class, $args);
+        LifeOsServer::tool(AddCycleMenuItem::class, $args);
+
+        $this->assertSame(1, PendingAction::query()->count());
+    }
+
+    public function test_apply_add_item_creates_day_if_missing(): void
+    {
+        LifeOsServer::tool(AddCycleMenuItem::class, [
+            'cycle_menu_id' => $this->menu->id,
+            'day_index' => 2,
+            'title' => 'Pasta',
+            'meal_type' => 'dinner',
+        ]);
+
+        $action = PendingAction::query()->firstOrFail();
+        app(PendingActionApplier::class)->apply($action, $this->user);
+
+        $this->assertSame(1, CycleMenuDay::query()->count());
+        $this->assertSame(1, CycleMenuItem::query()->count());
+        $item = CycleMenuItem::query()->first();
+        $this->assertSame('Pasta', $item->title);
+    }
+
+    public function test_add_item_rejects_out_of_range_day(): void
+    {
+        LifeOsServer::tool(AddCycleMenuItem::class, [
+            'cycle_menu_id' => $this->menu->id,
+            'day_index' => 99,
+            'title' => 'Bad',
+            'meal_type' => 'dinner',
+        ]);
+
+        $action = PendingAction::query()->firstOrFail();
+
+        $this->expectException(\RuntimeException::class);
+        app(PendingActionApplier::class)->apply($action, $this->user);
+    }
+
+    public function test_set_week_replaces_existing_items_on_apply(): void
+    {
+        $existingDay = CycleMenuDay::factory()->create([
+            'cycle_menu_id' => $this->menu->id,
+            'day_index' => 0,
+        ]);
+        CycleMenuItem::factory()->create([
+            'cycle_menu_day_id' => $existingDay->id,
+            'title' => 'Old Item',
+            'position' => 0,
+        ]);
+        $this->assertSame(1, CycleMenuItem::query()->count());
+
+        LifeOsServer::tool(SetCycleMenuWeek::class, [
+            'cycle_menu_id' => $this->menu->id,
+            'items_by_day_index' => [
+                0 => [
+                    ['title' => 'Eggs', 'meal_type' => 'breakfast'],
+                    ['title' => 'Salad', 'meal_type' => 'lunch'],
+                ],
+                1 => [
+                    ['title' => 'Pasta', 'meal_type' => 'dinner'],
+                ],
+            ],
+        ])->assertOk()->assertStructuredContent(function (array $content): bool {
+            $this->assertSame(2, $content['day_count']);
+            $this->assertSame(3, $content['item_count']);
+
+            return true;
+        });
+
+        $action = PendingAction::query()->firstOrFail();
+        app(PendingActionApplier::class)->apply($action, $this->user);
+
+        $this->assertSame(3, CycleMenuItem::query()->count());
+        $this->assertNull(CycleMenuItem::query()->where('title', 'Old Item')->first(), 'Old item should be deleted.');
+    }
+
+    public function test_revert_set_week_restores_prior_items(): void
+    {
+        $day = CycleMenuDay::factory()->create([
+            'cycle_menu_id' => $this->menu->id,
+            'day_index' => 0,
+        ]);
+        CycleMenuItem::factory()->create([
+            'cycle_menu_day_id' => $day->id,
+            'title' => 'Original',
+            'meal_type' => \App\Enums\MealType::Lunch,
+            'position' => 0,
+        ]);
+
+        LifeOsServer::tool(SetCycleMenuWeek::class, [
+            'cycle_menu_id' => $this->menu->id,
+            'items_by_day_index' => [
+                0 => [
+                    ['title' => 'Replacement', 'meal_type' => 'dinner'],
+                ],
+            ],
+        ]);
+
+        $action = PendingAction::query()->firstOrFail();
+        $applied = app(PendingActionApplier::class)->apply($action, $this->user);
+        $this->assertSame('Replacement', CycleMenuItem::query()->first()->title);
+
+        app(PendingActionApplier::class)->revert($applied, $this->user);
+
+        $this->assertSame(1, CycleMenuItem::query()->count());
+        $this->assertSame('Original', CycleMenuItem::query()->first()->title);
+    }
+
+    public function test_shopping_list_aggregates_upcoming_window(): void
+    {
+        // Two days, two items each, with one duplicate across days to verify counting.
+        $day0 = CycleMenuDay::factory()->create([
+            'cycle_menu_id' => $this->menu->id,
+            'day_index' => 0,
+        ]);
+        $day1 = CycleMenuDay::factory()->create([
+            'cycle_menu_id' => $this->menu->id,
+            'day_index' => 1,
+        ]);
+        CycleMenuItem::factory()->create([
+            'cycle_menu_day_id' => $day0->id,
+            'title' => 'Eggs',
+            'meal_type' => \App\Enums\MealType::Breakfast,
+            'quantity' => '2',
+        ]);
+        CycleMenuItem::factory()->create([
+            'cycle_menu_day_id' => $day1->id,
+            'title' => 'Eggs',
+            'meal_type' => \App\Enums\MealType::Breakfast,
+            'quantity' => '2',
+        ]);
+        CycleMenuItem::factory()->create([
+            'cycle_menu_day_id' => $day0->id,
+            'title' => 'Salad',
+            'meal_type' => \App\Enums\MealType::Lunch,
+        ]);
+
+        LifeOsServer::tool(CycleMenuShoppingList::class, ['window_days' => 7])
+            ->assertOk()
+            ->assertStructuredContent(function (array $content): bool {
+                $titles = collect($content['items'])->pluck('title', 'count')->all();
+                $this->assertNotEmpty($content['items']);
+                // Eggs should appear with count >= 1 (depending on which day is "today")
+                $eggsRow = collect($content['items'])->firstWhere('title', 'Eggs');
+                $this->assertNotNull($eggsRow);
+                $this->assertGreaterThanOrEqual(1, $eggsRow['count']);
+
+                return true;
+            });
+    }
+}

--- a/tests/Feature/Mcp/Phase9CycleMenuToolsTest.php
+++ b/tests/Feature/Mcp/Phase9CycleMenuToolsTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Mcp;
 
+use App\Enums\MealType;
 use App\Mcp\LifeOsServer;
 use App\Mcp\Tools\CycleMenu\AddItem as AddCycleMenuItem;
 use App\Mcp\Tools\CycleMenu\SetWeek as SetCycleMenuWeek;
@@ -18,6 +19,7 @@ use App\Models\User;
 use App\Services\Agents\PendingActionApplier;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\App;
+use Illuminate\Testing\Fluent\AssertableJson;
 use Tests\TestCase;
 
 class Phase9CycleMenuToolsTest extends TestCase
@@ -131,11 +133,10 @@ class Phase9CycleMenuToolsTest extends TestCase
                     ['title' => 'Pasta', 'meal_type' => 'dinner'],
                 ],
             ],
-        ])->assertOk()->assertStructuredContent(function (array $content): bool {
-            $this->assertSame(2, $content['day_count']);
-            $this->assertSame(3, $content['item_count']);
-
-            return true;
+        ])->assertOk()->assertStructuredContent(function (AssertableJson $json): void {
+            $json->where('day_count', 2)
+                ->where('item_count', 3)
+                ->etc();
         });
 
         $action = PendingAction::query()->firstOrFail();
@@ -154,7 +155,7 @@ class Phase9CycleMenuToolsTest extends TestCase
         CycleMenuItem::factory()->create([
             'cycle_menu_day_id' => $day->id,
             'title' => 'Original',
-            'meal_type' => \App\Enums\MealType::Lunch,
+            'meal_type' => MealType::Lunch,
             'position' => 0,
         ]);
 
@@ -191,32 +192,33 @@ class Phase9CycleMenuToolsTest extends TestCase
         CycleMenuItem::factory()->create([
             'cycle_menu_day_id' => $day0->id,
             'title' => 'Eggs',
-            'meal_type' => \App\Enums\MealType::Breakfast,
+            'meal_type' => MealType::Breakfast,
             'quantity' => '2',
         ]);
         CycleMenuItem::factory()->create([
             'cycle_menu_day_id' => $day1->id,
             'title' => 'Eggs',
-            'meal_type' => \App\Enums\MealType::Breakfast,
+            'meal_type' => MealType::Breakfast,
             'quantity' => '2',
         ]);
         CycleMenuItem::factory()->create([
             'cycle_menu_day_id' => $day0->id,
             'title' => 'Salad',
-            'meal_type' => \App\Enums\MealType::Lunch,
+            'meal_type' => MealType::Lunch,
         ]);
 
         LifeOsServer::tool(CycleMenuShoppingList::class, ['window_days' => 7])
             ->assertOk()
-            ->assertStructuredContent(function (array $content): bool {
-                $titles = collect($content['items'])->pluck('title', 'count')->all();
-                $this->assertNotEmpty($content['items']);
-                // Eggs should appear with count >= 1 (depending on which day is "today")
-                $eggsRow = collect($content['items'])->firstWhere('title', 'Eggs');
-                $this->assertNotNull($eggsRow);
-                $this->assertGreaterThanOrEqual(1, $eggsRow['count']);
+            ->assertStructuredContent(function (AssertableJson $json): void {
+                $json->where('items', function ($items): bool {
+                    $items = is_array($items) ? $items : $items->all();
+                    $this->assertNotEmpty($items);
+                    $eggsRow = collect($items)->firstWhere('title', 'Eggs');
+                    $this->assertNotNull($eggsRow);
+                    $this->assertGreaterThanOrEqual(1, $eggsRow['count']);
 
-                return true;
+                    return true;
+                })->etc();
             });
     }
 }

--- a/tests/Unit/Services/Agents/IdempotencyKeyPhase9Test.php
+++ b/tests/Unit/Services/Agents/IdempotencyKeyPhase9Test.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Agents;
+
+use App\Services\Agents\IdempotencyKey;
+use Tests\TestCase;
+
+class IdempotencyKeyPhase9Test extends TestCase
+{
+    private IdempotencyKey $keys;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->keys = new IdempotencyKey;
+    }
+
+    public function test_add_item_collapses_on_same_natural_fields(): void
+    {
+        $a = $this->keys->for('cycleMenu.addItem', 1, [
+            'cycle_menu_id' => 7,
+            'day_index' => 2,
+            'title' => 'Pasta Bolognese',
+            'meal_type' => 'dinner',
+        ]);
+        $b = $this->keys->for('cycleMenu.addItem', 1, [
+            'cycle_menu_id' => 7,
+            'day_index' => 2,
+            'title' => '  PASTA  Bolognese  ',
+            'meal_type' => 'DINNER',
+        ]);
+
+        $this->assertSame($a, $b);
+    }
+
+    public function test_add_item_distinguishes_by_meal_type(): void
+    {
+        $lunch = $this->keys->for('cycleMenu.addItem', 1, [
+            'cycle_menu_id' => 7,
+            'day_index' => 2,
+            'title' => 'Pasta Bolognese',
+            'meal_type' => 'lunch',
+        ]);
+        $dinner = $this->keys->for('cycleMenu.addItem', 1, [
+            'cycle_menu_id' => 7,
+            'day_index' => 2,
+            'title' => 'Pasta Bolognese',
+            'meal_type' => 'dinner',
+        ]);
+
+        $this->assertNotSame($lunch, $dinner);
+    }
+
+    public function test_set_week_is_order_insensitive_within_a_day(): void
+    {
+        $a = $this->keys->for('cycleMenu.setWeek', 1, [
+            'cycle_menu_id' => 7,
+            'items_by_day_index' => [
+                0 => [
+                    ['title' => 'Eggs', 'meal_type' => 'breakfast'],
+                    ['title' => 'Salad', 'meal_type' => 'lunch'],
+                ],
+            ],
+        ]);
+        $b = $this->keys->for('cycleMenu.setWeek', 1, [
+            'cycle_menu_id' => 7,
+            'items_by_day_index' => [
+                0 => [
+                    ['title' => 'Salad', 'meal_type' => 'lunch'],
+                    ['title' => 'Eggs', 'meal_type' => 'breakfast'],
+                ],
+            ],
+        ]);
+
+        $this->assertSame($a, $b);
+    }
+
+    public function test_set_week_changes_when_an_item_changes(): void
+    {
+        $base = [
+            'cycle_menu_id' => 7,
+            'items_by_day_index' => [
+                0 => [
+                    ['title' => 'Eggs', 'meal_type' => 'breakfast'],
+                ],
+            ],
+        ];
+        $different = [
+            'cycle_menu_id' => 7,
+            'items_by_day_index' => [
+                0 => [
+                    ['title' => 'Oatmeal', 'meal_type' => 'breakfast'],
+                ],
+            ],
+        ];
+
+        $this->assertNotSame(
+            $this->keys->for('cycleMenu.setWeek', 1, $base),
+            $this->keys->for('cycleMenu.setWeek', 1, $different),
+        );
+    }
+
+    public function test_set_week_distinguishes_across_menus(): void
+    {
+        $payload = [
+            'cycle_menu_id' => 7,
+            'items_by_day_index' => [
+                0 => [
+                    ['title' => 'Eggs', 'meal_type' => 'breakfast'],
+                ],
+            ],
+        ];
+
+        $this->assertNotSame(
+            $this->keys->for('cycleMenu.setWeek', 1, $payload),
+            $this->keys->for('cycleMenu.setWeek', 1, [...$payload, 'cycle_menu_id' => 8]),
+        );
+    }
+}


### PR DESCRIPTION
## Summary

This PR implements two new AI agents and their supporting infrastructure:

1. **Job-search hunter agent (Phase 8)** — discovers job postings matching user criteria and records them as pending applications
2. **Cycle-menu planner agent (Phase 9)** — plans weekly meals and generates shopping lists from cycle menus

Both agents follow the established pattern of queuing write operations as pending actions for user approval rather than auto-applying changes.

## Implementation Details

### Phase 8: Job-search Hunter

**New MCP Tool:**
- `jobs.createApplication` — Record discovered job postings with company, title, compensation, location, and contact details
  - Idempotent on (tenant, normalized company, normalized title, source_email_id || job_url)
  - Status defaults to "discovered"; user explicitly transitions to "applied"
  - Supports email/file source anchors for deduplication across channels

**Agent & Skills:**
- `agents/job-search/` — Agent definition with Claude Opus model, Gmail + LifeOS MCP servers
- `.claude/skills/cv/` — User's CV for fit assessment
- `.claude/skills/job-criteria/` — Hard/soft criteria (compensation, location, seniority, blocklists)

**Validation & Idempotency:**
- Added `validateJobsCreateApplication()` in `PendingActionApplier`
- Added `jobsCreateApplication()` idempotency key logic in `IdempotencyKey`
- Normalizes company/title for collision detection; prefers email_id > file_id > URL anchors

### Phase 9: Cycle-menu Planner

**New MCP Tools:**
- `cycleMenu.addItem` — Add single item to a day (idempotent on menu, day_index, title, meal_type)
- `cycleMenu.setWeek` — Bulk-replace items across multiple days in one transaction
- `cycleMenu.shoppingList` — Aggregate next N days into structured shopping list (read-only)

**New Service:**
- `CycleMenuService` — Handles item addition, day replacement, week replacement, and shopping list aggregation
  - Auto-creates `CycleMenuDay` rows if missing
  - Supports transaction-safe bulk operations with revert capability
  - Shopping list aggregates by normalized title + meal_type, counts occurrences, returns quantities as lists

**Agent & Tools:**
- `agents/cycle-menu-planner/` — Agent definition with Claude Sonnet model
- Allowed tools: `cycleMenu.currentWeek`, `cycleMenu.shoppingList`, `cycleMenu.addItem`, `cycleMenu.setWeek`, `expenses.list`

**Validation & Idempotency:**
- Added `validateCycleMenuAddItem()` and `validateCycleMenuSetWeek()` in `PendingActionApplier`
- Added `cycleMenuAddItem()` and `cycleMenuSetWeek()` idempotency logic
- `setWeek` is order-insensitive within a day (sorts items before hashing)

### Core Changes

**PendingActionApplier:**
- Added `CycleMenuService` dependency injection
- Extended `validatePayload()` switch with 3 new validators (jobs.createApplication, cycleMenu.addItem, cycleMenu.setWeek)
- Extended `execute()` switch with 3 new executors (jobs.createApplication, cycleMenu.addItem, cycleMenu.setWeek)
- Execution methods handle pending action recording, validation, and service invocation

**IdempotencyKey:**
- Added `jobsCreateApplication()` — anchors on (tenant, normalized company, normalized title, source reference)
- Added `cycleMenuAddItem()` — anchors on (tenant, menu, day_index, normalized title, normalized meal_type)
- Added `cycleMenuSetWeek()` — anchors on (tenant, menu, sorted day list, sorted item set per day)

**LifeOsServer:**
- Registered new tools: `AddItem`, `SetWeek`, `ShoppingList` (Cycle

https://claude.ai/code/session_01AxKEBuMxrHVjg7DShsnGi2